### PR TITLE
feat: 여행 상세 생성 API 구현 #18

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	testImplementation 'io.rest-assured:rest-assured:5.3.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/backend/src/main/java/com/staccato/StaccatoApplication.java
+++ b/backend/src/main/java/com/staccato/StaccatoApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class StaccatoApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(StaccatoApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(StaccatoApplication.class, args);
+    }
 
 }

--- a/backend/src/main/java/com/staccato/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/staccato/config/WebMvcConfig.java
@@ -1,0 +1,17 @@
+package com.staccato.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import com.staccato.config.auth.MemberIdArgumentResolver;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new MemberIdArgumentResolver());
+    }
+}

--- a/backend/src/main/java/com/staccato/config/auth/MemberId.java
+++ b/backend/src/main/java/com/staccato/config/auth/MemberId.java
@@ -1,0 +1,12 @@
+package com.staccato.config.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+
+}

--- a/backend/src/main/java/com/staccato/config/auth/MemberIdArgumentResolver.java
+++ b/backend/src/main/java/com/staccato/config/auth/MemberIdArgumentResolver.java
@@ -20,6 +20,6 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return request.getHeader(HttpHeaders.AUTHORIZATION);
+        return Long.parseLong(request.getHeader(HttpHeaders.AUTHORIZATION));
     }
 }

--- a/backend/src/main/java/com/staccato/config/auth/MemberIdArgumentResolver.java
+++ b/backend/src/main/java/com/staccato/config/auth/MemberIdArgumentResolver.java
@@ -1,0 +1,25 @@
+package com.staccato.config.auth;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -25,4 +25,10 @@ public class GlobalExceptionHandler {
                 .orElse("요청 형식이 잘못되었습니다.");
         return ResponseEntity.badRequest().body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), message));
     }
+
+    @ExceptionHandler(InvalidTravelException.class)
+    public ResponseEntity<ExceptionResponse> handleInvalidTravelException(InvalidTravelException e) {
+        return ResponseEntity.badRequest()
+                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage()));
+    }
 }

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -1,17 +1,28 @@
 package com.staccato.exception;
 
 import java.time.format.DateTimeParseException;
+import java.util.Optional;
 
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(DateTimeParseException.class)
-    public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
+    public ResponseEntity<ExceptionResponse> handleDateTimeParseException() {
         return ResponseEntity.badRequest()
                 .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "올바르지 않은 날짜 형식입니다."));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ExceptionResponse> handleValidationException(MethodArgumentNotValidException exception) {
+        String message = Optional.ofNullable(exception.getBindingResult().getFieldError())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
+                .orElse("요청 형식이 잘못되었습니다.");
+        return ResponseEntity.badRequest().body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), message));
     }
 }

--- a/backend/src/main/java/com/staccato/exception/InvalidTravelException.java
+++ b/backend/src/main/java/com/staccato/exception/InvalidTravelException.java
@@ -1,0 +1,19 @@
+package com.staccato.exception;
+
+public class InvalidTravelException extends RuntimeException {
+    public InvalidTravelException() {
+        super();
+    }
+
+    public InvalidTravelException(String message) {
+        super(message);
+    }
+
+    public InvalidTravelException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public InvalidTravelException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -11,9 +11,15 @@ import org.hibernate.annotations.SQLDelete;
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
 public class Member extends BaseEntity {

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -11,15 +11,12 @@ import org.hibernate.annotations.SQLDelete;
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
 public class Member extends BaseEntity {
@@ -30,4 +27,10 @@ public class Member extends BaseEntity {
     private String nickname;
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
+
+    @Builder
+    public Member(String nickname, String imageUrl) {
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.staccato.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.staccato.member.domain.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -1,9 +1,17 @@
 package com.staccato.travel.controller;
 
+import java.net.URI;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.staccato.config.auth.MemberId;
 import com.staccato.travel.service.TravelService;
+import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.travel.service.dto.response.TravelResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,4 +20,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TravelController {
     private final TravelService travelService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTravel(@RequestBody TravelRequest travelRequest, @MemberId Long memberId) {
+        TravelResponse travelResponse = travelService.createTravel(travelRequest, memberId);
+        return ResponseEntity.created(URI.create("/travels/" + travelResponse.travelId())).build();
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -2,6 +2,8 @@ package com.staccato.travel.controller;
 
 import java.net.URI;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,7 +24,7 @@ public class TravelController {
     private final TravelService travelService;
 
     @PostMapping
-    public ResponseEntity<Void> createTravel(@RequestBody TravelRequest travelRequest, @MemberId Long memberId) {
+    public ResponseEntity<Void> createTravel(@Valid @RequestBody TravelRequest travelRequest, @MemberId Long memberId) {
         TravelResponse travelResponse = travelService.createTravel(travelRequest, memberId);
         return ResponseEntity.created(URI.create("/travels/" + travelResponse.travelId())).build();
     }

--- a/backend/src/main/java/com/staccato/travel/domain/Mate.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Mate.java
@@ -14,15 +14,12 @@ import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE mate SET is_deleted = true WHERE id = ?")
 public class Mate extends BaseEntity {
@@ -35,4 +32,10 @@ public class Mate extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "travel_id", nullable = false)
     private Travel travel;
+
+    @Builder
+    public Mate(Member member, Travel travel) {
+        this.member = member;
+        this.travel = travel;
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/domain/Mate.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Mate.java
@@ -16,9 +16,11 @@ import com.staccato.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -48,7 +48,7 @@ public class Travel extends BaseEntity {
     }
 
     private void validateDate(LocalDate startAt, LocalDate endAt) {
-        if(endAt.isBefore(startAt)){
+        if (endAt.isBefore(startAt)) {
             throw new InvalidTravelException("끝 날짜가 시작 날짜보다 앞설 수 없어요.");
         }
     }

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -15,9 +15,11 @@ import com.staccato.config.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import org.hibernate.annotations.SQLDelete;
 
 import com.staccato.config.domain.BaseEntity;
+import com.staccato.exception.InvalidTravelException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -38,10 +39,17 @@ public class Travel extends BaseEntity {
 
     @Builder
     public Travel(String thumbnailUrl, String title, String description, LocalDate startAt, LocalDate endAt) {
+        validateDate(startAt, endAt);
         this.thumbnailUrl = thumbnailUrl;
         this.title = title;
         this.description = description;
         this.startAt = startAt;
         this.endAt = endAt;
+    }
+
+    private void validateDate(LocalDate startAt, LocalDate endAt) {
+        if(endAt.isBefore(startAt)){
+            throw new InvalidTravelException("끝 날짜가 시작 날짜보다 앞설 수 없어요.");
+        }
     }
 }

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -13,15 +13,12 @@ import org.hibernate.annotations.SQLDelete;
 import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE travel SET is_deleted = true WHERE id = ?")
 public class Travel extends BaseEntity {
@@ -38,4 +35,13 @@ public class Travel extends BaseEntity {
     private LocalDate startAt;
     @Column(nullable = false)
     private LocalDate endAt;
+
+    @Builder
+    public Travel(String thumbnailUrl, String title, String description, LocalDate startAt, LocalDate endAt) {
+        this.thumbnailUrl = thumbnailUrl;
+        this.title = title;
+        this.description = description;
+        this.startAt = startAt;
+        this.endAt = endAt;
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/repository/MateRepository.java
+++ b/backend/src/main/java/com/staccato/travel/repository/MateRepository.java
@@ -1,0 +1,8 @@
+package com.staccato.travel.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.staccato.travel.domain.Mate;
+
+public interface MateRepository extends JpaRepository<Mate, Long> {
+}

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -2,7 +2,14 @@ package com.staccato.travel.service;
 
 import org.springframework.stereotype.Service;
 
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+import com.staccato.travel.domain.Mate;
+import com.staccato.travel.domain.Travel;
+import com.staccato.travel.repository.MateRepository;
 import com.staccato.travel.repository.TravelRepository;
+import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.travel.service.dto.response.TravelResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +17,32 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TravelService {
     private final TravelRepository travelRepository;
+    private final MateRepository mateRepository;
+    private final MemberRepository memberRepository;
+
+    public TravelResponse createTravel(TravelRequest travelRequest, Long memberId) {
+        Travel travel = Travel.builder()
+                .title(travelRequest.travelTitle())
+                .description(travelRequest.description())
+                .startAt(travelRequest.startAt())
+                .endAt(travelRequest.endAt())
+                .build();
+        Travel savedTravel = travelRepository.save(travel);
+        saveMate(memberId, savedTravel);
+        return new TravelResponse(travel);
+    }
+
+    private void saveMate(Long memberId, Travel savedTravel) {
+        Member member = getMemberById(memberId);
+        Mate mate = Mate.builder()
+                .travel(savedTravel)
+                .member(member)
+                .build();
+        mateRepository.save(mate);
+    }
+
+    private Member getMemberById(long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid Operation"));
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
@@ -7,6 +7,9 @@ import jakarta.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
+import lombok.Builder;
+
+@Builder
 public record TravelRequest(
         String travelThumbnail,
         @NotNull(message = "여행 제목을 입력해주세요.")
@@ -14,8 +17,10 @@ public record TravelRequest(
         String travelTitle,
         @Size(max = 500, message = "내용의 최대 허용 글자수는 공백 포함 500자입니다.")
         String description,
+        @NotNull(message = "여행 시작 날짜를 입력해주세요.")
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate startAt,
+        @NotNull(message = "여행 끝 날짜를 입력해주세요.")
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate endAt) {
 }

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
@@ -1,4 +1,24 @@
 package com.staccato.travel.service.dto.response;
 
-public record TravelResponse() {
+import java.time.LocalDate;
+
+import com.staccato.travel.domain.Travel;
+
+public record TravelResponse(
+        Long travelId,
+        String travelThumbnail,
+        String travelTitle,
+        String description,
+        LocalDate startAt,
+        LocalDate endAt) {
+    public TravelResponse(Travel travel) {
+        this(
+                travel.getId(),
+                travel.getThumbnailUrl(),
+                travel.getTitle(),
+                travel.getDescription(),
+                travel.getStartAt(),
+                travel.getEndAt()
+        );
+    }
 }

--- a/backend/src/test/java/com/staccato/StaccatoApplicationTests.java
+++ b/backend/src/test/java/com/staccato/StaccatoApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class StaccatoApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -115,7 +114,6 @@ class TravelAcceptanceTest {
                 .header(HttpHeaders.LOCATION, containsString("/travels/"));
     }
 
-    @Disabled
     @DisplayName("사용자가 제목 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutTitle() {
@@ -137,11 +135,10 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("messages", is("여행 제목을 입력해주세요."))
+                .body("message", is("여행 제목을 입력해주세요."))
                 .body("status", is(BAD_REQUEST_STATUS));
     }
 
-    @Disabled
     @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutStartDate() {
@@ -163,12 +160,11 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("messages", is("여행 시작 날짜를 입력해주세요."))
+                .body("message", is("여행 시작 날짜를 입력해주세요."))
                 .body("status", is(BAD_REQUEST_STATUS));
     }
 
-    @Disabled
-    @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
+    @DisplayName("사용자가 끝 날짜 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutEndDate() {
         // given
@@ -189,7 +185,7 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("messages", is("여행 끝 날짜를 입력해주세요."))
+                .body("message", is("여행 끝 날짜를 입력해주세요."))
                 .body("status", is(BAD_REQUEST_STATUS));
     }
 }

--- a/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
@@ -188,4 +188,54 @@ class TravelAcceptanceTest {
                 .body("message", is("여행 끝 날짜를 입력해주세요."))
                 .body("status", is(BAD_REQUEST_STATUS));
     }
+
+    @DisplayName("사용자가 제목을 30자 초과로 입력하면 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWhenTitleExceedLength() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "가".repeat(31),
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is("제목의 최대 허용 글자수는 공백 포함 30자입니다."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
+
+    @DisplayName("사용자가 설명을 500자 초과로 입력하면 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWhenDescriptionExceedLength() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "가".repeat(501),
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is("내용의 최대 허용 글자수는 공백 포함 500자입니다."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
 }

--- a/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
@@ -1,25 +1,47 @@
 package com.staccato.travel.controller;
 
-import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
 import java.time.LocalDate;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
 import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.util.DatabaseCleanerExtension;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
-@Disabled
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class TravelAcceptanceTest {
     private static final String USER_AUTHORIZATION = "1";
     private static final String BAD_REQUEST_STATUS = "400 BAD_REQUEST";
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setPort() {
+        RestAssured.port = port;
+
+        memberRepository.save(Member.builder().nickname("staccato").build());
+    }
 
     @DisplayName("사용자가 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
     @Test
@@ -42,7 +64,7 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.CREATED.value())
-                .header(HttpHeaders.LOCATION, contains("/travels/"));
+                .header(HttpHeaders.LOCATION, containsString("/travels/"));
     }
 
     @DisplayName("사용자가 썸네일 없이 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
@@ -66,7 +88,7 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.CREATED.value())
-                .header(HttpHeaders.LOCATION, contains("/travels/"));
+                .header(HttpHeaders.LOCATION, containsString("/travels/"));
     }
 
     @DisplayName("사용자가 썸네일 없이 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
@@ -90,9 +112,10 @@ class TravelAcceptanceTest {
                 .post("/travels")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.CREATED.value())
-                .header(HttpHeaders.LOCATION, contains("/travels/"));
+                .header(HttpHeaders.LOCATION, containsString("/travels/"));
     }
 
+    @Disabled
     @DisplayName("사용자가 제목 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutTitle() {
@@ -118,6 +141,7 @@ class TravelAcceptanceTest {
                 .body("status", is(BAD_REQUEST_STATUS));
     }
 
+    @Disabled
     @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutStartDate() {
@@ -143,6 +167,7 @@ class TravelAcceptanceTest {
                 .body("status", is(BAD_REQUEST_STATUS));
     }
 
+    @Disabled
     @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
     @Test
     void failCreateTravelWithoutEndDate() {

--- a/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
@@ -238,4 +238,30 @@ class TravelAcceptanceTest {
                 .body("message", is("내용의 최대 허용 글자수는 공백 포함 500자입니다."))
                 .body("status", is(BAD_REQUEST_STATUS));
     }
+
+
+    @DisplayName("사용자가 끝 날짜를 시작 날짜보다 앞서게 설정하면 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWhenEndDateAheadOfStartDate() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 10),
+                LocalDate.of(2023, 7, 1)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is("끝 날짜가 시작 날짜보다 앞설 수 없어요."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
 }

--- a/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelAcceptanceTest.java
@@ -1,0 +1,170 @@
+package com.staccato.travel.controller;
+
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+
+import com.staccato.travel.service.dto.request.TravelRequest;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@Disabled
+class TravelAcceptanceTest {
+    private static final String USER_AUTHORIZATION = "1";
+    private static final String BAD_REQUEST_STATUS = "400 BAD_REQUEST";
+
+    @DisplayName("사용자가 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
+    @Test
+    void createTravel() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.CREATED.value())
+                .header(HttpHeaders.LOCATION, contains("/travels/"));
+    }
+
+    @DisplayName("사용자가 썸네일 없이 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
+    @Test
+    void createTravelWithoutThumbnail() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                null,
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.CREATED.value())
+                .header(HttpHeaders.LOCATION, contains("/travels/"));
+    }
+
+    @DisplayName("사용자가 썸네일 없이 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
+    @Test
+    void createTravelWithoutDescription() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                null,
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.CREATED.value())
+                .header(HttpHeaders.LOCATION, contains("/travels/"));
+    }
+
+    @DisplayName("사용자가 제목 없이 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWithoutTitle() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                null,
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("messages", is("여행 제목을 입력해주세요."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
+
+    @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWithoutStartDate() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                null,
+                LocalDate.of(2023, 7, 10)
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("messages", is("여행 시작 날짜를 입력해주세요."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
+
+    @DisplayName("사용자가 시작 날짜 없이 여행 상세를 생성할 수 없다.")
+    @Test
+    void failCreateTravelWithoutEndDate() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                null
+        );
+
+        // when & then
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .body(travelRequest)
+                .when().log().all()
+                .post("/travels")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("messages", is("여행 끝 날짜를 입력해주세요."))
+                .body("status", is(BAD_REQUEST_STATUS));
+    }
+}

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -1,0 +1,23 @@
+package com.staccato.travel.domain;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.staccato.exception.InvalidTravelException;
+
+class TravelTest {
+    @DisplayName("끝 날짜는 시작 날짜보다 앞설 수 없다.")
+    @Test
+    void validateDate() {
+        assertThatCode(() -> Travel.builder()
+                .endAt(LocalDate.MIN)
+                .startAt(LocalDate.MAX)
+                .build())
+                .isInstanceOf(InvalidTravelException.class)
+                .hasMessage("끝 날짜가 시작 날짜보다 앞설 수 없어요.");
+    }
+}

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -1,0 +1,55 @@
+package com.staccato.travel.service;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDate;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+import com.staccato.travel.domain.Mate;
+import com.staccato.travel.repository.MateRepository;
+import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.travel.service.dto.response.TravelResponse;
+import com.staccato.util.DatabaseCleanerExtension;
+
+@ExtendWith(DatabaseCleanerExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+class TravelServiceTest {
+    @Autowired
+    private TravelService travelService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MateRepository mateRepository;
+
+    @DisplayName("여행 상세 정보를 기반으로, 여행 상세를 생성하고 작성자를 저장한다.")
+    @Test
+    void createTravel() {
+        // given
+        TravelRequest travelRequest = new TravelRequest(
+                "https://example.com/travels/geumohrm.jpg",
+                "2023 여름 휴가",
+                "친구들과 함께한 여름 휴가 여행",
+                LocalDate.of(2023, 7, 1),
+                LocalDate.of(2023, 7, 10)
+        );
+        Member member = memberRepository.save(Member.builder().nickname("staccato").build());
+
+        // when
+        TravelResponse travel = travelService.createTravel(travelRequest, member.getId());
+        Mate mate = mateRepository.findAll().get(0);
+
+        // then
+        assertAll(
+                () -> Assertions.assertThat(mate.getMember().getId()).isEqualTo(member.getId()),
+                () -> Assertions.assertThat(mate.getTravel().getId()).isEqualTo(travel.travelId())
+        );
+    }
+}

--- a/backend/src/test/java/com/staccato/util/DatabaseCleaner.java
+++ b/backend/src/test/java/com/staccato/util/DatabaseCleaner.java
@@ -1,0 +1,49 @@
+package com.staccato.util;
+
+import java.util.List;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Transactional
+    public void cleanUp() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+        for (String tableName : getTableNames()) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1")
+                    .executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+
+    private List<String> getTableNames() {
+        return entityManager.getMetamodel().getEntities().stream()
+                .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
+                .map(entityType -> camelToSnake(entityType.getName()))
+                .toList();
+    }
+
+    private String camelToSnake(String camel) {
+        StringBuilder snake = new StringBuilder();
+        for (char c : camel.toCharArray()) {
+            if (Character.isUpperCase(c)) {
+                snake.append("_");
+            }
+            snake.append(Character.toLowerCase(c));
+        }
+        if (snake.charAt(0) == '_') {
+            snake.deleteCharAt(0);
+        }
+        return snake.toString();
+    }
+}

--- a/backend/src/test/java/com/staccato/util/DatabaseCleanerExtension.java
+++ b/backend/src/test/java/com/staccato/util/DatabaseCleanerExtension.java
@@ -1,0 +1,13 @@
+package com.staccato.util;
+
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+public class DatabaseCleanerExtension implements BeforeEachCallback {
+    @Override
+    public void beforeEach(ExtensionContext context) {
+        DatabaseCleaner databaseCleaner = SpringExtension.getApplicationContext(context).getBean(DatabaseCleaner.class);
+        databaseCleaner.cleanUp();
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #18 
## 🚩 Summary

- 여행 상세 생성 API 구현
  - 인수 테스트(통합 테스트)를 작성 후, bottom-up으로 단위 테스트 작성하며 구현했습니다.
  - 서비스는 슬라이스 테스트(서비스+레포지토리)를 진행했습니다.
  - Fixture 분리는 보류했습니다.
- 간단한 memberIdArgumentResolver 구현
- 도메인 커스텀 예외 생성 : `InvalidTravelException`
- 테스트 시 테이블 초기화 위한 DatabaseCleaner 구현

## 🛠️ Technical Concerns
- 커스텀 예외 단위를 어떻게 가져갈지 정하면 좋을 것 같아요.
  - 현재는 도메인 패키지 범위로 정의했습니다.
- dto에서 검증하는 형식적인 부분들을 도메인에서 이중으로 검증할지 정해보면 좋을 것 같아요.
- 과연 builder를 사용하는 것이 정말 좋을지는 고민해볼 부분일 것 같아요.
  - 필드 누락 휴먼 에러가 우려됩니다.
  - 도메인 검증 로직이 복잡해질 수도 있을 것 같아요.
  - 직접 초기화하지 않을 필드들도 builder에 노출됩니다. -> 생성자를 정의하고, 생성자에 builder를 달아주는 방법으로 해결 가능합니다.

## 🙂 To Reviewer
- 중간 테이블을 엔티티 레벨로 승격시켜 사용해보는 것은 처음이라 제대로 사용했는지 모르겠네요. 서비스 로직에서 이상한 부분이 없는지 리뷰 부탁드려요.
- 테스트 컨벤션도 같이 정해보면 좋을 것 같아요. 테스트도 유심히 봐주세요🙇‍♀️

## 📋 To Do
- 여행 상세 목록 조회 API 구현