### PR TITLE
ui: 방문 기록, 방문 기록 생성, 방문 기록 수정 화면 구현 #52

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/DeleteDialogFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/DeleteDialogFragment.kt
@@ -10,6 +10,12 @@ import androidx.fragment.app.DialogFragment
 import com.woowacourse.staccato.databinding.FragmentDeleteDialogBinding
 
 class DeleteDialogFragment : DialogFragment() {
+    private lateinit var dialogHandler: DialogHandler
+
+    fun setDialogHandler(newDialogHandler: DialogHandler) {
+        dialogHandler = newDialogHandler
+    }
+
     private var _binding: FragmentDeleteDialogBinding? = null
     private val binding get() = _binding!!
 
@@ -29,7 +35,18 @@ class DeleteDialogFragment : DialogFragment() {
         savedInstanceState: Bundle?,
     ): View {
         _binding = FragmentDeleteDialogBinding.inflate(inflater, container, false)
+        initButtonClickListener()
         return binding.root
+    }
+
+    private fun initButtonClickListener() {
+        binding.btnDeleteCancel.setOnClickListener {
+            dismiss()
+        }
+        binding.btnDeleteConfirm.setOnClickListener {
+            dialogHandler.onConfirmClicked()
+            dismiss()
+        }
     }
 
     override fun onDestroyView() {
@@ -40,4 +57,8 @@ class DeleteDialogFragment : DialogFragment() {
     companion object {
         const val TAG = "DeleteDialogFragment"
     }
+}
+
+fun interface DialogHandler {
+    fun onConfirmClicked()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/DeleteDialogFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/DeleteDialogFragment.kt
@@ -9,13 +9,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import com.woowacourse.staccato.databinding.FragmentDeleteDialogBinding
 
-class DeleteDialogFragment : DialogFragment() {
-    private lateinit var dialogHandler: DialogHandler
-
-    fun setDialogHandler(newDialogHandler: DialogHandler) {
-        dialogHandler = newDialogHandler
-    }
-
+class DeleteDialogFragment(private val dialogHandler: DialogHandler) : DialogFragment() {
     private var _binding: FragmentDeleteDialogBinding? = null
     private val binding get() = _binding!!
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -1,11 +1,17 @@
 package com.woowacourse.staccato.presentation
 
 import android.graphics.drawable.Drawable
+import android.widget.Button
 import android.widget.ImageView
+import android.widget.NumberPicker
+import android.widget.TextView
+import androidx.core.view.isGone
 import androidx.databinding.BindingAdapter
 import coil.load
 import coil.transform.RoundedCornersTransformation
 import com.bumptech.glide.Glide
+import com.woowacourse.staccato.R
+import com.woowacourse.staccato.presentation.visitcreation.model.TravelUiModel
 
 @BindingAdapter(
     value = ["coilImageUrl", "coilPlaceHolder"],
@@ -61,4 +67,69 @@ fun ImageView.setCircleImageWithGlide(
         .circleCrop()
         .error(placeHolder)
         .into(this)
+}
+
+@BindingAdapter("bindSetSelectedTravel")
+fun TextView.setSelectedTravel(selectedTravel: TravelUiModel?) {
+    if (selectedTravel == null) {
+        text = resources.getString(R.string.visit_creation_travel_selection_hint)
+        setTextColor(resources.getColor(R.color.gray3, null))
+    } else {
+        text = selectedTravel.travelTitle
+        setTextColor(resources.getColor(R.color.staccato_black, null))
+    }
+}
+
+@BindingAdapter("bindSetSelectedVisitedAt")
+fun TextView.setSelectedVisitedAt(selectedVisitedAt: String?) {
+    if (selectedVisitedAt == null) {
+        text = resources.getString(R.string.visit_creation_visited_at_hint)
+        setTextColor(resources.getColor(R.color.gray3, null))
+    } else {
+        text = selectedVisitedAt
+        setTextColor(resources.getColor(R.color.staccato_black, null))
+    }
+}
+
+@BindingAdapter(
+    value = ["selectedTravel", "visitedAt"],
+)
+fun Button.setVisitUpdateButtonActive(
+    travel: TravelUiModel?,
+    visitedAt: String?,
+) {
+    isEnabled =
+        if (travel == null || visitedAt == null) {
+            setTextColor(resources.getColor(R.color.gray4, null))
+            false
+        } else {
+            setTextColor(resources.getColor(R.color.white, null))
+            true
+        }
+}
+
+@BindingAdapter("bindSetVisitedAtConfirmButtonActive")
+fun Button.setVisitedAtConfirmButtonActive(items: List<String>?) {
+    isEnabled =
+        if (items.isNullOrEmpty()) {
+            setTextColor(resources.getColor(R.color.gray4, null))
+            false
+        } else {
+            setTextColor(resources.getColor(R.color.white, null))
+            true
+        }
+}
+
+@BindingAdapter("bindSetVisitedAtNumberPickerItems")
+fun NumberPicker.setVisitedAtNumberPickerItems(items: List<String>?) {
+    if (items.isNullOrEmpty()) {
+        isGone = true
+    } else {
+        displayedValues = items.toTypedArray()
+    }
+}
+
+@BindingAdapter("bindSetVisitedAtIsEmptyVisibility")
+fun TextView.setVisitedAtIsEmptyVisibility(items: List<String>?) {
+    isGone = !items.isNullOrEmpty()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/ToolbarHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/ToolbarHandler.kt
@@ -1,0 +1,7 @@
+package com.woowacourse.staccato.presentation
+
+interface ToolbarHandler {
+    fun onUpdateClicked()
+
+    fun onDeleteClicked()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/VisitFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/VisitFragment.kt
@@ -2,25 +2,69 @@ package com.woowacourse.staccato.presentation.visit
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
+import androidx.navigation.fragment.findNavController
+import com.woowacourse.staccato.DeleteDialogFragment
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.FragmentVisitBinding
+import com.woowacourse.staccato.presentation.ToolbarHandler
 import com.woowacourse.staccato.presentation.base.BindingFragment
 import com.woowacourse.staccato.presentation.main.MainActivity
+import com.woowacourse.staccato.presentation.visit.adapter.VisitAdapter
+import com.woowacourse.staccato.presentation.visit.viewmodel.VisitViewModel
+import com.woowacourse.staccato.presentation.visit.viewmodel.VisitViewModelFactory
 import com.woowacourse.staccato.presentation.visitupdate.VisitUpdateActivity
 
 class VisitFragment :
-    BindingFragment<FragmentVisitBinding>(R.layout.fragment_visit) {
+    BindingFragment<FragmentVisitBinding>(R.layout.fragment_visit), ToolbarHandler {
+    private val viewModel: VisitViewModel by viewModels { VisitViewModelFactory() }
+    private lateinit var visitAdapter: VisitAdapter
+
     override fun onViewCreated(
         view: View,
         savedInstanceState: Bundle?,
     ) {
-        binding.btnVisitUpdate.setOnClickListener {
-            val visitUpdateLauncher = (activity as MainActivity).visitUpdateLauncher
-            VisitUpdateActivity.startWithResultLauncher(
-                this.requireActivity(),
-                visitUpdateLauncher,
-            )
-//            findNavController().navigate(R.id.action_travelFragment_to_travelUpdateFragment)
+        initAdapter()
+        initToolbarHandler()
+        observeData()
+        viewModel.fetchVisitDetailData()
+    }
+
+    private fun initAdapter() {
+        visitAdapter = VisitAdapter(mutableListOf())
+        binding.rvVisitDetail.adapter = visitAdapter
+    }
+
+    private fun initToolbarHandler() {
+        binding.toolbarHandler = this
+        binding.includeVisitToolbar.toolbarDetail.setNavigationOnClickListener {
+            findNavController().popBackStack()
         }
+    }
+
+    private fun observeData() {
+        viewModel.visitDefault.observe(viewLifecycleOwner) { visitDefault ->
+            visitAdapter.updateVisitDefault(visitDefault)
+        }
+        viewModel.visitLogs.observe(viewLifecycleOwner) { visitLogs ->
+            visitAdapter.updateVisitLogs(visitLogs)
+        }
+    }
+
+    override fun onDeleteClicked() {
+        val fragmentManager = parentFragmentManager
+        val deleteDialog = DeleteDialogFragment()
+        deleteDialog.apply {
+            setDialogHandler { findNavController().popBackStack() }
+            show(fragmentManager, DeleteDialogFragment.TAG)
+        }
+    }
+
+    override fun onUpdateClicked() {
+        val visitUpdateLauncher = (activity as MainActivity).visitUpdateLauncher
+        VisitUpdateActivity.startWithResultLauncher(
+            this.requireActivity(),
+            visitUpdateLauncher,
+        )
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/VisitFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/VisitFragment.kt
@@ -19,6 +19,7 @@ class VisitFragment :
     BindingFragment<FragmentVisitBinding>(R.layout.fragment_visit), ToolbarHandler {
     private val viewModel: VisitViewModel by viewModels { VisitViewModelFactory() }
     private lateinit var visitAdapter: VisitAdapter
+    private val deleteDialog = DeleteDialogFragment { findNavController().popBackStack() }
 
     override fun onViewCreated(
         view: View,
@@ -53,9 +54,7 @@ class VisitFragment :
 
     override fun onDeleteClicked() {
         val fragmentManager = parentFragmentManager
-        val deleteDialog = DeleteDialogFragment()
         deleteDialog.apply {
-            setDialogHandler { findNavController().popBackStack() }
             show(fragmentManager, DeleteDialogFragment.TAG)
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitAdapter.kt
@@ -1,0 +1,76 @@
+package com.woowacourse.staccato.presentation.visit.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.woowacourse.staccato.databinding.ItemMyVisitLogBinding
+import com.woowacourse.staccato.databinding.ItemVisitDefaultBinding
+import com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel
+
+class VisitAdapter(private val items: MutableList<VisitDetailUiModel> = mutableListOf()) :
+    RecyclerView.Adapter<VisitViewHolder>() {
+    override fun getItemCount(): Int = items.size
+
+    override fun getItemViewType(position: Int): Int {
+        return if (position == VISIT_DEFAULT_POSITION) {
+            VisitViewHolderType.VISIT_DEFAULT.value
+        } else {
+            VisitViewHolderType.MY_VISIT_LOG.value
+        }
+    }
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int,
+    ): VisitViewHolder {
+        return when (VisitViewHolderType.of(viewType)) {
+            VisitViewHolderType.VISIT_DEFAULT -> {
+                val inflater = LayoutInflater.from(parent.context)
+                val binding = ItemVisitDefaultBinding.inflate(inflater, parent, false)
+                VisitViewHolder.VisitDefaultViewHolder(binding)
+            }
+
+            VisitViewHolderType.MY_VISIT_LOG -> {
+                val inflater = LayoutInflater.from(parent.context)
+                val binding = ItemMyVisitLogBinding.inflate(inflater, parent, false)
+                VisitViewHolder.MyVisitLogViewHolder(binding)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(
+        holder: VisitViewHolder,
+        position: Int,
+    ) {
+        if (holder is VisitViewHolder.VisitDefaultViewHolder) {
+            holder.bind(items[position] as VisitDetailUiModel.VisitDefaultUiModel)
+        }
+        if (holder is VisitViewHolder.MyVisitLogViewHolder) {
+            holder.bind(items[position] as VisitDetailUiModel.VisitLogUiModel)
+        }
+    }
+
+    fun updateVisitDefault(newVisitDefault: VisitDetailUiModel.VisitDefaultUiModel) {
+        val result = mutableListOf<VisitDetailUiModel>(newVisitDefault)
+        result.addAll(items.drop(VISIT_DEFAULT_ITEM_SIZE))
+        replaceAllItems(result)
+        notifyItemChanged(VISIT_DEFAULT_POSITION)
+    }
+
+    fun updateVisitLogs(newVisitLogs: List<VisitDetailUiModel.VisitLogUiModel>) {
+        val result = items.take(VISIT_DEFAULT_ITEM_SIZE).toMutableList()
+        result.addAll(newVisitLogs)
+        replaceAllItems(result)
+        notifyItemRangeInserted(VISIT_DEFAULT_ITEM_SIZE, result.size)
+    }
+
+    private fun replaceAllItems(result: MutableList<VisitDetailUiModel>) {
+        items.clear()
+        items.addAll(result)
+    }
+
+    companion object {
+        private const val VISIT_DEFAULT_POSITION = 0
+        private const val VISIT_DEFAULT_ITEM_SIZE = 1
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitAdapter.kt
@@ -23,7 +23,7 @@ class VisitAdapter(private val items: MutableList<VisitDetailUiModel> = mutableL
         parent: ViewGroup,
         viewType: Int,
     ): VisitViewHolder {
-        return when (VisitViewHolderType.of(viewType)) {
+        return when (VisitViewHolderType.from(viewType)) {
             VisitViewHolderType.VISIT_DEFAULT -> {
                 val inflater = LayoutInflater.from(parent.context)
                 val binding = ItemVisitDefaultBinding.inflate(inflater, parent, false)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolder.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolder.kt
@@ -1,0 +1,23 @@
+package com.woowacourse.staccato.presentation.visit.adapter
+
+import androidx.databinding.ViewDataBinding
+import androidx.recyclerview.widget.RecyclerView
+import com.woowacourse.staccato.databinding.ItemMyVisitLogBinding
+import com.woowacourse.staccato.databinding.ItemVisitDefaultBinding
+import com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel
+
+sealed class VisitViewHolder(binding: ViewDataBinding) : RecyclerView.ViewHolder(binding.root) {
+    class VisitDefaultViewHolder(private val binding: ItemVisitDefaultBinding) :
+        VisitViewHolder(binding) {
+        fun bind(item: VisitDetailUiModel.VisitDefaultUiModel) {
+            binding.visitDefault = item
+        }
+    }
+
+    class MyVisitLogViewHolder(private val binding: ItemMyVisitLogBinding) :
+        VisitViewHolder(binding) {
+        fun bind(item: VisitDetailUiModel.VisitLogUiModel) {
+            binding.visitLog = item
+        }
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolderType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolderType.kt
@@ -1,0 +1,25 @@
+package com.woowacourse.staccato.presentation.visit.adapter
+
+enum class VisitViewHolderType(val value: Int) {
+    VISIT_DEFAULT(0),
+    MY_VISIT_LOG(1),
+    ;
+
+    companion object {
+        fun of(value: Int): VisitViewHolderType {
+            return when (value) {
+                0 -> {
+                    VISIT_DEFAULT
+                }
+
+                1 -> {
+                    MY_VISIT_LOG
+                }
+
+                else -> {
+                    throw IllegalArgumentException("")
+                }
+            }
+        }
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolderType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/adapter/VisitViewHolderType.kt
@@ -6,7 +6,7 @@ enum class VisitViewHolderType(val value: Int) {
     ;
 
     companion object {
-        fun of(value: Int): VisitViewHolderType {
+        fun from(value: Int): VisitViewHolderType {
             return when (value) {
                 0 -> {
                     VISIT_DEFAULT

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/model/VisitDetailUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/model/VisitDetailUiModel.kt
@@ -1,0 +1,20 @@
+package com.woowacourse.staccato.presentation.visit.model
+
+sealed class VisitDetailUiModel {
+    data class VisitDefaultUiModel(
+        val visitId: Long,
+        val placeName: String,
+        val visitImage: String,
+        val address: String,
+        val visitedAt: String,
+        val visitedCount: Long,
+    ) : VisitDetailUiModel()
+
+    data class VisitLogUiModel(
+        val visitLogId: Long = 0,
+        val memberId: Long = 0,
+        val nickName: String,
+        val memberImage: String,
+        val content: String,
+    ) : VisitDetailUiModel()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/viewmodel/VisitViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/viewmodel/VisitViewModel.kt
@@ -1,0 +1,66 @@
+package com.woowacourse.staccato.presentation.visit.viewmodel
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel
+
+class VisitViewModel : ViewModel() {
+    private val _visitDefault = MutableLiveData<VisitDetailUiModel.VisitDefaultUiModel>()
+    val visitDefault: LiveData<VisitDetailUiModel.VisitDefaultUiModel> get() = _visitDefault
+
+    private val _visitLogs = MutableLiveData<List<VisitDetailUiModel.VisitLogUiModel>>()
+    val visitLogs: LiveData<List<VisitDetailUiModel.VisitLogUiModel>> get() = _visitLogs
+
+    fun fetchVisitDetailData() {
+        fetchVisitDefault()
+        fetchVisitLogs()
+    }
+
+    private fun fetchVisitDefault() {
+        _visitDefault.value =
+            VisitDetailUiModel.VisitDefaultUiModel(
+                1,
+                "곽지해수욕장",
+                "https://postfiles.pstatic.net/MjAyNDA3MTZfMTMg/MDAxNzIxMDk5MjU5NTY0._coi0xlHtVjiwV7XjIABXv9EeRqi-kbJL3A7WeElA5og" +
+                    ".mv0BFE8-Sv3TKhzZiw38YdkhGTW3NRYoO16ZHH2d5YEg.JPEG/%EC%A0%9C%EC%A3%BC%EB%8F%84.jpg?type=w966",
+                "제주특별자치도 제주시 애월읍 곽지리",
+                "2024년 7월 15일에 처음 방문했어요!",
+                3,
+            )
+    }
+
+    private fun fetchVisitLogs() {
+        _visitLogs.value =
+            listOf(
+                VisitDetailUiModel.VisitLogUiModel(
+                    0,
+                    0,
+                    "s6m1n",
+                    "https://search.pstatic.net/common/?src=http%3A%2F%2Fimage.nmv.nav" +
+                        "er.net%2Fcafe_2023_09_19_1290%2Fd9bcfa00-56af-11ee-9ba4-a0369ffb3258_01.jpg&type=sc960_832",
+                    "오랜만에 우테코 친구들과 여행!\n바다 색깔이 너무 예뻤다.",
+                ),
+                VisitDetailUiModel.VisitLogUiModel(
+                    0,
+                    0,
+                    "haena",
+                    "https://search.pstatic.net/sunny/?src=https%3A%2F%2Fdcimg2.dcinsi" +
+                        "de.co.kr%2Fviewimage.php%3Fid%3D2fb4de21f1ed2c%26no%3D24b0d769e1d3" +
+                        "2ca73fe987fa1bd8233c0baf48e1ef0fb2b7008f21f62cd074543b96b120f51c61e" +
+                        "c086ef073c6e6f22b31f9b2a3bf236a7c5adcb183d4e6504c158ab2a2ea18145a1436&type=sc960_832",
+                    "안녕 ? 나는 해나야\n오늘은 내가 비눗방울 만드는 법을 알려줄게",
+                ),
+                VisitDetailUiModel.VisitLogUiModel(
+                    0,
+                    0,
+                    "hodu",
+                    "https://search.pstatic.net/common/?src=http%3A%2F%2Fcafefiles." +
+                        "naver.net%2FMjAyMDA1MDZfMTQw%2FMDAxNTg4NzY1ODYxODA1.vFk_nJQvHMHtT" +
+                        "IDzK7DiXYZHV-SBqiDgZzn0mxTRG0gg.sgBRmTE6nynrV5tir0KjwG_kKwytvMhVV" +
+                        "EhZ0A6CL-8g.JPEG%2FexternalFile.jpg&type=sc960_832",
+                    "좋은 사람, 좋은 시간.\n갓 두 ~!?",
+                ),
+            )
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/viewmodel/VisitViewModelFactory.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/viewmodel/VisitViewModelFactory.kt
@@ -1,0 +1,10 @@
+package com.woowacourse.staccato.presentation.visit.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+
+class VisitViewModelFactory : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return VisitViewModel() as T
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
@@ -1,23 +1,87 @@
 package com.woowacourse.staccato.presentation.visitcreation
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.FragmentManager
+import com.woowacourse.staccato.PhotoAttachFragment
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.ActivityVisitCreationBinding
 import com.woowacourse.staccato.presentation.base.BindingActivity
+import com.woowacourse.staccato.presentation.visitcreation.dialog.TravelSelectionFragment
+import com.woowacourse.staccato.presentation.visitcreation.dialog.VisitedAtSelectionFragment
 
-class VisitCreationActivity : BindingActivity<ActivityVisitCreationBinding>() {
+class VisitCreationActivity :
+    BindingActivity<ActivityVisitCreationBinding>(),
+    VisitCreationHandler {
     override val layoutResourceId = R.layout.activity_visit_creation
+    private val viewModel = VisitCreationViewModel()
+
+    private val travelSelectionFragment = TravelSelectionFragment()
+    private val visitedAtSelectionFragment = VisitedAtSelectionFragment()
+    private val photoAttachFragment = PhotoAttachFragment()
+    private val fragmentManager: FragmentManager = supportFragmentManager
 
     override fun initStartView(savedInstanceState: Bundle?) {
-        binding.btnVisitCreateDone.setOnClickListener {
-            val resultIntent = Intent()
-            setResult(Activity.RESULT_OK, resultIntent)
+        initBinding()
+        initDialogHandler()
+        initVisitCreateDoneButton()
+        initToolbar()
+        observeViewModelData()
+        viewModel.fetchVisitCreation()
+    }
+
+    private fun initBinding() {
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+        binding.visitCreationHandler = this
+    }
+
+    private fun initDialogHandler() {
+        travelSelectionFragment.setOnTravelSelected { selectedTravel ->
+            viewModel.updateSelectedTravel(selectedTravel)
+        }
+        visitedAtSelectionFragment.setOnVisitedAtSelected { selectedVisitedAt ->
+            viewModel.updateVisitedAt(selectedVisitedAt)
+        }
+    }
+
+    private fun initToolbar() {
+        binding.toolbarVisitCreation.setNavigationOnClickListener {
             finish()
         }
+    }
+
+    private fun initVisitCreateDoneButton() {
+        binding.btnVisitCreateDone.setOnClickListener {
+            val resultIntent = Intent()
+            setResult(RESULT_OK, resultIntent)
+            finish()
+        }
+    }
+
+    private fun observeViewModelData() {
+        viewModel.visitCreationData.observe(this) { visitCreationData ->
+            travelSelectionFragment.setItems(visitCreationData.travels)
+        }
+        viewModel.selectedTravel.observe(this) { selectedTravel ->
+            val dates = selectedTravel.buildLocalDatesInRange()
+            viewModel.updateVisitedAt(null)
+            visitedAtSelectionFragment.setItems(dates)
+        }
+    }
+
+    override fun onTravelSelectionClicked() {
+        travelSelectionFragment.show(fragmentManager, TravelSelectionFragment.TAG)
+    }
+
+    override fun onVisitedAtClicked() {
+        visitedAtSelectionFragment.show(fragmentManager, VisitedAtSelectionFragment.TAG)
+    }
+
+    override fun onPhotoAttachClicked() {
+        photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationHandler.kt
@@ -1,0 +1,9 @@
+package com.woowacourse.staccato.presentation.visitcreation
+
+interface VisitCreationHandler {
+    fun onTravelSelectionClicked()
+
+    fun onVisitedAtClicked()
+
+    fun onPhotoAttachClicked()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationViewModel.kt
@@ -1,0 +1,65 @@
+package com.woowacourse.staccato.presentation.visitcreation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.woowacourse.staccato.presentation.visitcreation.model.TravelUiModel
+import com.woowacourse.staccato.presentation.visitcreation.model.VisitCreationUiModel
+
+class VisitCreationViewModel : ViewModel() {
+    private val _visitCreationData = MutableLiveData<VisitCreationUiModel>()
+    val visitCreationData: LiveData<VisitCreationUiModel> get() = _visitCreationData
+
+    private val _selectedTravel = MutableLiveData<TravelUiModel>()
+    val selectedTravel: LiveData<TravelUiModel> get() = _selectedTravel
+
+    private val _selectedVisitedAt = MutableLiveData<String?>()
+    val selectedVisitedAt: LiveData<String?> get() = _selectedVisitedAt
+
+    private val dummyTravels =
+        listOf(
+            TravelUiModel(
+                travelId = 0,
+                travelTitle = "제주도",
+                startAt = "2024-03-01",
+                endAt = "2024-03-05",
+            ),
+            TravelUiModel(
+                travelId = 1,
+                travelTitle = "평택",
+                startAt = "2024-04-11",
+                endAt = "2024-04-14",
+            ),
+            TravelUiModel(
+                travelId = 2,
+                travelTitle = "강릉",
+                startAt = "2024-08-13",
+                endAt = "2024-08-16",
+            ),
+            TravelUiModel(
+                travelId = 3,
+                travelTitle = "부산",
+                startAt = "2024-11-28",
+                endAt = "2024-12-01",
+            ),
+        )
+
+    fun fetchVisitCreation() {
+        _visitCreationData.value =
+            VisitCreationUiModel(
+                pinId = 0,
+                placeName = "제주도 감귤 농장",
+                address = "제주도 남서기 서귀포시",
+                visitedImages = listOf(""),
+                travels = dummyTravels,
+            )
+    }
+
+    fun updateSelectedTravel(newSelectedTravel: TravelUiModel) {
+        _selectedTravel.value = newSelectedTravel
+    }
+
+    fun updateVisitedAt(newSelectedVisitedAt: String?) {
+        _selectedVisitedAt.value = newSelectedVisitedAt
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/TravelSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/TravelSelectionFragment.kt
@@ -1,0 +1,68 @@
+package com.woowacourse.staccato.presentation.visitcreation.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.woowacourse.staccato.databinding.FragmentTravelSelectionBinding
+import com.woowacourse.staccato.presentation.visitcreation.model.TravelUiModel
+
+class TravelSelectionFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentTravelSelectionBinding? = null
+    private val binding get() = _binding!!
+    private val items = mutableListOf<TravelUiModel>()
+
+    private lateinit var handler: TravelSelectionHandler
+
+    fun setOnTravelSelected(newHandler: TravelSelectionHandler) {
+        handler = newHandler
+    }
+
+    fun setItems(newItems: List<TravelUiModel>) {
+        items.clear()
+        items.addAll(newItems)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentTravelSelectionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        initNumberPicker()
+        initConfirmButton()
+    }
+
+    private fun initNumberPicker() {
+        binding.pickerTravelSelection.apply {
+            minValue = 0
+            maxValue = (items.size - 1).coerceAtLeast(0)
+            displayedValues = items.map { it.travelTitle }.toTypedArray()
+            wrapSelectorWheel = false
+        }
+    }
+
+    private fun initConfirmButton() {
+        binding.btnTravelSelectionConfirm.setOnClickListener {
+            handler.onConfirmClicked(items[binding.pickerTravelSelection.value])
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "TravelSelectionModalBottomSheet"
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/TravelSelectionHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/TravelSelectionHandler.kt
@@ -1,0 +1,7 @@
+package com.woowacourse.staccato.presentation.visitcreation.dialog
+
+import com.woowacourse.staccato.presentation.visitcreation.model.TravelUiModel
+
+fun interface TravelSelectionHandler {
+    fun onConfirmClicked(travelUiModel: TravelUiModel)
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/VisitedAtSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/VisitedAtSelectionFragment.kt
@@ -1,0 +1,67 @@
+package com.woowacourse.staccato.presentation.visitcreation.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.woowacourse.staccato.databinding.FragmentVisitedAtSelectionBinding
+
+class VisitedAtSelectionFragment : BottomSheetDialogFragment() {
+    private var _binding: FragmentVisitedAtSelectionBinding? = null
+    private val binding get() = _binding!!
+    private val items = mutableListOf<String>()
+
+    private lateinit var handler: VisitedAtSelectionHandler
+
+    fun setOnVisitedAtSelected(newHandler: VisitedAtSelectionHandler) {
+        handler = newHandler
+    }
+
+    fun setItems(newItems: List<String>) {
+        items.clear()
+        items.addAll(newItems)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentVisitedAtSelectionBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        binding.items = items
+        initNumberPicker()
+        initConfirmButton()
+    }
+
+    private fun initNumberPicker() {
+        binding.pickerVisitedAt.apply {
+            minValue = 0
+            maxValue = (items.size - 1).coerceAtLeast(0)
+            wrapSelectorWheel = false
+        }
+    }
+
+    private fun initConfirmButton() {
+        binding.btnVisitedAtConfirm.setOnClickListener {
+            handler.onConfirmClicked(items[binding.pickerVisitedAt.value])
+            dismiss()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG = "VisitedAtSelectionModalBottomSheet"
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/VisitedAtSelectionHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/dialog/VisitedAtSelectionHandler.kt
@@ -1,0 +1,5 @@
+package com.woowacourse.staccato.presentation.visitcreation.dialog
+
+fun interface VisitedAtSelectionHandler {
+    fun onConfirmClicked(visitedAt: String)
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/model/VisitCreationUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/model/VisitCreationUiModel.kt
@@ -1,0 +1,35 @@
+package com.woowacourse.staccato.presentation.visitcreation.model
+
+import java.time.LocalDate
+
+data class VisitCreationUiModel(
+    val pinId: Long,
+    val placeName: String,
+    val address: String,
+    val visitedImages: List<String>,
+    val travels: List<TravelUiModel>,
+)
+
+data class TravelUiModel(
+    val travelId: Long,
+    val travelTitle: String,
+    val startAt: String,
+    val endAt: String,
+) {
+    fun buildLocalDatesInRange(): List<String> {
+        val startDateNumbers = startAt.split("-").map { it.toInt() }
+        val endDateNumbers = endAt.split("-").map { it.toInt() }
+        val startDate = LocalDate.of(startDateNumbers[0], startDateNumbers[1], startDateNumbers[2])
+        val endDate = LocalDate.of(endDateNumbers[0], endDateNumbers[1], endDateNumbers[2])
+        return createDateList(startDate, endDate).map { it.toString() }
+    }
+
+    private fun createDateList(
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): List<LocalDate> {
+        return generateSequence(startDate) { it.plusDays(1) }
+            .takeWhile { !it.isAfter(endDate) }
+            .toList()
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -1,6 +1,5 @@
 package com.woowacourse.staccato.presentation.visitupdate
 
-import android.app.Activity
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -29,12 +28,6 @@ class VisitUpdateActivity : BindingActivity<ActivityVisitUpdateBinding>(), Visit
         initToolbar()
         observeViewModelData()
         viewModel.fetchVisitUpdate()
-
-        binding.btnVisitUpdateDone.setOnClickListener {
-            val resultIntent = Intent()
-            setResult(Activity.RESULT_OK, resultIntent)
-            finish()
-        }
     }
 
     private fun initBinding() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -5,19 +5,88 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
+import androidx.fragment.app.FragmentManager
+import com.woowacourse.staccato.PhotoAttachFragment
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.ActivityVisitUpdateBinding
 import com.woowacourse.staccato.presentation.base.BindingActivity
+import com.woowacourse.staccato.presentation.visitcreation.dialog.TravelSelectionFragment
+import com.woowacourse.staccato.presentation.visitcreation.dialog.VisitedAtSelectionFragment
 
-class VisitUpdateActivity : BindingActivity<ActivityVisitUpdateBinding>() {
+class VisitUpdateActivity : BindingActivity<ActivityVisitUpdateBinding>(), VisitUpdateHandler {
     override val layoutResourceId = R.layout.activity_visit_update
+    private val viewModel = VisitUpdateViewModel()
+
+    private val travelSelectionFragment = TravelSelectionFragment()
+    private val visitedAtSelectionFragment = VisitedAtSelectionFragment()
+    private val photoAttachFragment = PhotoAttachFragment()
+    private val fragmentManager: FragmentManager = supportFragmentManager
 
     override fun initStartView(savedInstanceState: Bundle?) {
+        initBinding()
+        initDialogHandler()
+        initVisitUpdateDoneButton()
+        initToolbar()
+        observeViewModelData()
+        viewModel.fetchVisitUpdate()
+
         binding.btnVisitUpdateDone.setOnClickListener {
             val resultIntent = Intent()
             setResult(Activity.RESULT_OK, resultIntent)
             finish()
         }
+    }
+
+    private fun initBinding() {
+        binding.lifecycleOwner = this
+        binding.viewModel = viewModel
+        binding.visitUpdateHandler = this
+    }
+
+    private fun initDialogHandler() {
+        travelSelectionFragment.setOnTravelSelected { selectedTravel ->
+            viewModel.updateSelectedTravel(selectedTravel)
+        }
+        visitedAtSelectionFragment.setOnVisitedAtSelected { selectedVisitedAt ->
+            viewModel.updateVisitedAt(selectedVisitedAt)
+        }
+    }
+
+    private fun initToolbar() {
+        binding.toolbarVisitUpdate.setNavigationOnClickListener {
+            finish()
+        }
+    }
+
+    private fun initVisitUpdateDoneButton() {
+        binding.btnVisitUpdateDone.setOnClickListener {
+            val resultIntent = Intent()
+            setResult(RESULT_OK, resultIntent)
+            finish()
+        }
+    }
+
+    private fun observeViewModelData() {
+        viewModel.visitUpdateData.observe(this) { visitUpdateData ->
+            travelSelectionFragment.setItems(visitUpdateData.travels)
+        }
+        viewModel.selectedTravel.observe(this) { selectedTravel ->
+            val dates = selectedTravel.buildLocalDatesInRange()
+            viewModel.updateVisitedAt(null)
+            visitedAtSelectionFragment.setItems(dates)
+        }
+    }
+
+    override fun onTravelSelectionClicked() {
+        travelSelectionFragment.show(fragmentManager, TravelSelectionFragment.TAG)
+    }
+
+    override fun onVisitedAtClicked() {
+        visitedAtSelectionFragment.show(fragmentManager, VisitedAtSelectionFragment.TAG)
+    }
+
+    override fun onPhotoAttachClicked() {
+        photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateHandler.kt
@@ -1,0 +1,9 @@
+package com.woowacourse.staccato.presentation.visitupdate
+
+interface VisitUpdateHandler {
+    fun onTravelSelectionClicked()
+
+    fun onVisitedAtClicked()
+
+    fun onPhotoAttachClicked()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateViewModel.kt
@@ -1,0 +1,65 @@
+package com.woowacourse.staccato.presentation.visitupdate
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.woowacourse.staccato.presentation.visitcreation.model.TravelUiModel
+import com.woowacourse.staccato.presentation.visitcreation.model.VisitCreationUiModel
+
+class VisitUpdateViewModel : ViewModel() {
+    private val _visitUpdateData = MutableLiveData<VisitCreationUiModel>()
+    val visitUpdateData: LiveData<VisitCreationUiModel> get() = _visitUpdateData
+
+    private val _selectedTravel = MutableLiveData<TravelUiModel>()
+    val selectedTravel: LiveData<TravelUiModel> get() = _selectedTravel
+
+    private val _selectedVisitedAt = MutableLiveData<String?>()
+    val selectedVisitedAt: LiveData<String?> get() = _selectedVisitedAt
+
+    private val dummyTravels =
+        listOf(
+            TravelUiModel(
+                travelId = 0,
+                travelTitle = "제주도",
+                startAt = "2024-03-01",
+                endAt = "2024-03-05",
+            ),
+            TravelUiModel(
+                travelId = 1,
+                travelTitle = "평택",
+                startAt = "2024-04-11",
+                endAt = "2024-04-14",
+            ),
+            TravelUiModel(
+                travelId = 2,
+                travelTitle = "강릉",
+                startAt = "2024-08-13",
+                endAt = "2024-08-16",
+            ),
+            TravelUiModel(
+                travelId = 3,
+                travelTitle = "부산",
+                startAt = "2024-11-28",
+                endAt = "2024-12-01",
+            ),
+        )
+
+    fun fetchVisitUpdate() {
+        _visitUpdateData.value =
+            VisitCreationUiModel(
+                pinId = 0,
+                placeName = "제주도 감귤 농장",
+                address = "제주도 남서기 서귀포시",
+                visitedImages = listOf(""),
+                travels = dummyTravels,
+            )
+    }
+
+    fun updateSelectedTravel(newSelectedTravel: TravelUiModel) {
+        _selectedTravel.value = newSelectedTravel
+    }
+
+    fun updateVisitedAt(newSelectedVisitedAt: String?) {
+        _selectedVisitedAt.value = newSelectedVisitedAt
+    }
+}

--- a/android/Staccato_AN/app/src/main/res/drawable/shape_place_holder_oval.xml
+++ b/android/Staccato_AN/app/src/main/res/drawable/shape_place_holder_oval.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="oval">
+    <solid android:color="@color/gray1" />
+</shape>

--- a/android/Staccato_AN/app/src/main/res/drawable/shape_place_holder_rectangle.xml
+++ b/android/Staccato_AN/app/src/main/res/drawable/shape_place_holder_rectangle.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gray1" />
+</shape>

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -5,35 +5,194 @@
 
     <data>
 
+
+        <variable
+            name="viewModel"
+            type="com.woowacourse.staccato.presentation.visitcreation.VisitCreationViewModel" />
+
+        <variable
+            name="visitCreationHandler"
+            type="com.woowacourse.staccato.presentation.visitcreation.VisitCreationHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#999999"
-        tools:context=".presentation.visitcreation.VisitCreationActivity">
+        android:background="@color/white">
 
-        <TextView
-            android:id="@+id/tv_tmp_title"
-            android:layout_width="0dp"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_visit_creation"
+            style="@style/DefaultToolbarStyle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:gravity="center"
-            android:text="방문 상세 생성 화면"
-            android:textSize="30sp"
+            android:paddingEnd="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/btn_visit_create_done"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:text="생성 완료 (방문 상세로 이동)"
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar_visit_creation">
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:context=".presentation.visitcreation.VisitCreationActivity">
+
+                <TextView
+                    android:id="@+id/tv_place_name_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="24dp"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/visit_creation_place_name"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_place_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:text="@{viewModel.visitCreationData.placeName}"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_name_title"
+                    tools:text="장소 이름 (고정)" />
+
+                <TextView
+                    android:id="@+id/tv_place_address_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/visit_creation_address"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_name" />
+
+                <TextView
+                    android:id="@+id/tv_place_address"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:text="@{viewModel.visitCreationData.address}"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_address_title"
+                    tools:text="장소 주소 (고정)" />
+
+                <TextView
+                    android:id="@+id/tv_photo_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/all_photo"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_address" />
+
+                <FrameLayout
+                    android:id="@+id/frame_photo_attach"
+                    android:layout_width="0dp"
+                    android:layout_height="200dp"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitCreationHandler.onPhotoAttachClicked()}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
+
+                    <include
+                        layout="@layout/layout_photo_attach"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center" />
+
+                </FrameLayout>
+
+
+                <TextView
+                    android:id="@+id/tv_travel_selection_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="여행 선택"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/frame_photo_attach" />
+
+                <TextView
+                    android:id="@+id/tv_travel_selection"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitCreationHandler.onTravelSelectionClicked()}"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:bindSetSelectedTravel="@{viewModel.selectedTravel}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_travel_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/visit_creation_visited_at"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_travel_selection" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitCreationHandler.onVisitedAtClicked()}"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:bindSetSelectedVisitedAt="@{viewModel.selectedVisitedAt}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
+
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_visit_create_done"
+                    style="@style/ButtonStyle.Save.Active"
+                    selectedTravel="@{viewModel.selectedTravel}"
+                    visitedAt="@{viewModel.selectedVisitedAt}"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="36dp"
+                    android:layout_marginBottom="24dp"
+                    android:text="@string/all_save"
+                    android:textAppearance="@style/Typography.Title3"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -42,7 +42,7 @@
                 tools:context=".presentation.visitcreation.VisitCreationActivity">
 
                 <TextView
-                    android:id="@+id/tv_place_name_title"
+                    android:id="@+id/tv_visit_creation_place_name_title"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="24dp"
@@ -63,9 +63,9 @@
                     android:paddingVertical="12dp"
                     android:text="@{viewModel.visitCreationData.placeName}"
                     android:textAppearance="@style/Typography.Body1"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visit_creation_place_name_title"
                     tools:text="장소 이름 (고정)" />
 
                 <TextView
@@ -75,8 +75,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/visit_creation_address"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_name" />
 
                 <TextView
@@ -89,8 +89,8 @@
                     android:paddingVertical="12dp"
                     android:text="@{viewModel.visitCreationData.address}"
                     android:textAppearance="@style/Typography.Body1"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_address_title"
                     tools:text="장소 주소 (고정)" />
 
@@ -101,8 +101,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/all_photo"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_address" />
 
                 <FrameLayout
@@ -112,8 +112,8 @@
                     android:layout_marginTop="8dp"
                     android:background="@drawable/shape_button_gray1_5dp"
                     android:onClick="@{()->visitCreationHandler.onPhotoAttachClicked()}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
 
                     <include
@@ -132,8 +132,8 @@
                     android:layout_marginTop="24dp"
                     android:text="여행 선택"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/frame_photo_attach" />
 
                 <TextView
@@ -147,8 +147,8 @@
                     android:paddingVertical="12dp"
                     android:textAppearance="@style/Typography.Body1"
                     app:bindSetSelectedTravel="@{viewModel.selectedTravel}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_travel_selection_title" />
 
                 <TextView
@@ -158,8 +158,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/visit_creation_visited_at"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_travel_selection" />
 
                 <TextView
@@ -173,8 +173,8 @@
                     android:paddingVertical="12dp"
                     android:textAppearance="@style/Typography.Body1"
                     app:bindSetSelectedVisitedAt="@{viewModel.selectedVisitedAt}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
 
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
@@ -42,7 +42,7 @@
                 tools:context=".presentation.visitcreation.VisitCreationActivity">
 
                 <TextView
-                    android:id="@+id/tv_place_name_title"
+                    android:id="@+id/tv_visit_update_place_name_title"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginHorizontal="24dp"
@@ -63,9 +63,9 @@
                     android:paddingVertical="12dp"
                     android:text="@{viewModel.visitUpdateData.placeName}"
                     android:textAppearance="@style/Typography.Body1"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visit_update_place_name_title"
                     tools:text="장소 이름 (고정)" />
 
                 <TextView
@@ -75,8 +75,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/visit_creation_address"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_name" />
 
                 <TextView
@@ -89,8 +89,8 @@
                     android:paddingVertical="12dp"
                     android:text="@{viewModel.visitUpdateData.address}"
                     android:textAppearance="@style/Typography.Body1"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_address_title"
                     tools:text="장소 주소 (고정)" />
 
@@ -101,8 +101,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/all_photo"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_place_address" />
 
                 <FrameLayout
@@ -112,8 +112,8 @@
                     android:layout_marginTop="8dp"
                     android:background="@drawable/shape_button_gray1_5dp"
                     android:onClick="@{()->visitUpdateHandler.onPhotoAttachClicked()}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
 
                     <include
@@ -132,8 +132,8 @@
                     android:layout_marginTop="24dp"
                     android:text="여행 선택"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/frame_photo_attach" />
 
                 <TextView
@@ -147,8 +147,8 @@
                     android:paddingVertical="12dp"
                     android:textAppearance="@style/Typography.Body1"
                     app:bindSetSelectedTravel="@{viewModel.selectedTravel}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_travel_selection_title" />
 
                 <TextView
@@ -158,8 +158,8 @@
                     android:layout_marginTop="24dp"
                     android:text="@string/visit_creation_visited_at"
                     android:textAppearance="@style/Typography.Title2"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_travel_selection" />
 
                 <TextView
@@ -173,8 +173,8 @@
                     android:paddingVertical="12dp"
                     android:textAppearance="@style/Typography.Body1"
                     app:bindSetSelectedVisitedAt="@{viewModel.selectedVisitedAt}"
-                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
-                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
 
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
@@ -5,35 +5,194 @@
 
     <data>
 
+
+        <variable
+            name="viewModel"
+            type="com.woowacourse.staccato.presentation.visitupdate.VisitUpdateViewModel" />
+
+        <variable
+            name="visitUpdateHandler"
+            type="com.woowacourse.staccato.presentation.visitupdate.VisitUpdateHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#999999"
-        tools:context=".presentation.visitupdate.VisitUpdateActivity">
+        android:background="@color/white">
 
-        <TextView
-            android:id="@+id/tv_tmp_title"
-            android:layout_width="0dp"
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar_visit_update"
+            style="@style/DefaultToolbarStyle"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:gravity="center"
-            android:text="방문 상세 수정 화면"
-            android:textSize="30sp"
+            android:paddingEnd="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/btn_visit_update_done"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:text="수정 완료 (방문 상세로 이동)"
+        <androidx.core.widget.NestedScrollView
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/toolbar_visit_update">
 
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                tools:context=".presentation.visitcreation.VisitCreationActivity">
+
+                <TextView
+                    android:id="@+id/tv_place_name_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="24dp"
+                    android:layout_marginTop="12dp"
+                    android:text="@string/visit_creation_place_name"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/tv_place_name"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:text="@{viewModel.visitUpdateData.placeName}"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_name_title"
+                    tools:text="장소 이름 (고정)" />
+
+                <TextView
+                    android:id="@+id/tv_place_address_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/visit_creation_address"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_name" />
+
+                <TextView
+                    android:id="@+id/tv_place_address"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:text="@{viewModel.visitUpdateData.address}"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_address_title"
+                    tools:text="장소 주소 (고정)" />
+
+                <TextView
+                    android:id="@+id/tv_photo_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/all_photo"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_place_address" />
+
+                <FrameLayout
+                    android:id="@+id/frame_photo_attach"
+                    android:layout_width="0dp"
+                    android:layout_height="200dp"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitUpdateHandler.onPhotoAttachClicked()}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
+
+                    <include
+                        layout="@layout/layout_photo_attach"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center" />
+
+                </FrameLayout>
+
+
+                <TextView
+                    android:id="@+id/tv_travel_selection_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="여행 선택"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/frame_photo_attach" />
+
+                <TextView
+                    android:id="@+id/tv_travel_selection"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitUpdateHandler.onTravelSelectionClicked()}"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:bindSetSelectedTravel="@{viewModel.selectedTravel}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_travel_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at_title"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="24dp"
+                    android:text="@string/visit_creation_visited_at"
+                    android:textAppearance="@style/Typography.Title2"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_travel_selection" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="8dp"
+                    android:background="@drawable/shape_button_gray1_5dp"
+                    android:onClick="@{()->visitUpdateHandler.onVisitedAtClicked()}"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp"
+                    android:textAppearance="@style/Typography.Body1"
+                    app:bindSetSelectedVisitedAt="@{viewModel.selectedVisitedAt}"
+                    app:layout_constraintEnd_toEndOf="@id/tv_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
+
+
+                <androidx.appcompat.widget.AppCompatButton
+                    android:id="@+id/btn_visit_update_done"
+                    style="@style/ButtonStyle.Save.Active"
+                    selectedTravel="@{viewModel.selectedTravel}"
+                    visitedAt="@{viewModel.selectedVisitedAt}"
+                    android:layout_marginHorizontal="16dp"
+                    android:layout_marginTop="36dp"
+                    android:layout_marginBottom="24dp"
+                    android:text="@string/all_save"
+                    android:textAppearance="@style/Typography.Title3"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </androidx.core.widget.NestedScrollView>
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_travel_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_travel_selection.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/shape_bottom_sheet_20dp"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_travel_selection_title"
+            style="@style/SubTitleStyle"
+            android:text="@string/visit_creation_travel_selection"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <NumberPicker
+            android:id="@+id/picker_travel_selection"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="36dp"
+            android:descendantFocusability="blocksDescendants"
+            android:selectionDividerHeight="0.5dp"
+            android:theme="@style/ThemeOverlay.NumberPicker"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_travel_selection_title" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_travel_selection_confirm"
+            style="@style/ButtonStyle.Confirm"
+            android:text="@string/all_confirm"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/picker_travel_selection" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_visit.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_visit.xml
@@ -5,33 +5,37 @@
 
     <data>
 
+        <variable
+            name="toolbarHandler"
+            type="com.woowacourse.staccato.presentation.ToolbarHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/constraint_visit"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="#AAAAAA"
-        tools:context=".presentation.visit.VisitFragment">
+        android:background="@color/white"
+        tools:context=".presentation.ui.staccato.StaccatoActivity">
 
-        <TextView
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="100dp"
-            android:gravity="center"
-            android:text="방문 상세 화면"
-            android:textSize="30sp"
+        <include
+            android:id="@+id/include_visit_toolbar"
+            layout="@layout/toolbar_detail"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toTopOf="parent"
+            app:toolbarHandler="@{toolbarHandler}"
+            />
 
-        <Button
-            android:id="@+id/btn_visit_update"
-            android:layout_width="wrap_content"
-            android:layout_height="50dp"
-            android:text="내용 수정하기(방문 수정 화면으로)"
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_visit_detail"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            android:clipToPadding="false"
+            android:paddingBottom="15dp"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/include_visit_toolbar" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+
+        <variable
+            name="items"
+            type="java.util.List&lt;String&gt;" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/shape_bottom_sheet_20dp"
+        android:padding="24dp">
+
+        <TextView
+            android:id="@+id/tv_visited_at_title"
+            style="@style/SubTitleStyle"
+            android:text="@string/all_visited_date"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_visited_at_is_empty"
+            style="@style/Typography.Body2"
+            bindSetVisitedAtIsEmptyVisibility="@{items}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="50dp"
+            android:gravity="center"
+            android:text="@string/visit_creation_travel_unselected_travel"
+            app:layout_constraintBottom_toTopOf="@id/btn_visited_at_confirm"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
+
+        <NumberPicker
+            android:id="@+id/picker_visited_at"
+            bindSetVisitedAtNumberPickerItems="@{items}"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="36dp"
+            android:descendantFocusability="blocksDescendants"
+            android:selectionDividerHeight="0.5dp"
+            android:theme="@style/ThemeOverlay.NumberPicker"
+            app:layout_constraintBottom_toTopOf="@id/btn_visited_at_confirm"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_visited_at_confirm"
+            style="@style/ButtonStyle.Save.Active"
+            bindSetVisitedAtConfirmButtonActive="@{items}"
+            android:text="@string/all_confirm"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/android/Staccato_AN/app/src/main/res/layout/item_my_visit_log.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_my_visit_log.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="visitLog"
+            type="com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel.VisitLogUiModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+
+        <ImageView
+            android:id="@+id/iv_profile"
+            coilCircleImageUrl="@{visitLog.memberImage}"
+            coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_margin="10dp"
+            android:layout_marginEnd="19dp"
+            android:elevation="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{visitLog.nickName}"
+            android:textAppearance="@style/Typography.Body4"
+            app:layout_constraintEnd_toEndOf="@id/tv_chat"
+            app:layout_constraintTop_toTopOf="@id/iv_profile"
+            tools:text="username" />
+
+        <TextView
+            android:id="@+id/tv_chat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="25dp"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="10dp"
+            android:background="@drawable/shape_my_visit_log_12dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="12dp"
+            android:text="@{visitLog.content}"
+            android:textAppearance="@style/Typography.Body3"
+            android:textColor="@color/gray5"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/iv_profile"
+            app:layout_constraintHorizontal_bias="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_name"
+            tools:text="어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어엄청 긴 임시 방문 로그" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/Staccato_AN/app/src/main/res/layout/item_others_visit_log.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_others_visit_log.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="visitLog"
+            type="com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel.VisitLogUiModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+
+        <ImageView
+            android:id="@+id/iv_profile"
+            coilCircleImageUrl="@{visitLog.memberImage}"
+            coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_margin="10dp"
+            android:layout_marginStart="19dp"
+            android:elevation="8dp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_name"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@{visitLog.nickName}"
+            android:textAppearance="@style/Typography.Body4"
+            app:layout_constraintStart_toStartOf="@id/tv_chat"
+            app:layout_constraintTop_toTopOf="@id/iv_profile"
+            tools:text="username" />
+
+        <TextView
+            android:id="@+id/tv_chat"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="10dp"
+            android:layout_marginTop="6dp"
+            android:layout_marginEnd="25dp"
+            android:background="@drawable/shape_others_visit_log_12dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="12dp"
+            android:text="@{visitLog.content}"
+            android:textAppearance="@style/Typography.Body3"
+            android:textColor="@color/gray5"
+            app:layout_constrainedWidth="true"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
+            app:layout_constraintStart_toEndOf="@id/iv_profile"
+            app:layout_constraintTop_toBottomOf="@id/tv_name"
+            tools:text="어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어어엄청 긴 임시 방문 로그" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/Staccato_AN/app/src/main/res/layout/item_visit_default.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_visit_default.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="visitDefault"
+            type="com.woowacourse.staccato.presentation.visit.model.VisitDetailUiModel.VisitDefaultUiModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp">
+
+        <ImageView
+            android:id="@+id/iv_thumbnail"
+            coilImageUrl="@{visitDefault.visitImage}"
+            coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:adjustViewBounds="true"
+            android:scaleType="centerCrop"
+            app:layout_constraintDimensionRatio="H,1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tv_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="18dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginEnd="18dp"
+            android:text="@{visitDefault.placeName}"
+            android:textAppearance="@style/Typography.Title1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/iv_thumbnail"
+            tools:text="장소 제목" />
+
+        <TextView
+            android:id="@+id/tv_detail"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@{visitDefault.address}"
+            android:textAppearance="@style/Typography.Body4"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_title"
+            tools:text="상세 주소" />
+
+        <TextView
+            android:id="@+id/tv_visited_at"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="20dp"
+            android:text="@{visitDefault.visitedAt}"
+            android:textAppearance="@style/Typography.Body2"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/tv_detail"
+            tools:text="2024년 7월 15일에 처음 방문했어요!" />
+
+        <com.google.android.material.divider.MaterialDivider
+            android:id="@+id/divider"
+            android:layout_width="0dp"
+            android:layout_height="0.5dp"
+            android:layout_marginTop="17dp"
+            app:dividerColor="@color/gray2"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
+
+        <TextView
+            android:id="@+id/tv_visit_log"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/visit_logs"
+            android:textAppearance="@style/Typography.Title2"
+            app:layout_constraintStart_toStartOf="@id/tv_title"
+            app:layout_constraintTop_toBottomOf="@id/divider" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/android/Staccato_AN/app/src/main/res/layout/toolbar_detail.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/toolbar_detail.xml
@@ -3,6 +3,9 @@
 
     <data>
 
+        <variable
+            name="toolbarHandler"
+            type="com.woowacourse.staccato.presentation.ToolbarHandler" />
     </data>
 
     <com.google.android.material.appbar.MaterialToolbar
@@ -15,11 +18,13 @@
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_detail_delete"
             style="@style/ToolbarMenuStyle"
+            android:onClick="@{()->toolbarHandler.onDeleteClicked()}"
             android:text="@string/all_delete" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/btn_detail_update"
             style="@style/ToolbarMenuStyle"
+            android:onClick="@{()->toolbarHandler.onUpdateClicked()}"
             android:text="@string/all_update" />
 
     </com.google.android.material.appbar.MaterialToolbar>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -40,6 +40,11 @@
     // activity_visit_creation / activity_visit_update
     <string name="visit_creation_place_name">장소 이름</string>
     <string name="visit_creation_address">주소</string>
+    <string name="visit_creation_visited_at">방문 날짜</string>
+    <string name="visit_creation_visited_at_hint">방문 날짜를 선택해주세요</string>
+    <string name="visit_creation_travel_selection">여행 선택</string>
+    <string name="visit_creation_travel_selection_hint">여행을 선택해주세요</string>
+    <string name="visit_creation_travel_unselected_travel">여행에 해당하는 방문 날짜가 없습니다.\n여행을 먼저 선택해주세요!</string>
 
     // fragment_photo_attach
     <string name="photo_attach_title">사진을 등록해주세요</string>

--- a/android/Staccato_AN/app/src/main/res/values/themes.xml
+++ b/android/Staccato_AN/app/src/main/res/values/themes.xml
@@ -1,4 +1,4 @@
-<resources xmlns:tools="http://schemas.android.com/tools">
+<resources>
     <!-- Base application theme. -->
     <style name="Base.Theme.Staccato_AN" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Status bar color. -->
@@ -8,4 +8,8 @@
     </style>
 
     <style name="Theme.Staccato_AN" parent="Base.Theme.Staccato_AN" />
+
+    <style name="ThemeOverlay.NumberPicker" parent="Theme.Staccato_AN">
+        <item name="colorControlNormal">@color/gray2</item>
+    </style>
 </resources>

--- a/android/Staccato_AN/app/src/main/res/values/typography.xml
+++ b/android/Staccato_AN/app/src/main/res/values/typography.xml
@@ -26,26 +26,26 @@
 
     <style name="Typography.Body1" parent="Typography">
         <item name="fontFamily">@font/pretendard_regular</item>
-        <item name="android:textSize">16sp</item>
+        <item name="android:textSize">17sp</item>
         <item name="lineHeight">20dp</item>
         <item name="android:letterSpacing">-0.02</item>
     </style>
 
     <style name="Typography.Body2" parent="Typography">
         <item name="fontFamily">@font/pretendard_medium</item>
-        <item name="android:textSize">14sp</item>
+        <item name="android:textSize">15sp</item>
         <item name="lineHeight">20dp</item>
     </style>
 
     <style name="Typography.Body3" parent="Typography">
         <item name="fontFamily">@font/pretendard_regular</item>
-        <item name="android:textSize">13sp</item>
+        <item name="android:textSize">14sp</item>
         <item name="lineHeight">18dp</item>
     </style>
 
     <style name="Typography.Body4" parent="Typography">
         <item name="fontFamily">@font/pretendard_regular</item>
-        <item name="android:textSize">12sp</item>
+        <item name="android:textSize">13sp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## ⭐️ Issue Number
- #52

## 🚩 Summary


https://github.com/user-attachments/assets/889ffc95-d067-4112-9ba6-0d10e3eb76a1


- [x] 방문 기록 상세 `Fragment` 구현
- [x] 방문 기록 상세 생성 `Activity` 구현
- [x] 방문 기록 상세 수정 `Activity` 구현
- [x] 여행 선택 `BottomSheetDialogFragment` 구현
- [x] 날짜 선택 `BottomSheetDialogFragment` 구현

## 🛠️ Technical Concerns

BottomSheetDialogFragment 내부에 NumberPicker를 넣었습니다.
날짜 선택을 위한 `VisitedAtSelectionFragment : BottomSheetDialogFragment` 클래스의 경우
현재 선택된 여행이 없다면 NumberPicker를 GONE 처리한 뒤 여행을 먼저 선택해달라는 텍스트를 띄우도록 구현했습니다.

## 🙂 To Reviwer

## 📋 To Do

BottomSheetDialogFragment가 show 될 때 가장 최근에 선택한 값을 기본으로 보여주도록 수정할 예정입니다.