### PR TITLE
fix: android-ci.yml 파일의 명령어 수정

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Access LOCAL_PROPERTIES_API_KEY
         run: |
-          echo LOCAL_PROPERTIES_API_KEY=\"$LOCAL_PROPERTIES_API_KEY\" >> local.properties
+          echo LOCAL_PROPERTIES_API_KEY=\"$LOCAL_PROPERTIES_API_KEY\" > local.properties
         shell: bash
         env:
           LOCAL_PROPERTIES_API_KEY: ${{ secrets.LOCAL_PROPERTIES_API_KEY }}


### PR DESCRIPTION
LOCAL_PROPERTIES_API_KEY에 접근하는 명령어 수정

## ⭐️ Issue Number
- #47

## 🚩 Summary

- 명령어 수정 : echo의 출력을 local.properties 파일로 지정하는 연산자를 '>' 로 수정

