### PR TITLE
feat: 특정 여행 상세 삭제 API 구현 #24

### DIFF
--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -49,6 +50,14 @@ public class TravelController {
             @Valid @RequestBody TravelRequest travelRequest,
             @MemberId Long memberId) {
         travelService.updateTravel(travelRequest, travelId);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{travelId}")
+    public ResponseEntity<Void> deleteTravel(
+            @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
+            @MemberId Long memberId) {
+        travelService.deleteTravel(travelId);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -85,4 +85,13 @@ public class TravelService {
                 .toList();
         return TravelResponses.from(travels);
     }
+
+    @Transactional
+    public void deleteTravel(Long travelId) {
+        if (!visitRepository.findAllByTravelId(travelId).isEmpty()) {
+            throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
+        }
+        visitRepository.deleteByTravelId(travelId);
+        travelRepository.deleteById(travelId);
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -19,6 +19,7 @@ import com.staccato.travel.service.dto.response.TravelResponses;
 import com.staccato.visit.domain.Visit;
 import com.staccato.visit.domain.VisitImage;
 import com.staccato.visit.repository.VisitImageRepository;
+import com.staccato.visit.repository.VisitLogRepository;
 import com.staccato.visit.repository.VisitRepository;
 import com.staccato.visit.service.dto.response.VisitResponse;
 
@@ -31,6 +32,7 @@ public class TravelService {
     private final TravelRepository travelRepository;
     private final TravelMemberRepository travelMemberRepository;
     private final VisitRepository visitRepository;
+    private final VisitLogRepository visitLogRepository;
     private final MemberRepository memberRepository;
     private final VisitImageRepository visitImageRepository;
 
@@ -89,7 +91,8 @@ public class TravelService {
     @Transactional
     public void deleteTravel(Long travelId) {
         validateVisitExistsByTravelId(travelId);
-        visitRepository.deleteByTravelId(travelId);
+        visitRepository.findAllByTravelIdAndIsDeletedIsFalse(travelId)
+                .forEach(visit -> deleteVisits(visit.getId()));
         travelRepository.deleteById(travelId);
     }
 
@@ -97,6 +100,12 @@ public class TravelService {
         if (visitRepository.existsByTravelId(travelId)) {
             throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
         }
+    }
+
+    private void deleteVisits(long visitId) {
+        visitLogRepository.deleteByVisitId(visitId);
+        visitImageRepository.deleteByVisitId(visitId);
+        visitRepository.deleteById(visitId);
     }
 
     public TravelDetailResponse readTravelById(long travelId) {

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -16,6 +16,8 @@ import com.staccato.travel.repository.TravelRepository;
 import com.staccato.travel.service.dto.request.TravelRequest;
 import com.staccato.travel.service.dto.response.TravelResponses;
 import com.staccato.visit.domain.Visit;
+import com.staccato.visit.repository.VisitImageRepository;
+import com.staccato.visit.repository.VisitLogRepository;
 import com.staccato.visit.repository.VisitRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -28,6 +30,8 @@ public class TravelService {
     private final TravelMemberRepository travelMemberRepository;
     private final VisitRepository visitRepository;
     private final MemberRepository memberRepository;
+    private final VisitImageRepository visitImageRepository;
+    private final VisitLogRepository visitLogRepository;
 
     @Transactional
     public long createTravel(TravelRequest travelRequest, Long memberId) {
@@ -88,10 +92,14 @@ public class TravelService {
 
     @Transactional
     public void deleteTravel(Long travelId) {
-        if (!visitRepository.findAllByTravelId(travelId).isEmpty()) {
-            throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
-        }
+        validateVisitExistsByTravelId(travelId);
         visitRepository.deleteByTravelId(travelId);
         travelRepository.deleteById(travelId);
+    }
+
+    private void validateVisitExistsByTravelId(Long travelId) {
+        if (visitRepository.existsByTravelId(travelId)) {
+            throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
+        }
     }
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -15,4 +15,7 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Visit vi SET vi.isDeleted = true WHERE vi.travel.id = :travelId")
     void deleteByTravelId(@Param("travelId") Long travelId);
+
+    @Query("SELECT CASE WHEN COUNT(v) > 0 THEN true ELSE false END FROM Visit v WHERE v.travel.id = :travelId")
+    boolean existsByTravelId(@Param("travelId") Long travelId);
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -3,9 +3,16 @@ package com.staccato.visit.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.staccato.visit.domain.Visit;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
     List<Visit> findAllByTravelId(Long travelId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Visit vi SET vi.isDeleted = true WHERE vi.travel.id = :travelId")
+    void deleteByTravelId(@Param("travelId") Long travelId);
 }

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -225,5 +226,22 @@ class TravelIntegrationTest extends IntegrationTest {
                 "친구들과 함께한 여름 휴가 여행",
                 LocalDate.of(year, 7, 1),
                 LocalDate.of(year, 7, 10));
+    }
+
+    @DisplayName("사용자가 여행 상세 삭제를 요청하면, 여행 상세를 삭제한다.")
+    @Test
+    void deleteTravel() {
+        // given
+        Long travelId = 1L;
+        TravelRequest travelRequest = new TravelRequest("https://example.com/travels/geumohrm.jpg", "2023 여름 휴가", "친구들과 함께한 여름 휴가 여행", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10));
+        createTravel(travelRequest);
+
+        // when & then
+        RestAssured.given().pathParam("travelId", travelId).log().all()
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .contentType(ContentType.JSON)
+                .when().delete("/travels/{travelId}")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.OK.value());
     }
 }

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -43,7 +43,7 @@ class TravelTest {
 
     @DisplayName("여행 상세를 수정 시 기존 방문 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")
     @Test
-    void validateDuration(){
+    void validateDuration() {
         // given
         Travel travel = Travel.builder()
                 .title("2023 여름 여행")


### PR DESCRIPTION
## ⭐️ Issue Number
- #24 

## 🚩 Summary

- 특정 여행 상세 삭제 API 구현

## 🛠️ Technical Concerns

## 🙂 To Reviwer
- 방문기록이 있는 경우 삭제가 불가능하게 구현하였는데, 회의에서 말했던 것 처럼 여행 상세가 삭제 될 때 우선 논리적 삭제가 특정 여행 상세에 포함된 방문 기록들에게도 전파되게 구성했습니다.

## 📋 To Do
