### PR TITLE
fix: 특정 방문 기록 삭제 API 호출 시 관련된 VisitImage를 모두 삭제하도록 수정 #65

### DIFF
--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -16,9 +16,11 @@ import com.staccato.config.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
@@ -1,0 +1,14 @@
+package com.staccato.visit.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.staccato.visit.domain.VisitImage;
+
+public interface VisitImageRepository extends JpaRepository<VisitImage, Long> {
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE VisitImage vi SET vi.isDeleted = true WHERE vi.visit.id = :visitId")
+    void deleteByVisitId(@Param("visitId") Long visitId);
+}

--- a/backend/src/main/java/com/staccato/visit/repository/VisitLogRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitLogRepository.java
@@ -9,6 +9,6 @@ import com.staccato.visit.domain.VisitLog;
 
 public interface VisitLogRepository extends JpaRepository<VisitLog, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE VisitLog v SET v.isDeleted = true WHERE v.visit.id = :visitId")
+    @Query("UPDATE VisitLog vl SET vl.isDeleted = true WHERE vl.visit.id = :visitId")
     void deleteByVisitId(@Param("visitId") Long visitId);
 }

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -28,7 +28,6 @@ public class VisitService {
     private final TravelRepository travelRepository;
     private final VisitImageRepository visitImageRepository;
     private final VisitLogRepository visitLogRepository;
-    private final VisitImageRepository visitImageRepository;
 
     @Transactional
     public long createVisit(VisitRequest visitRequest) {

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -1,5 +1,6 @@
 package com.staccato.visit.service;
 
+import com.staccato.visit.repository.VisitImageRepository;
 import com.staccato.visit.repository.VisitLogRepository;
 import com.staccato.visit.repository.VisitRepository;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +13,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class VisitService {
     private final VisitRepository visitRepository;
     private final VisitLogRepository visitLogRepository;
+    private final VisitImageRepository visitImageRepository;
 
     public void deleteById(Long visitId) {
         visitLogRepository.deleteByVisitId(visitId);
+        visitImageRepository.deleteByVisitId(visitId);
         visitRepository.deleteById(visitId);
     }
 }

--- a/backend/src/test/java/com/staccato/visit/repository/VisitImageRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitImageRepositoryTest.java
@@ -1,0 +1,53 @@
+package com.staccato.visit.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.time.LocalDate;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import com.staccato.pin.domain.Pin;
+import com.staccato.pin.repository.PinRepository;
+import com.staccato.travel.domain.Travel;
+import com.staccato.travel.repository.TravelRepository;
+import com.staccato.visit.domain.Visit;
+import com.staccato.visit.domain.VisitImage;
+
+@DataJpaTest
+class VisitImageRepositoryTest {
+    @Autowired
+    private VisitImageRepository visitImageRepository;
+    @Autowired
+    private VisitRepository visitRepository;
+    @Autowired
+    private TravelRepository travelRepository;
+    @Autowired
+    private PinRepository pinRepository;
+
+    @DisplayName("특정 visitId를 갖는 visitImage들을 모두 삭제한다.")
+    @Test
+    void deleteByVisitId() {
+        // given
+        Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
+        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now())
+                .endAt(LocalDate.now().plusDays(1)).build());
+        Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
+        VisitImage visitImage1 = visitImageRepository.save(VisitImage.builder().imageUrl("Sample Visit Image1")
+                .visit(visit).build());
+        VisitImage visitImage2 = visitImageRepository.save(VisitImage.builder().imageUrl("Sample Visit Image2")
+                .visit(visit).build());
+
+        // when
+        visitImageRepository.deleteByVisitId(visit.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(visitImageRepository.findById(visitImage1.getId()).get().getIsDeleted()).isTrue(),
+                () -> assertThat(visitImageRepository.findById(visitImage2.getId()).get().getIsDeleted()).isTrue()
+        );
+    }
+}

--- a/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
@@ -39,10 +39,9 @@ class VisitLogRepositoryTest {
         Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
         Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
         Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
-        Member member1 = memberRepository.save(Member.builder().nickname("Sample Member1").build());
-        Member member2 = memberRepository.save(Member.builder().nickname("Sample Member2").build());
-        VisitLog visitLog1 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log1").visit(visit).member(member1).build());
-        VisitLog visitLog2 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log2").visit(visit).member(member2).build());
+        Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
+        VisitLog visitLog1 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log1").visit(visit).member(member).build());
+        VisitLog visitLog2 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log2").visit(visit).member(member).build());
 
         // when
         visitLogRepository.deleteByVisitId(visit.getId());

--- a/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
@@ -1,7 +1,7 @@
 package com.staccato.visit.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
 
@@ -36,42 +36,13 @@ class VisitLogRepositoryTest {
     @Test
     void deleteByVisitId() {
         // given
-        Pin pin = pinRepository.save(Pin.builder()
-                .place("Sample Place")
-                .address("Sample Address")
-                .build());
-
-        Travel travel = travelRepository.save(Travel.builder()
-                .title("Sample Travel")
-                .startAt(LocalDate.now())
-                .endAt(LocalDate.now().plusDays(1))
-                .build());
-
-        Visit visit = visitRepository.save(Visit.builder()
-                .visitedAt(LocalDate.now())
-                .pin(pin)
-                .travel(travel)
-                .build());
-
-        Member member1 = memberRepository.save(Member.builder()
-                .nickname("Sample Member1")
-                .build());
-
-        Member member2 = memberRepository.save(Member.builder()
-                .nickname("Sample Member2")
-                .build());
-
-        VisitLog visitLog1 = visitLogRepository.save(VisitLog.builder()
-                .content("Sample Visit Log1")
-                .visit(visit)
-                .member(member1)
-                .build());
-
-        VisitLog visitLog2 = visitLogRepository.save(VisitLog.builder()
-                .content("Sample Visit Log2")
-                .visit(visit)
-                .member(member2)
-                .build());
+        Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
+        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
+        Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
+        Member member1 = memberRepository.save(Member.builder().nickname("Sample Member1").build());
+        Member member2 = memberRepository.save(Member.builder().nickname("Sample Member2").build());
+        VisitLog visitLog1 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log1").visit(visit).member(member1).build());
+        VisitLog visitLog2 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log2").visit(visit).member(member2).build());
 
         // when
         visitLogRepository.deleteByVisitId(visit.getId());

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -38,32 +38,11 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void deleteById() {
         // given
-        Pin pin = pinRepository.save(Pin.builder()
-                .place("Sample Place")
-                .address("Sample Address")
-                .build());
-
-        Travel travel = travelRepository.save(Travel.builder()
-                .title("Sample Travel")
-                .startAt(LocalDate.now())
-                .endAt(LocalDate.now().plusDays(1))
-                .build());
-
-        Visit visit = visitRepository.save(Visit.builder()
-                .visitedAt(LocalDate.now())
-                .pin(pin)
-                .travel(travel)
-                .build());
-
-        Member member = memberRepository.save(Member.builder()
-                .nickname("Sample Member")
-                .build());
-
-        VisitLog visitLog = visitLogRepository.save(VisitLog.builder()
-                .content("Sample Visit Log")
-                .visit(visit)
-                .member(member)
-                .build());
+        Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
+        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
+        Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
+        Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
+        VisitLog visitLog = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log").visit(visit).member(member).build());
 
         // when
         visitService.deleteById(visit.getId());


### PR DESCRIPTION
## ⭐️ Issue Number
- #65 
## 🚩 Summary

- 특정 방문 기록 삭제 API 호출 시 관련된 VisitImage를 모두 삭제하도록 수정

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
