### PR TITLE
feat: 특정 여행 상세 조회 API 구현 #20

### DIFF
--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
@@ -1,11 +1,12 @@
 package com.staccato.member.service.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.member.domain.Member;
 
 public record MemberResponse(
         Long memberId,
         String nickName,
-        String memberImage
+        @JsonInclude(JsonInclude.Include.NON_NULL) String memberImage
 ) {
     public MemberResponse(Member member) {
         this(member.getId(), member.getNickname(), member.getImageUrl());

--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.staccato.config.auth.MemberId;
 import com.staccato.travel.service.TravelService;
 import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.travel.service.dto.response.TravelDetailResponse;
 import com.staccato.travel.service.dto.response.TravelResponses;
 
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,13 @@ public class TravelController {
             @MemberId Long memberId,
             @RequestParam(value = "year", required = false) Integer year) {
         return ResponseEntity.ok(travelService.readAllTravels(memberId, year));
+    }
+
+    @GetMapping("/{travelId}")
+    public ResponseEntity<TravelDetailResponse> readTravel(
+            @MemberId Long memberId,
+            @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId) {
+        return ResponseEntity.ok(travelService.readTravelById(travelId));
     }
 
     @PutMapping("/{travelId}")

--- a/backend/src/main/java/com/staccato/travel/repository/TravelRepository.java
+++ b/backend/src/main/java/com/staccato/travel/repository/TravelRepository.java
@@ -1,8 +1,11 @@
 package com.staccato.travel.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.staccato.travel.domain.Travel;
 
 public interface TravelRepository extends JpaRepository<Travel, Long> {
+    Optional<Travel> findByIdAndIsDeletedIsFalse(long id);
 }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -71,15 +71,15 @@ public class TravelService {
 
     private TravelResponses readAll(long memberId) {
         List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdAndIsDeletedIsFalse(memberId);
-        return getTravelDetailResponses(travelMembers);
+        return getTravelResponses(travelMembers);
     }
 
     private TravelResponses readAllByYear(long memberId, Integer year) {
         List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdAndTravelStartAtYear(memberId, year);
-        return getTravelDetailResponses(travelMembers);
+        return getTravelResponses(travelMembers);
     }
 
-    private TravelResponses getTravelDetailResponses(List<TravelMember> travelMembers) {
+    private TravelResponses getTravelResponses(List<TravelMember> travelMembers) {
         List<Travel> travels = travelMembers.stream()
                 .map(TravelMember::getTravel)
                 .toList();

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -54,7 +54,7 @@ public class TravelService {
     public void updateTravel(TravelRequest travelRequest, Long travelId) {
         Travel updatedTravel = travelRequest.toTravel();
         Travel originTravel = getTravelById(travelId);
-        List<Visit> visits = visitRepository.findAllByTravelId(travelId);
+        List<Visit> visits = visitRepository.findAllByTravelIdAndIsDeletedIsFalse(travelId);
         originTravel.update(updatedTravel, visits);
     }
 

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -21,7 +21,6 @@ import com.staccato.visit.domain.VisitImage;
 import com.staccato.visit.repository.VisitImageRepository;
 import com.staccato.visit.repository.VisitRepository;
 import com.staccato.visit.service.dto.response.VisitResponse;
-import com.staccato.visit.service.dto.response.VisitResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -89,7 +88,7 @@ public class TravelService {
 
     public TravelDetailResponse readTravelById(long travelId) {
         Travel travel = getTravelById(travelId);
-        VisitResponses visitResponses = getVisitResponses(visitRepository.findAllByTravelIdAndIsDeletedIsFalse(travelId));
+        List<VisitResponse> visitResponses = getVisitResponses(visitRepository.findAllByTravelIdAndIsDeletedIsFalse(travelId));
         return new TravelDetailResponse(travel, visitResponses);
     }
 
@@ -98,10 +97,10 @@ public class TravelService {
                 .orElseThrow(() -> new StaccatoException("요청하신 여행을 찾을 수 없어요."));
     }
 
-    private VisitResponses getVisitResponses(List<Visit> visits) {
-        return new VisitResponses(visits.stream()
+    private List<VisitResponse> getVisitResponses(List<Visit> visits) {
+        return visits.stream()
                 .map(visit -> new VisitResponse(visit, getFirstVisitImageUrl(visit)))
-                .toList());
+                .toList();
     }
 
     private String getFirstVisitImageUrl(Visit visit) {

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
@@ -3,6 +3,7 @@ package com.staccato.travel.service.dto.response;
 import java.time.LocalDate;
 
 import com.staccato.member.service.dto.response.MemberResponses;
+import com.staccato.travel.domain.Travel;
 import com.staccato.visit.service.dto.response.VisitResponses;
 
 public record TravelDetailResponse(
@@ -15,4 +16,16 @@ public record TravelDetailResponse(
         MemberResponses mates,
         VisitResponses visits
 ) {
+    public TravelDetailResponse(Travel travel, VisitResponses visitResponses) {
+        this(
+                travel.getId(),
+                travel.getThumbnailUrl(),
+                travel.getTitle(),
+                travel.getDescription(),
+                travel.getStartAt(),
+                travel.getEndAt(),
+                MemberResponses.from(travel.getMates()),
+                visitResponses
+        );
+    }
 }

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
@@ -2,15 +2,16 @@ package com.staccato.travel.service.dto.response;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.member.service.dto.response.MemberResponses;
 import com.staccato.travel.domain.Travel;
 import com.staccato.visit.service.dto.response.VisitResponses;
 
 public record TravelDetailResponse(
         Long travelId,
-        String travelThumbnail,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String travelThumbnail,
         String travelTitle,
-        String description,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String description,
         LocalDate startAt,
         LocalDate endAt,
         MemberResponses mates,

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
@@ -1,11 +1,12 @@
 package com.staccato.travel.service.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.staccato.member.service.dto.response.MemberResponses;
+import com.staccato.member.service.dto.response.MemberResponse;
 import com.staccato.travel.domain.Travel;
-import com.staccato.visit.service.dto.response.VisitResponses;
+import com.staccato.visit.service.dto.response.VisitResponse;
 
 public record TravelDetailResponse(
         Long travelId,
@@ -14,10 +15,10 @@ public record TravelDetailResponse(
         @JsonInclude(JsonInclude.Include.NON_NULL) String description,
         LocalDate startAt,
         LocalDate endAt,
-        MemberResponses mates,
-        VisitResponses visits
+        List<MemberResponse> mates,
+        List<VisitResponse> visits
 ) {
-    public TravelDetailResponse(Travel travel, VisitResponses visitResponses) {
+    public TravelDetailResponse(Travel travel, List<VisitResponse> visitResponses) {
         this(
                 travel.getId(),
                 travel.getThumbnailUrl(),
@@ -25,8 +26,12 @@ public record TravelDetailResponse(
                 travel.getDescription(),
                 travel.getStartAt(),
                 travel.getEndAt(),
-                MemberResponses.from(travel.getMates()),
+                toMemberResponses(travel),
                 visitResponses
         );
+    }
+
+    private static List<MemberResponse> toMemberResponses(Travel travel) {
+        return travel.getMates().stream().map(MemberResponse::new).toList();
     }
 }

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
@@ -1,0 +1,18 @@
+package com.staccato.travel.service.dto.response;
+
+import java.time.LocalDate;
+
+import com.staccato.member.service.dto.response.MemberResponses;
+import com.staccato.visit.service.dto.response.VisitResponses;
+
+public record TravelDetailResponse(
+        Long travelId,
+        String travelThumbnail,
+        String travelTitle,
+        String description,
+        LocalDate startAt,
+        LocalDate endAt,
+        MemberResponses mates,
+        VisitResponses visits
+) {
+}

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
@@ -2,14 +2,15 @@ package com.staccato.travel.service.dto.response;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.member.service.dto.response.MemberResponses;
 import com.staccato.travel.domain.Travel;
 
 public record TravelResponse(
         Long travelId,
-        String travelThumbnail,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String travelThumbnail,
         String travelTitle,
-        String description,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String description,
         LocalDate startAt,
         LocalDate endAt,
         MemberResponses mates

--- a/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
@@ -1,5 +1,7 @@
 package com.staccato.visit.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,4 +13,6 @@ public interface VisitImageRepository extends JpaRepository<VisitImage, Long> {
     @Modifying(clearAutomatically = true)
     @Query("UPDATE VisitImage vi SET vi.isDeleted = true WHERE vi.visit.id = :visitId")
     void deleteByVisitId(@Param("visitId") Long visitId);
+
+    Optional<VisitImage> findFirstByVisitIdAndIsDeletedIsFalse(long visitId);
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -3,9 +3,10 @@ package com.staccato.visit.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 import com.staccato.visit.domain.Visit;
 
 public interface VisitRepository extends JpaRepository<Visit, Long> {
-    List<Visit> findAllByTravelId(Long travelId);
+    List<Visit> findAllByTravelIdAndIsDeletedIsFalse(@Param("travelId") long travelId);
 }

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
@@ -2,10 +2,15 @@ package com.staccato.visit.service.dto.response;
 
 import java.time.LocalDate;
 
+import com.staccato.visit.domain.Visit;
+
 public record VisitResponse(
         Long visitId,
         String placeName,
-        String visitedImages,
+        String visitImage,
         LocalDate visitedAt
 ) {
+    public VisitResponse(Visit visit, String visitImage) {
+        this(visit.getId(), visit.getPin().getPlace(), visitImage, visit.getVisitedAt());
+    }
 }

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
@@ -1,0 +1,11 @@
+package com.staccato.visit.service.dto.response;
+
+import java.time.LocalDate;
+
+public record VisitResponse(
+        Long visitId,
+        String placeName,
+        String visitedImages,
+        LocalDate visitedAt
+) {
+}

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponse.java
@@ -2,12 +2,13 @@ package com.staccato.visit.service.dto.response;
 
 import java.time.LocalDate;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.visit.domain.Visit;
 
 public record VisitResponse(
         Long visitId,
         String placeName,
-        String visitImage,
+        @JsonInclude(JsonInclude.Include.NON_NULL) String visitImage,
         LocalDate visitedAt
 ) {
     public VisitResponse(Visit visit, String visitImage) {

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponses.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitResponses.java
@@ -1,0 +1,8 @@
+package com.staccato.visit.service.dto.response;
+
+import java.util.List;
+
+public record VisitResponses(
+        List<VisitResponse> visits
+) {
+}

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -7,13 +7,14 @@ import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -147,24 +148,23 @@ class TravelIntegrationTest extends IntegrationTest {
     }
 
     @DisplayName("사용자가 잘못된 여행식별자로 접근한다면 예외가 발생한다.")
-    @ParameterizedTest
-    @ValueSource(longs = {0, -1})
-    void failAccessTravel(Long travelId) {
+    @Test
+    void failAccessTravel() {
         // given
         TravelRequest travelRequest = new TravelRequest("https://example.com/travels/geumohrm.jpg", "2023 여름 휴가", "친구들과 함께한 여름 휴가 여행", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10));
-        String expectedMessage = "여행 식별자는 양수로 이루어져야 합니다.";
         createTravel(travelRequest);
 
         // when & then
-        RestAssured.given().pathParam("travelId", travelId).log().all()
+        RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .pathParam("travelId", 0)
                 .body(travelRequest)
                 .when().log().all()
                 .put("/travels/{travelId}")
                 .then().log().all()
                 .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
-                .body("message", is(expectedMessage))
+                .body("message", is("여행 식별자는 양수로 이루어져야 합니다."))
                 .body("status", is(HttpStatus.BAD_REQUEST.toString()));
     }
 
@@ -176,7 +176,6 @@ class TravelIntegrationTest extends IntegrationTest {
                 createTravel(2024),
                 DynamicTest.dynamicTest("사용자가 타임라인을 조회하면 2개의 여행 목록이 조회된다.", () ->
                         RestAssured.given().log().all()
-                                .contentType(ContentType.JSON)
                                 .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
                                 .when().log().all()
                                 .get("/travels")
@@ -194,15 +193,47 @@ class TravelIntegrationTest extends IntegrationTest {
                 createTravel(2024),
                 DynamicTest.dynamicTest("사용자가 타임라인에서 2023년도를 선택하면 1개의 여행 목록이 조회된다.", () ->
                         RestAssured.given().log().all()
-                                .contentType(ContentType.JSON)
                                 .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
                                 .param("year", 2023)
                                 .when().log().all()
                                 .get("/travels")
                                 .then().log().all()
                                 .assertThat().statusCode(HttpStatus.OK.value())
-                                .body("size()", is(1)))
+                                .body("travels.size()", is(1)))
         );
+    }
+
+    @Disabled
+    @DisplayName("사용자가 특정 여행 상세를 조회한다.")
+    @TestFactory
+    Stream<DynamicTest> findTravelById() {
+        return Stream.of(
+                createTravel(2023),
+                DynamicTest.dynamicTest("사용자가 타임라인에서 특정 여행 상세를 선택하여 조회한다.", () ->
+                        RestAssured.given().log().all()
+                                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                                .pathParam("travelId", 1)
+                                .when().log().all()
+                                .get("/travels/{travelId}")
+                                .then().log().all()
+                                .assertThat().statusCode(HttpStatus.OK.value()))
+        );
+    }
+
+    @Disabled
+    @DisplayName("사용자가 잘못된 여행식별자로 조회하려고 한다면 예외가 발생한다.")
+    @Test
+    void failFindTravelById() {
+        RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .pathParam("travelId", 0)
+                .when().log().all()
+                .get("/travels/{travelId}")
+                .then().log().all()
+                .assertThat().statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is("여행 식별자는 양수로 이루어져야 합니다."))
+                .body("status", is(HttpStatus.BAD_REQUEST.toString()));
     }
 
     private DynamicTest createTravel(int year) {

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -203,7 +203,6 @@ class TravelIntegrationTest extends IntegrationTest {
         );
     }
 
-    @Disabled
     @DisplayName("사용자가 특정 여행 상세를 조회한다.")
     @TestFactory
     Stream<DynamicTest> findTravelById() {
@@ -220,7 +219,6 @@ class TravelIntegrationTest extends IntegrationTest {
         );
     }
 
-    @Disabled
     @DisplayName("사용자가 잘못된 여행식별자로 조회하려고 한다면 예외가 발생한다.")
     @Test
     void failFindTravelById() {

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -43,7 +43,7 @@ class TravelTest {
 
     @DisplayName("여행 상세를 수정 시 기존 방문 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")
     @Test
-    void validateDuration(){
+    void validateDuration() {
         // given
         Travel travel = Travel.builder()
                 .title("2023 여름 여행")

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -104,9 +104,9 @@ class TravelServiceTest extends ServiceSliceTest {
         // then
         assertAll(
                 () -> assertThat(travelDetailResponse.travelId()).isEqualTo(targetId),
-                () -> assertThat(travelDetailResponse.mates().members()).hasSize(1),
-                () -> assertThat(travelDetailResponse.visits().visits()).hasSize(1),
-                () -> assertThat(travelDetailResponse.visits().visits().get(0).visitId()).isEqualTo(visit.getId())
+                () -> assertThat(travelDetailResponse.mates()).hasSize(1),
+                () -> assertThat(travelDetailResponse.visits()).hasSize(1),
+                () -> assertThat(travelDetailResponse.visits().get(0).visitId()).isEqualTo(visit.getId())
         );
     }
 

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -18,12 +18,17 @@ import com.staccato.ServiceSliceTest;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
+import com.staccato.pin.domain.Pin;
+import com.staccato.pin.repository.PinRepository;
 import com.staccato.travel.domain.Travel;
 import com.staccato.travel.domain.TravelMember;
 import com.staccato.travel.repository.TravelMemberRepository;
 import com.staccato.travel.repository.TravelRepository;
 import com.staccato.travel.service.dto.request.TravelRequest;
+import com.staccato.travel.service.dto.response.TravelDetailResponse;
 import com.staccato.travel.service.dto.response.TravelResponses;
+import com.staccato.visit.domain.Visit;
+import com.staccato.visit.repository.VisitRepository;
 
 class TravelServiceTest extends ServiceSliceTest {
     @Autowired
@@ -34,6 +39,10 @@ class TravelServiceTest extends ServiceSliceTest {
     private TravelMemberRepository travelMemberRepository;
     @Autowired
     private TravelRepository travelRepository;
+    @Autowired
+    private VisitRepository visitRepository;
+    @Autowired
+    private PinRepository pinRepository;
 
     static Stream<Arguments> yearProvider() {
         return Stream.of(
@@ -76,6 +85,31 @@ class TravelServiceTest extends ServiceSliceTest {
         assertThat(travelResponses.travels()).hasSize(expectedSize);
     }
 
+    @DisplayName("특정 여행 상세 목록을 조회한다.")
+    @Test
+    void readTravelById() {
+        // given
+        Member member = memberRepository.save(Member.builder().nickname("staccato").build());
+        Pin pin = pinRepository.save(Pin.builder().place("장소").address("주소").build());
+
+        long targetId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        Visit visit = saveVisit(pin, targetId);
+
+        long otherId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        saveVisit(pin, otherId);
+
+        // when
+        TravelDetailResponse travelDetailResponse = travelService.readTravelById(targetId);
+
+        // then
+        assertAll(
+                () -> assertThat(travelDetailResponse.travelId()).isEqualTo(targetId),
+                () -> assertThat(travelDetailResponse.mates().members()).hasSize(1),
+                () -> assertThat(travelDetailResponse.visits().visits()).hasSize(1),
+                () -> assertThat(travelDetailResponse.visits().visits().get(0).visitId()).isEqualTo(visit.getId())
+        );
+    }
+
     private static TravelRequest createTravelRequest(int year) {
         return new TravelRequest(
                 "https://example.com/travels/geumohrm.jpg",
@@ -84,6 +118,15 @@ class TravelServiceTest extends ServiceSliceTest {
                 LocalDate.of(year, 7, 1),
                 LocalDate.of(2024, 7, 10)
         );
+    }
+
+    private Visit saveVisit(Pin pin, long otherId) {
+        return visitRepository.save(
+                Visit.builder()
+                        .travel(travelRepository.findByIdAndIsDeletedIsFalse(otherId).get())
+                        .visitedAt(LocalDate.of(2023, 7, 1))
+                        .pin(pin)
+                        .build());
     }
 
     @DisplayName("여행 상세 정보를 기반으로, 여행 상세를 수정한다.")

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -181,4 +181,16 @@ class TravelServiceTest extends ServiceSliceTest {
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("요청하신 여행을 찾을 수 없어요.");
     }
+
+    @DisplayName("존재하지 않는 여행 상세를 조회하려고 할 경우 예외가 발생한다.")
+    @Test
+    void failReadTravel() {
+        // given
+        long unknownId = 1;
+
+        // when & then
+        assertThatThrownBy(() -> travelService.readTravelById(unknownId))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("요청하신 여행을 찾을 수 없어요.");
+    }
 }

--- a/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
@@ -37,7 +37,9 @@ class VisitLogRepositoryTest {
     void deleteByVisitId() {
         // given
         Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
-        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
+        Travel travel = travelRepository.save(
+                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build()
+        );
         Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
         Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
         VisitLog visitLog1 = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log1").visit(visit).member(member).build());

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -39,7 +39,9 @@ class VisitServiceTest extends ServiceSliceTest {
     void deleteById() {
         // given
         Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").build());
-        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
+        Travel travel = travelRepository.save(
+                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build()
+        );
         Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());
         Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
         VisitLog visitLog = visitLogRepository.save(VisitLog.builder().content("Sample Visit Log").visit(visit).member(member).build());


### PR DESCRIPTION
## ⭐️ Issue Number
- close #20 
## 🚩 Summary

- 응답이 null인 필드는 포함시키지 않도록 구현
- 특정 상세 조회용 응답 구현 (TravelDetailResponse, VisitResponse, VisitResponses)

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
