### PR TITLE
feat: 둥근 모서리의 이미지를 로드하는 BindingAdapters 추가 #58

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -6,6 +6,8 @@ import androidx.databinding.BindingAdapter
 import coil.load
 import coil.transform.RoundedCornersTransformation
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.bitmap.RoundedCorners
+import com.bumptech.glide.request.RequestOptions
 
 @BindingAdapter(
     value = ["coilImageUrl", "coilPlaceHolder"],
@@ -59,6 +61,22 @@ fun ImageView.setCircleImageWithGlide(
         .load(url)
         .placeholder(placeHolder)
         .circleCrop()
+        .error(placeHolder)
+        .into(this)
+}
+
+@BindingAdapter(
+    value = ["glideRoundedCornerImageUrl", "glidePlaceHolder", "glideRoundingRadius"],
+)
+fun ImageView.setRoundedCornerImageWithGlide(
+    url: String?,
+    placeHolder: Drawable? = null,
+    roundingRadius: Int,
+) {
+    Glide.with(context)
+        .load(url)
+        .placeholder(placeHolder)
+        .apply(RequestOptions.bitmapTransform(RoundedCorners(roundingRadius)))
         .error(placeHolder)
         .into(this)
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -61,6 +61,7 @@ fun ImageView.loadImageWithGlide(
     Glide.with(context)
         .load(url)
         .placeholder(placeHolder)
+        .centerCrop()
         .error(placeHolder)
         .into(this)
 }
@@ -91,6 +92,7 @@ fun ImageView.setRoundedCornerImageWithGlide(
     Glide.with(context)
         .load(url)
         .placeholder(placeHolder)
+        .centerCrop()
         .apply(RequestOptions.bitmapTransform(RoundedCorners(roundingRadius)))
         .error(placeHolder)
         .into(this)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -37,6 +37,21 @@ fun ImageView.setCircleImageWithCoil(
 }
 
 @BindingAdapter(
+    value = ["coilRoundedCornerImageUrl", "coilPlaceHolder", "coilRoundingRadius"],
+)
+fun ImageView.setRoundedCornerImageWithCoil(
+    url: String?,
+    placeHolder: Drawable? = null,
+    roundingRadius: Float,
+) {
+    load(url) {
+        placeholder(placeHolder)
+        transformations(RoundedCornersTransformation(roundingRadius))
+        error(placeHolder)
+    }
+}
+
+@BindingAdapter(
     value = ["glideImageUrl", "glidePlaceHolder"],
 )
 fun ImageView.loadImageWithGlide(


### PR DESCRIPTION
## ⭐️ Issue Number
- #58 

## 🚩 Summary
둥근 모서리 이미지를 출력하는 바인딩 어댑터를 추가했습니다!
아래 설명을 참고해주세요.

### 사용 방법
- **Coil**
  - **세 가지 속성** 모두 필요
  - `app:coilRoundedCornerImageUrl` : 둥근 모서리로 나타내고자 하는 이미지 URL
  - `app:coilPlaceHolder` : placeHolder URL
  - `app:coilRoundingRadius` : **`Float`** 형, 모서리의 둥근 정도
  - xml의 `scaleType` 속성에 `"centerCrop"` 값을 줄 필요 없음.

- **Glide**
  - 마찬가지로, **세 가지 속성** 모두 필요
  - `app:glideRoundedCornerImageUrl` : 둥근 모서리로 나타내고자 하는 이미지 URL
  - `app:glidePlaceHolder` : placeHolder URL
  - `app:glideRoundingRadius` : **`Int`** 형, 모서리의 둥근 정도
  - 마찬가지로 xml의 `scaleType` 속성에 `"centerCrop"` 값을 줄 필요 없음.

### 사용 예시
- **Coil**
  ```xml
  <ImageView
                  android:layout_width="200dp"
                  android:layout_height="150dp"
                  app:coilRoundedCornerImageUrl="@{ yourImageUrl }"
                  app:coilPlaceHolder="@{ yourPlaceHolderDrawable }"
                  app:coilRoundingRadius="@{ 50f (put Float here) }" />
  ```

- **Glide**
  ```xml
  <ImageView
                  android:layout_width="200dp"
                  android:layout_height="150dp"
                  app:glideRoundedCornerImageUrl="@{ yourImageUrl }"
                  app:glidePlaceHolder="@{ yourPlaceHolderDrawable }"
                  app:glideRoundingRadius="@{ 12 (put Int here) }" />
  ```

### `BindingAdapters.kt` 코드
- **`Coil` 코드**
   ```kotlin
   @BindingAdapter(
       value = ["coilRoundedCornerImageUrl", "coilPlaceHolder", "coilRoundingRadius"],
   )
   fun ImageView.setRoundedCornerImageWithCoil(
       url: String?,
       placeHolder: Drawable? = null,
       roundingRadius: Int,
   ) {
       load(url) {
           placeholder(placeHolder)
           transformations(RoundedCornersTransformation(roundingRadius))
           error(placeHolder)
       }
   }
   ```

- **`Glide` 코드**
   ```kotlin
   @BindingAdapter(
       value = ["glideRoundedCornerImageUrl", "glidePlaceHolder", "glideRoundingRadius"],
   )
   fun ImageView.setRoundedCornerImageWithGlide(
       url: String?,
       placeHolder: Drawable? = null,
       roundingRadius: Int,
   ) {
       Glide.with(context)
           .load(url)
           .placeholder(placeHolder)
           .centerCrop()     // Glide의 경우 코드 상에서 centerCrop 설정, xml의 속성으로 설정 시 Rounded Corner 적용 X
           .apply(RequestOptions.bitmapTransform(RoundedCorners(roundingRadius)))
           .error(placeHolder)
           .into(this)
   }
   ```

## 🙂 To Reviwer
- 사용법을 보고 이해가 되지 않는다면 언제든 이야기해주세요!
- 코드를 확인해보고, 수정할 부분이나 추가하고 싶은 기능이 있다면 이야기해주세요!

## 📋 To Do
- 문제 없다면 Merge 진행하고 다시 신나게 코딩~ 🙃 
- `RoundingRadius` 속성에 Float 형과 Int 형을 구분하여 작성하는게 불편할 것 같아서, 하나의 자료형으로 통일시키는 건 어떨까 고민중이에요.