### PR TITLE
feat: VisitLog, VisitImage 양방향 관계 설정 및 논리적 삭제 제거 #87

### DIFF
--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -126,7 +126,7 @@ public class TravelService {
     }
 
     private String getFirstVisitImageUrl(Visit visit) {
-        return visitImageRepository.findFirstByVisitIdAndIsDeletedIsFalse(visit.getId())
+        return visitImageRepository.findFirstByVisitId(visit.getId())
                 .map(VisitImage::getImageUrl)
                 .orElse(null);
     }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -19,7 +19,6 @@ import com.staccato.travel.service.dto.response.TravelResponses;
 import com.staccato.visit.domain.Visit;
 import com.staccato.visit.domain.VisitImage;
 import com.staccato.visit.repository.VisitImageRepository;
-import com.staccato.visit.repository.VisitLogRepository;
 import com.staccato.visit.repository.VisitRepository;
 import com.staccato.visit.service.dto.response.VisitResponse;
 
@@ -32,7 +31,6 @@ public class TravelService {
     private final TravelRepository travelRepository;
     private final TravelMemberRepository travelMemberRepository;
     private final VisitRepository visitRepository;
-    private final VisitLogRepository visitLogRepository;
     private final MemberRepository memberRepository;
     private final VisitImageRepository visitImageRepository;
 
@@ -91,8 +89,7 @@ public class TravelService {
     @Transactional
     public void deleteTravel(Long travelId) {
         validateVisitExistsByTravelId(travelId);
-        visitRepository.findAllByTravelIdAndIsDeletedIsFalse(travelId)
-                .forEach(visit -> deleteVisits(visit.getId()));
+        visitRepository.deleteAllByTravelIdAndIsDeletedIsFalse(travelId);
         travelRepository.deleteById(travelId);
     }
 
@@ -100,12 +97,6 @@ public class TravelService {
         if (visitRepository.existsByTravelId(travelId)) {
             throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
         }
-    }
-
-    private void deleteVisits(long visitId) {
-        visitLogRepository.deleteByVisitId(visitId);
-        visitImageRepository.deleteByVisitId(visitId);
-        visitRepository.deleteById(visitId);
     }
 
     public TravelDetailResponse readTravelById(long travelId) {

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -1,7 +1,10 @@
 package com.staccato.visit.domain;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -10,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 
 import org.hibernate.annotations.SQLDelete;
 
@@ -40,10 +44,24 @@ public class Visit extends BaseEntity {
     @JoinColumn(name = "travel_id", nullable = false)
     private Travel travel;
 
+    @OneToMany(mappedBy = "visit", orphanRemoval = true, cascade = CascadeType.REMOVE)
+    private List<VisitImage> visitImages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "visit", orphanRemoval = true, cascade = CascadeType.REMOVE)
+    private List<VisitLog> visitLogs = new ArrayList<>();
+
     @Builder
     public Visit(@NonNull LocalDate visitedAt, @NonNull Pin pin, @NonNull Travel travel) {
         this.visitedAt = visitedAt;
         this.pin = pin;
         this.travel = travel;
+    }
+
+    public void addVisitImage(VisitImage visitImage) {
+        visitImages.add(visitImage);
+    }
+
+    public void addVisitLog(VisitLog visitLog) {
+        visitLogs.add(visitLog);
     }
 }

--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -32,5 +32,6 @@ public class VisitImage {
     public VisitImage(@Nonnull String imageUrl, @Nonnull Visit visit) {
         this.imageUrl = imageUrl;
         this.visit = visit;
+        visit.addVisitImage(this);
     }
 }

--- a/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitImage.java
@@ -10,10 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import org.hibernate.annotations.SQLDelete;
-
-import com.staccato.config.domain.BaseEntity;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -22,8 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE visit_image SET is_deleted = true WHERE id = ?")
-public class VisitImage extends BaseEntity {
+public class VisitImage {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -41,5 +41,6 @@ public class VisitLog {
         this.content = content;
         this.visit = visit;
         this.member = member;
+        visit.addVisitLog(this);
     }
 }

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -10,9 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 
-import org.hibernate.annotations.SQLDelete;
-
-import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
 import lombok.AccessLevel;
@@ -26,8 +23,7 @@ import lombok.NonNull;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE visit_log SET is_deleted = true WHERE id = ?")
-public class VisitLog extends BaseEntity {
+public class VisitLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitImageRepository.java
@@ -5,17 +5,15 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.staccato.visit.domain.VisitImage;
 
 public interface VisitImageRepository extends JpaRepository<VisitImage, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE VisitImage vi SET vi.isDeleted = true WHERE vi.visit.id = :visitId")
     void deleteByVisitId(@Param("visitId") Long visitId);
 
-    Optional<VisitImage> findFirstByVisitIdAndIsDeletedIsFalse(long visitId);
+    Optional<VisitImage> findFirstByVisitId(long visitId);
 
-    List<VisitImage> findAllByVisitIdAndIsDeletedIsFalse(long visitId);
+    List<VisitImage> findAllByVisitId(long visitId);
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitLogRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitLogRepository.java
@@ -4,15 +4,13 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.staccato.visit.domain.VisitLog;
 
 public interface VisitLogRepository extends JpaRepository<VisitLog, Long> {
     @Modifying(clearAutomatically = true)
-    @Query("UPDATE VisitLog vl SET vl.isDeleted = true WHERE vl.visit.id = :visitId")
     void deleteByVisitId(@Param("visitId") Long visitId);
 
-    List<VisitLog> findAllByVisitIdAndIsDeletedIsFalse(long visitId);
+    List<VisitLog> findAllByVisitId(long visitId);
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -16,4 +16,6 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
 
     @Query("SELECT CASE WHEN COUNT(v) > 0 THEN true ELSE false END FROM Visit v WHERE v.travel.id = :travelId")
     boolean existsByTravelId(@Param("travelId") Long travelId);
+
+    List<Visit> deleteAllByTravelIdAndIsDeletedIsFalse(@Param("travelId") long travelId);
 }

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -68,9 +68,9 @@ public class VisitService {
                 pin.getId(), visit.getVisitedAt());
         return new VisitDetailResponse(
                 visit,
-                visitImageRepository.findAllByVisitIdAndIsDeletedIsFalse(visitId),
+                visitImageRepository.findAllByVisitId(visitId),
                 visitedCountBefore + 1,
-                visitLogRepository.findAllByVisitIdAndIsDeletedIsFalse(visitId)
+                visitLogRepository.findAllByVisitId(visitId)
         );
     }
 

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -13,7 +13,6 @@ import com.staccato.travel.repository.TravelRepository;
 import com.staccato.visit.domain.Visit;
 import com.staccato.visit.domain.VisitImage;
 import com.staccato.visit.repository.VisitImageRepository;
-import com.staccato.visit.repository.VisitLogRepository;
 import com.staccato.visit.repository.VisitRepository;
 import com.staccato.visit.service.dto.request.VisitRequest;
 import com.staccato.visit.service.dto.response.VisitDetailResponse;
@@ -28,7 +27,6 @@ public class VisitService {
     private final PinRepository pinRepository;
     private final TravelRepository travelRepository;
     private final VisitImageRepository visitImageRepository;
-    private final VisitLogRepository visitLogRepository;
 
     @Transactional
     public long createVisit(VisitRequest visitRequest) {
@@ -64,13 +62,12 @@ public class VisitService {
     public VisitDetailResponse readVisitById(long visitId) {
         Visit visit = getVisitById(visitId);
         Pin pin = visit.getPin();
-        long visitedCountBefore = visitRepository.countByPinIdAndIsDeletedIsFalseAndVisitedAtBefore(
-                pin.getId(), visit.getVisitedAt());
+        long visitedCountBefore = visitRepository.countByPinIdAndIsDeletedIsFalseAndVisitedAtBefore(pin.getId(), visit.getVisitedAt());
         return new VisitDetailResponse(
                 visit,
-                visitImageRepository.findAllByVisitId(visitId),
+                visit.getVisitImages(),
                 visitedCountBefore + 1,
-                visitLogRepository.findAllByVisitId(visitId)
+                visit.getVisitLogs()
         );
     }
 
@@ -81,8 +78,6 @@ public class VisitService {
 
     @Transactional
     public void deleteVisitById(Long visitId) {
-        visitLogRepository.deleteByVisitId(visitId);
-        visitImageRepository.deleteByVisitId(visitId);
         visitRepository.deleteById(visitId);
     }
 }

--- a/backend/src/test/java/com/staccato/visit/repository/VisitImageRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitImageRepositoryTest.java
@@ -51,8 +51,8 @@ class VisitImageRepositoryTest {
 
         // then
         assertAll(
-                () -> assertThat(visitImageRepository.findById(visitImage1.getId()).get().getIsDeleted()).isTrue(),
-                () -> assertThat(visitImageRepository.findById(visitImage2.getId()).get().getIsDeleted()).isTrue()
+                () -> assertThat(visitImageRepository.findById(visitImage1.getId())).isEmpty(),
+                () -> assertThat(visitImageRepository.findById(visitImage2.getId())).isEmpty()
         );
     }
 }

--- a/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/visit/repository/VisitLogRepositoryTest.java
@@ -50,8 +50,8 @@ class VisitLogRepositoryTest {
 
         // then
         assertAll(
-                () -> assertThat(visitLogRepository.findById(visitLog1.getId()).get().getIsDeleted()).isTrue(),
-                () -> assertThat(visitLogRepository.findById(visitLog2.getId()).get().getIsDeleted()).isTrue()
+                () -> assertThat(visitLogRepository.findById(visitLog1.getId())).isEmpty(),
+                () -> assertThat(visitLogRepository.findById(visitLog2.getId())).isEmpty()
         );
     }
 }

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -60,7 +60,7 @@ class VisitServiceTest extends ServiceSliceTest {
 
         // then
         assertThat(visitRepository.findById(visit.getId()).get().getIsDeleted()).isTrue();
-        assertThat(visitLogRepository.findById(visitLog.getId()).get().getIsDeleted()).isTrue();
+        assertThat(visitLogRepository.findById(visitLog.getId())).isEmpty();
     }
 
     @DisplayName("특정 방문 상세를 조회하면, 이번이 몇 번째 방문인지까지 알 수 있다.")
@@ -69,7 +69,8 @@ class VisitServiceTest extends ServiceSliceTest {
         // given
         Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
         Pin pin = pinRepository.save(Pin.builder().place("Sample Place").address("Sample Address").member(member).build());
-        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build());
+        Travel travel = travelRepository.save(Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1))
+                .build());
         Visit prevVisit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now().minusDays(2)).pin(pin).travel(travel).build());
         Visit visit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now().minusDays(1)).pin(pin).travel(travel).build());
         Visit nextVisit = visitRepository.save(Visit.builder().visitedAt(LocalDate.now()).pin(pin).travel(travel).build());


### PR DESCRIPTION
## ⭐️ Issue Number
- #87 

## 🚩 Summary

- 구체적인 구현 내용은 Issue를 참고해주세요
- 양방향 관계 설정으로 cascade를 사용하여 여행 & 방문기록 삭제 로직이 변경되었습니다.

## 🛠️ Technical Concerns

## 🙂 To Reviwer
- 양방향 관계 설정 및 cascade에 대한 학습이 부족한 상태입니다. 놓친 부분이나 오류가 없는지 테스트로 확인했으나 꼼꼼한 리뷰 부탁드립니다!

## 📋 To Do
