### PR TITLE
feat: Entity 구성 #2

### DIFF
--- a/backend/src/main/java/com/staccato/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/staccato/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.staccato.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
+++ b/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
@@ -20,12 +20,4 @@ public abstract class BaseEntity {
     @LastModifiedDate
     private LocalDateTime modifiedDateTime;
     private Boolean isDeleted = false;
-
-    public void delete() {
-        isDeleted = true;
-    }
-
-    public void restore() {
-        isDeleted = false;
-    }
 }

--- a/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
+++ b/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
@@ -1,0 +1,31 @@
+package com.staccato.config.domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import lombok.Getter;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createdDateTIme;
+    @LastModifiedDate
+    private LocalDateTime modifiedDateTime;
+    private Boolean isDeleted = false;
+
+    public void delete() {
+        isDeleted = true;
+    }
+
+    public void restore() {
+        isDeleted = false;
+    }
+}

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -1,0 +1,26 @@
+package com.staccato.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false, unique = true)
+    private String nickname;
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+}

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "member")
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/pin/domain/Pin.java
+++ b/backend/src/main/java/com/staccato/pin/domain/Pin.java
@@ -1,0 +1,26 @@
+package com.staccato.pin.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "pin")
+public class Pin extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String place;
+    @Column(nullable = false)
+    private String address;
+}

--- a/backend/src/main/java/com/staccato/pin/domain/Pin.java
+++ b/backend/src/main/java/com/staccato/pin/domain/Pin.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
@@ -13,6 +15,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE pin SET is_deleted = true WHERE id = ?")
 public class Pin extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/pin/domain/Pin.java
+++ b/backend/src/main/java/com/staccato/pin/domain/Pin.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 
@@ -14,7 +13,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "pin")
 public class Pin extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/domain/Mate.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Mate.java
@@ -8,6 +8,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE mate SET is_deleted = true WHERE id = ?")
 public class Mate extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/domain/Mate.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Mate.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
@@ -17,7 +16,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "mate")
 public class Mate extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/domain/Mate.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Mate.java
@@ -1,0 +1,31 @@
+package com.staccato.travel.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+import com.staccato.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mate")
+public class Mate extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_id", nullable = false)
+    private Travel travel;
+}

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -1,0 +1,34 @@
+package com.staccato.travel.domain;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "travel")
+public class Travel extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(columnDefinition = "TEXT")
+    private String thumbnailUrl;
+    @Column(nullable = false, length = 50)
+    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    @Column(nullable = false)
+    private LocalDate startAt;
+    @Column(nullable = false)
+    private LocalDate endAt;
+}

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
@@ -15,6 +17,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE travel SET is_deleted = true WHERE id = ?")
 public class Travel extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -7,7 +7,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 
@@ -16,7 +15,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "travel")
 public class Travel extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.pin.domain.Pin;
@@ -21,7 +20,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "visit")
 public class Visit extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -1,0 +1,37 @@
+package com.staccato.visit.domain;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+import com.staccato.pin.domain.Pin;
+import com.staccato.travel.domain.Travel;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "visit")
+public class Visit extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private LocalDate visitedAt;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pin_id", nullable = false)
+    private Pin pin;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "travel_id", nullable = false)
+    private Travel travel;
+}

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -11,6 +11,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.pin.domain.Pin;
 import com.staccato.travel.domain.Travel;
@@ -20,6 +22,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE visit SET is_deleted = true WHERE id = ?")
 public class Visit extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 
@@ -17,7 +16,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "visit_image")
 public class VisitImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -1,0 +1,30 @@
+package com.staccato.visit.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "visit_image")
+public class VisitImage extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(columnDefinition = "TEXT")
+    private String imageUrl;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "visit_id", nullable = false)
+    private Visit visit;
+}

--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
@@ -16,6 +18,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE visit_image SET is_deleted = true WHERE id = ?")
 public class VisitImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
@@ -18,7 +17,6 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "visit_log")
 public class VisitLog extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
+import org.hibernate.annotations.SQLDelete;
+
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
@@ -17,6 +19,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE visit_log SET is_deleted = true WHERE id = ?")
 public class VisitLog extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -1,0 +1,34 @@
+package com.staccato.visit.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.staccato.config.domain.BaseEntity;
+import com.staccato.member.domain.Member;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "visit_log")
+public class VisitLog extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(columnDefinition = "TEXT")
+    private String content;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "visit_id", nullable = false)
+    private Visit visit;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,3 +1,19 @@
 spring:
   application:
     name: staccato
+  sql:
+    init:
+      mode: always
+  h2:
+    console:
+      enabled: true
+  datasource:
+    url: jdbc:h2:mem:staccato
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: create
+    defer-datasource-initialization: true


### PR DESCRIPTION
## ⭐️ Issue Number
- #2 

## 🚩 Summary

![image](https://github.com/user-attachments/assets/f721ccb7-c6e7-4454-9bc0-b7f7d5202405)
- 작성한 ERD를 기반으로 JPA Entity 구성

## 🛠️ Technical Concerns
- 작성된 `ERD`에서는 `created_at`이 `LocalDate`로 표현이 되었지만, `log`를 남기기 위한 목적임을 감안해 `LocalDateTime`으로 변경하는 것을 고려 중
- `h2` 는 `TinyInt`를 지원하지 않아 따로 `columnDefinition`으로 명시하지 않았습니다.

## 🙂 To Reviwer

## 📋 To Do
- API 기능 중심으로 역할 분담
