### PR TITLE
build: develop-an의 CI 설정 수정 #38

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -44,3 +44,10 @@ jobs:
 
       - name: Build with Gradle
         run: ./gradlew build
+
+      - name: Access LOCAL_PROPERTIES_API_KEY
+          run: |
+            echo LOCAL_PROPERTIES_API_KEY=\"$LOCAL_PROPERTIES_API_KEY\" >> local.properties
+          shell: bash
+          env:
+            $LOCAL_PROPERTIES_API_KEY: ${{ secrets.LOCAL_PROPERTIES_API_KEY }}


### PR DESCRIPTION
## ⭐️ Issue Number

- #38 

## 🚩 Summary
- [x] **Secret API key 생성**
  - **Git Actions Secret**에 local.properties 접근에 대한 **API key를 설정**한다.
- [x] **git action yml 파일**에 **`local.properties` 파일에 대한 변수 접근 설정**
  **`android-ci.yml` 에 추가된 코드**   
     ```
         - name: Access LOCAL_PROPERTIES_API_KEY
          run: |
            echo LOCAL_PROPERTIES_API_KEY=\"$LOCAL_PROPERTIES_API_KEY\" >> local.properties
          shell: bash
          env:
            $LOCAL_PROPERTIES_API_KEY: ${{ secrets.LOCAL_PROPERTIES_API_KEY }}
     ```
  **코드 설명**
    - Git Action에 Secret으로 저장된 LOCAL_PROPERTIES_API_KEY를 `secret`에 접근하여 환경 변수로 가져온다.
    - 가져온 변수를 echo를 활용하여 local.properties에 설정할 수 있다.
    - 이로써 CI 과정에서 원격에서도 local.properties를 직접 설정하여 해당 파일에 접근할 수 있다.
- [x] `local.properties` 파일에 API 키 값 추가

## 🛠️ Technical Concerns

## 🙂 To Reviwer
- 이후 PR 요청에서 CI workflow가 문제 없이 통과되는지 확인해주세요!

## 📋 To Do
- 해당 커밋을 local의 `develop-an` 브랜치에 전파 후 Merge 필요
- 각 local의 `local.properties` 에 해당 Api key 값을 설정하여야 함
  ```
  // in local.properties
  // add this various
  LOCAL_PROPERTIES_API_KEY="our_local_properties_key_value"
  ```
