### PR TITLE
fix: 여행 상세 수정 날짜 필터링 오류와 썸네일 저장 오류 수정 #90

### DIFF
--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -76,15 +76,15 @@ public class Travel extends BaseEntity {
 
     private void validateDuration(Travel updatedTravel, List<Visit> visits) {
         visits.stream()
-                .filter(visit -> !updatedTravel.withinDuration(visit.getVisitedAt()))
+                .filter(visit -> updatedTravel.isWithoutDuration(visit.getVisitedAt()))
                 .findAny()
                 .ifPresent(visit -> {
                     throw new StaccatoException("변경하려는 여행 기간이 이미 존재하는 방문 기록을 포함하지 않습니다. 여행 기간을 다시 설정해주세요.");
                 });
     }
 
-    public boolean withinDuration(LocalDate date) {
-        return startAt.isBefore(date) && endAt.isAfter(date);
+    public boolean isWithoutDuration(LocalDate date) {
+        return startAt.isAfter(date) || endAt.isBefore(date);
     }
 
     public List<Member> getMates() {

--- a/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
@@ -24,6 +24,7 @@ public record TravelRequest(
         LocalDate endAt) {
     public Travel toTravel() {
         return Travel.builder()
+                .thumbnailUrl(travelThumbnail)
                 .title(travelTitle)
                 .description(description)
                 .startAt(startAt)

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -30,7 +30,7 @@ class TravelTest {
 
     @DisplayName("특정 날짜가 여행 상세 날짜에 속하는지 알 수 있다.")
     @Test
-    void withinDuration() {
+    void withoutDuration() {
         // given
         Travel travel = Travel.builder()
                 .title("2023 여름 여행")
@@ -39,7 +39,7 @@ class TravelTest {
                 .build();
 
         // when & then
-        assertThat(travel.withinDuration(LocalDate.of(2023, 7, 11))).isFalse();
+        assertThat(travel.isWithoutDuration(LocalDate.of(2023, 7, 11))).isTrue();
     }
 
     @DisplayName("여행 상세를 수정 시 기존 방문 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")


### PR DESCRIPTION
## ⭐️ Issue Number
- #90 
## 🚩 Summary
- 여행 생성 시 썸네일을 저장하지 않는 오류 수정
- 여행 상세 수정 날짜 필터링 오류 수정

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
