### PR TITLE
fix: Travel 삭제시 발생하는 오류 수정 #103

### DIFF
--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -42,7 +43,7 @@ public class Travel extends BaseEntity {
     private LocalDate startAt;
     @Column(nullable = false)
     private LocalDate endAt;
-    @OneToMany(mappedBy = "travel")
+    @OneToMany(mappedBy = "travel", orphanRemoval = true, cascade = CascadeType.REMOVE)
     private List<TravelMember> travelMembers = new ArrayList<>();
 
     @Builder

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -94,7 +94,7 @@ public class TravelService {
     }
 
     private void validateVisitExistsByTravelId(Long travelId) {
-        if (visitRepository.existsByTravelId(travelId)) {
+        if (visitRepository.existsByTravelIdAndIsDeleteIsFalse(travelId)) {
             throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
         }
     }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -94,7 +94,7 @@ public class TravelService {
     }
 
     private void validateVisitExistsByTravelId(Long travelId) {
-        if (visitRepository.existsByTravelIdAndIsDeleteIsFalse(travelId)) {
+        if (visitRepository.existsByTravelIdAndIsDeletedIsFalse(travelId)) {
             throw new StaccatoException("해당 여행 상세에 방문 기록이 남아있어 삭제할 수 없습니다.");
         }
     }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -4,8 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.staccato.visit.domain.Visit;
 
@@ -14,8 +12,7 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
 
     long countByPinIdAndIsDeletedIsFalseAndVisitedAtBefore(Long pinId, LocalDate visitedAt);
 
-    @Query("SELECT CASE WHEN COUNT(v) > 0 THEN true ELSE false END FROM Visit v WHERE v.travel.id = :travelId AND v.isDeleted = false")
-    boolean existsByTravelIdAndIsDeleteIsFalse(@Param("travelId") Long travelId);
+    boolean existsByTravelIdAndIsDeletedIsFalse(Long travelId);
 
     void deleteAllByTravelIdAndIsDeletedIsFalse(long travelId);
 }

--- a/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
+++ b/backend/src/main/java/com/staccato/visit/repository/VisitRepository.java
@@ -14,8 +14,8 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
 
     long countByPinIdAndIsDeletedIsFalseAndVisitedAtBefore(Long pinId, LocalDate visitedAt);
 
-    @Query("SELECT CASE WHEN COUNT(v) > 0 THEN true ELSE false END FROM Visit v WHERE v.travel.id = :travelId")
-    boolean existsByTravelId(@Param("travelId") Long travelId);
+    @Query("SELECT CASE WHEN COUNT(v) > 0 THEN true ELSE false END FROM Visit v WHERE v.travel.id = :travelId AND v.isDeleted = false")
+    boolean existsByTravelIdAndIsDeleteIsFalse(@Param("travelId") Long travelId);
 
     void deleteAllByTravelIdAndIsDeletedIsFalse(long travelId);
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #103 
## 🚩 Summary

- Travel 삭제시 연관된 TravelMember에도 논리적 삭제가 전파되도록 수정
-  방문 기록이 남아있을 때 Travel을 삭제 불가능하게 만드는 validation에서, 방문 기록의 isDeleted flag를 확인하도록 수정

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
