### PR TITLE
fix: 논리적 삭제 데이터는 조회에서 제외

### DIFF
--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -1,8 +1,11 @@
 package com.staccato.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.staccato.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByIdAndIsDeletedIsFalse(long memberId);
 }

--- a/backend/src/main/java/com/staccato/travel/domain/TravelMember.java
+++ b/backend/src/main/java/com/staccato/travel/domain/TravelMember.java
@@ -22,7 +22,7 @@ import lombok.NonNull;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE mate SET is_deleted = true WHERE id = ?")
+@SQLDelete(sql = "UPDATE travel_member SET is_deleted = true WHERE id = ?")
 public class TravelMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/repository/TravelMemberRepository.java
+++ b/backend/src/main/java/com/staccato/travel/repository/TravelMemberRepository.java
@@ -9,8 +9,8 @@ import org.springframework.data.repository.query.Param;
 import com.staccato.travel.domain.TravelMember;
 
 public interface TravelMemberRepository extends JpaRepository<TravelMember, Long> {
-    List<TravelMember> findAllByMemberId(long memberId);
+    List<TravelMember> findAllByMemberIdAndIsDeletedIsFalse(long memberId);
 
-    @Query("SELECT tm FROM TravelMember tm WHERE tm.member.id = :memberId AND YEAR(tm.travel.startAt) = :year")
+    @Query("SELECT tm FROM TravelMember tm WHERE tm.member.id = :memberId AND YEAR(tm.travel.startAt) = :year AND tm.isDeleted IS FALSE")
     List<TravelMember> findAllByMemberIdAndTravelStartAtYear(@Param("memberId") long memberId, @Param("year") int year);
 }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -53,7 +53,7 @@ public class TravelService {
     }
 
     private TravelResponses readAll(long memberId) {
-        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberId(memberId);
+        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdAndIsDeletedIsFalse(memberId);
         return getTravelDetailResponses(travelMembers);
     }
 

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -42,7 +42,7 @@ public class TravelService {
     }
 
     private Member getMemberById(long memberId) {
-        return memberRepository.findById(memberId)
+        return memberRepository.findByIdAndIsDeletedIsFalse(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("Invalid Operation"));
     }
 

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -1,10 +1,12 @@
 package com.staccato.visit.service;
 
-import com.staccato.visit.repository.VisitLogRepository;
-import com.staccato.visit.repository.VisitRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import com.staccato.visit.repository.VisitLogRepository;
+import com.staccato.visit.repository.VisitRepository;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional

--- a/backend/src/test/java/com/staccato/travel/repository/TravelMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/travel/repository/TravelMemberRepositoryTest.java
@@ -43,6 +43,24 @@ class TravelMemberRepositoryTest {
         assertThat(result).hasSize(2);
     }
 
+    @DisplayName("사용자 식별자와 년도로 삭제 되지 않은 여행 상세 목록만 조회한다.")
+    @Test
+    void findAllByMemberIdAndTravelStartAtYearWithoutDeleted() {
+        // given
+        Member member = memberRepository.save(Member.builder().nickname("staccato").build());
+        Travel travel = travelRepository.save(createTravel(LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)));
+        Travel travel2 = travelRepository.save(createTravel(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
+        TravelMember target = travelMemberRepository.save(new TravelMember(member, travel));
+        travelMemberRepository.save(new TravelMember(member, travel2));
+        travelMemberRepository.deleteById(target.getId());
+
+        // when
+        List<TravelMember> result = travelMemberRepository.findAllByMemberIdAndTravelStartAtYear(member.getId(), 2023);
+
+        // then
+        assertThat(result).hasSize(1);
+    }
+
     private static Travel createTravel(LocalDate startAt, LocalDate endAt) {
         return Travel.builder()
                 .title("여행")

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -45,7 +45,7 @@ class TravelServiceTest extends ServiceSliceTest {
 
         // when
         long travelId = travelService.createTravel(travelRequest, member.getId());
-        TravelMember travelMember = travelMemberRepository.findAllByMemberId(member.getId()).get(0);
+        TravelMember travelMember = travelMemberRepository.findAllByMemberIdAndIsDeletedIsFalse(member.getId()).get(0);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -45,7 +45,7 @@ class TravelServiceTest extends ServiceSliceTest {
 
         // when
         long travelId = travelService.createTravel(travelRequest, member.getId());
-        TravelMember travelMember = travelMemberRepository.findAll().get(0);
+        TravelMember travelMember = travelMemberRepository.findAllByMemberId(member.getId()).get(0);
 
         // then
         assertAll(


### PR DESCRIPTION
## ⭐️ Issue Number
- #66 
## 🚩 Summary

- Member, TravelMember에서 findById -> findByIdAndIsDeletedIsFalse로 변경

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
