### PR TITLE
feat: 로그인 API 구현 #123

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     defaults:
       run:

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     defaults:
       run:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -33,6 +33,9 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
 	testImplementation 'io.rest-assured:rest-assured:5.3.1'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -20,6 +20,7 @@ public class AuthController implements AuthControllerDocs {
 
     @PostMapping("/login")
     public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
-        return ResponseEntity.ok(authService.login(loginRequest));
+        LoginResponse loginResponse = authService.login(loginRequest);
+        return ResponseEntity.ok(loginResponse);
     }
 }

--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-public class AuthController {
+public class AuthController implements AuthControllerDocs {
     private final AuthService authService;
 
     @PostMapping("/login")

--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.staccato.auth.controller;
 
+import jakarta.validation.Valid;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,7 +19,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest) {
         return ResponseEntity.ok(authService.login(loginRequest));
     }
 }

--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -8,8 +8,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.staccato.auth.service.AuthService;
-import com.staccato.auth.service.request.LoginRequest;
-import com.staccato.auth.service.response.LoginResponse;
+import com.staccato.auth.service.dto.request.LoginRequest;
+import com.staccato.auth.service.dto.response.LoginResponse;
 
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -1,0 +1,23 @@
+package com.staccato.auth.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.staccato.auth.service.AuthService;
+import com.staccato.auth.service.request.LoginRequest;
+import com.staccato.auth.service.response.LoginResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        return ResponseEntity.ok(authService.login(loginRequest));
+    }
+}

--- a/backend/src/main/java/com/staccato/auth/controller/AuthControllerDocs.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthControllerDocs.java
@@ -1,0 +1,36 @@
+package com.staccato.auth.controller;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+
+import com.staccato.auth.service.dto.request.LoginRequest;
+import com.staccato.auth.service.dto.response.LoginResponse;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Authorization", description = "Authorization API")
+public interface AuthControllerDocs {
+    @Operation(summary = "등록 및 로그인", description = "애플리케이션을 최초 실행할 때 한 번만 닉네임 입력을 받고, 식별 코드를 발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "등록 및 로그인 성공", responseCode = "200", content = @Content(schema = @Schema(implementation = LoginResponse.class))),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                                        
+                    (1) 이미 존재하는 닉네임일 때
+                                        
+                    (2) 닉네임의 형식이 잘못되었을 때 (한글, 영어, 마침표(.), 언더바(_)만 사용 가능)
+                                        
+                    (3) 닉네임이 20자를 초과하였을 때
+                                        
+                    (4) 닉네임을 입력하지 않았을 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<LoginResponse> login(@Valid LoginRequest loginRequest);
+}

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -2,8 +2,8 @@ package com.staccato.auth.service;
 
 import org.springframework.stereotype.Service;
 
-import com.staccato.auth.service.request.LoginRequest;
-import com.staccato.auth.service.response.LoginResponse;
+import com.staccato.auth.service.dto.request.LoginRequest;
+import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.config.auth.TokenProvider;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -31,7 +31,7 @@ public class AuthService {
     }
 
     private void validateNickname(Nickname nickname) {
-        if(memberRepository.existsByNickname(nickname)){
+        if (memberRepository.existsByNickname(nickname)) {
             throw new StaccatoException("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
         }
     }

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.staccato.auth.service.response.LoginResponse;
 import com.staccato.config.auth.TokenProvider;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
+import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,7 @@ public class AuthService {
         return memberRepository.save(member);
     }
 
-    private void validateNickname(String nickname) {
+    private void validateNickname(Nickname nickname) {
         if(memberRepository.existsByNickname(nickname)){
             throw new StaccatoException("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
         }

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.staccato.auth.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
@@ -15,10 +16,12 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AuthService {
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
 
+    @Transactional
     public LoginResponse login(LoginRequest loginRequest) {
         Member member = createMember(loginRequest);
         String token = tokenProvider.create(member);

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -6,6 +6,7 @@ import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.config.auth.TokenProvider;
 import com.staccato.exception.StaccatoException;
+import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
@@ -34,5 +35,10 @@ public class AuthService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new StaccatoException("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
         }
+    }
+
+    public Member extractFromToken(String token) {
+        return memberRepository.findById(tokenProvider.extractMemberId(token))
+                .orElseThrow(UnauthorizedException::new);
     }
 }

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -1,0 +1,37 @@
+package com.staccato.auth.service;
+
+import org.springframework.stereotype.Service;
+
+import com.staccato.auth.service.request.LoginRequest;
+import com.staccato.auth.service.response.LoginResponse;
+import com.staccato.config.auth.TokenProvider;
+import com.staccato.exception.StaccatoException;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    public LoginResponse login(LoginRequest loginRequest) {
+        Member member = createMember(loginRequest);
+        String token = tokenProvider.create(member);
+        return new LoginResponse(token);
+    }
+
+    private Member createMember(LoginRequest loginRequest) {
+        Member member = loginRequest.toMember();
+        validateNickname(member.getNickname());
+        return memberRepository.save(member);
+    }
+
+    private void validateNickname(String nickname) {
+        if(memberRepository.existsByNickname(nickname)){
+            throw new StaccatoException("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
+        }
+    }
+}

--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.staccato.auth.service.request;
+package com.staccato.auth.service.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -6,7 +6,7 @@ import com.staccato.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "여행 상세를 생성/수정하기 위한 요청 형식입니다.")
+@Schema(description = "회원을 등록하기 위한 요청 형식입니다.")
 public record LoginRequest(
         @Schema(example = "hi_staccato")
         @NotNull(message = "닉네임을 입력해주세요.")

--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -4,8 +4,14 @@ import jakarta.validation.constraints.NotNull;
 
 import com.staccato.member.domain.Member;
 
-public record LoginRequest(@NotNull(message = "닉네임을 입력해주세요.")
-                           String nickname) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "여행 상세를 생성/수정하기 위한 요청 형식입니다.")
+public record LoginRequest(
+        @Schema(example = "hi_staccato")
+        @NotNull(message = "닉네임을 입력해주세요.")
+        String nickname
+) {
     public Member toMember() {
         return Member.builder()
                 .nickname(nickname)

--- a/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.staccato.auth.service.dto.response;
+
+public record LoginResponse(String token) {
+}

--- a/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
@@ -1,4 +1,10 @@
 package com.staccato.auth.service.dto.response;
 
-public record LoginResponse(String token) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 등록 시 발급되는 토큰에 대한 응답 형식입니다.")
+public record LoginResponse(
+        @Schema(example = "{tokenString}")
+        String token
+) {
 }

--- a/backend/src/main/java/com/staccato/auth/service/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/request/LoginRequest.java
@@ -1,8 +1,11 @@
 package com.staccato.auth.service.request;
 
+import jakarta.validation.constraints.NotNull;
+
 import com.staccato.member.domain.Member;
 
-public record LoginRequest(String nickname) {
+public record LoginRequest(@NotNull(message = "닉네임을 입력해주세요.")
+                           String nickname) {
     public Member toMember() {
         return Member.builder()
                 .nickname(nickname)

--- a/backend/src/main/java/com/staccato/auth/service/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/request/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.staccato.auth.service.request;
+
+import com.staccato.member.domain.Member;
+
+public record LoginRequest(String nickname) {
+    public Member toMember() {
+        return Member.builder()
+                .nickname(nickname)
+                .build();
+    }
+}

--- a/backend/src/main/java/com/staccato/auth/service/response/LoginResponse.java
+++ b/backend/src/main/java/com/staccato/auth/service/response/LoginResponse.java
@@ -1,0 +1,4 @@
+package com.staccato.auth.service.response;
+
+public record LoginResponse(String token) {
+}

--- a/backend/src/main/java/com/staccato/auth/service/response/LoginResponse.java
+++ b/backend/src/main/java/com/staccato/auth/service/response/LoginResponse.java
@@ -1,4 +1,0 @@
-package com.staccato.auth.service.response;
-
-public record LoginResponse(String token) {
-}

--- a/backend/src/main/java/com/staccato/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/staccato/config/WebMvcConfig.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);

--- a/backend/src/main/java/com/staccato/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/staccato/config/WebMvcConfig.java
@@ -6,12 +6,16 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
-import com.staccato.config.auth.MemberIdArgumentResolver;
+import com.staccato.config.auth.LoginMemberArgumentResolver;
+
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new MemberIdArgumentResolver());
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/backend/src/main/java/com/staccato/config/auth/LoginMember.java
+++ b/backend/src/main/java/com/staccato/config/auth/LoginMember.java
@@ -7,5 +7,5 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface MemberId {
+public @interface LoginMember {
 }

--- a/backend/src/main/java/com/staccato/config/auth/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/com/staccato/config/auth/LoginMemberArgumentResolver.java
@@ -10,8 +10,15 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+import com.staccato.auth.service.AuthService;
+
+import lombok.RequiredArgsConstructor;
+
 @Component
-public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
+@RequiredArgsConstructor
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private final AuthService authService;
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginMember.class);
@@ -20,6 +27,7 @@ public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
-        return Long.parseLong(request.getHeader(HttpHeaders.AUTHORIZATION));
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
+        return authService.extractFromToken(token);
     }
 }

--- a/backend/src/main/java/com/staccato/config/auth/LoginMemberArgumentResolver.java
+++ b/backend/src/main/java/com/staccato/config/auth/LoginMemberArgumentResolver.java
@@ -14,7 +14,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class MemberIdArgumentResolver implements HandlerMethodArgumentResolver {
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(MemberId.class);
+        return parameter.hasParameterAnnotation(LoginMember.class);
     }
 
     @Override

--- a/backend/src/main/java/com/staccato/config/auth/TokenProperties.java
+++ b/backend/src/main/java/com/staccato/config/auth/TokenProperties.java
@@ -4,5 +4,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "security.jwt.token")
 public record TokenProperties(String secretKey) {
-
 }

--- a/backend/src/main/java/com/staccato/config/auth/TokenProperties.java
+++ b/backend/src/main/java/com/staccato/config/auth/TokenProperties.java
@@ -1,0 +1,8 @@
+package com.staccato.config.auth;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "security.jwt.token")
+public record TokenProperties(String secretKey) {
+
+}

--- a/backend/src/main/java/com/staccato/config/auth/TokenProvider.java
+++ b/backend/src/main/java/com/staccato/config/auth/TokenProvider.java
@@ -3,8 +3,11 @@ package com.staccato.config.auth;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.stereotype.Component;
 
+import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import lombok.RequiredArgsConstructor;
@@ -22,5 +25,21 @@ public class TokenProvider {
                 .claim("createdAt", member.getCreatedAt().toString())
                 .signWith(SignatureAlgorithm.HS256, tokenProperties.secretKey().getBytes())
                 .compact();
+    }
+
+    public long extractMemberId(String token) {
+        Claims claims = getPayload(token);
+        return claims.get("id", Long.class);
+    }
+
+    public Claims getPayload(String token) {
+        try {
+            return Jwts.parser()
+                    .setSigningKey(tokenProperties.secretKey().getBytes())
+                    .parseClaimsJws(token)
+                    .getBody();
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new UnauthorizedException();
+        }
     }
 }

--- a/backend/src/main/java/com/staccato/config/auth/TokenProvider.java
+++ b/backend/src/main/java/com/staccato/config/auth/TokenProvider.java
@@ -1,0 +1,26 @@
+package com.staccato.config.auth;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.staccato.member.domain.Member;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@EnableConfigurationProperties(TokenProperties.class)
+public class TokenProvider {
+    private final TokenProperties tokenProperties;
+
+    public String create(Member member) {
+        return Jwts.builder()
+                .claim("id", member.getId())
+                .claim("nickname", member.getNickname())
+                .claim("createdAt", member.getCreatedAt().toString())
+                .signWith(SignatureAlgorithm.HS256, tokenProperties.secretKey().getBytes())
+                .compact();
+    }
+}

--- a/backend/src/main/java/com/staccato/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/staccato/exception/ForbiddenException.java
@@ -1,0 +1,20 @@
+package com.staccato.exception;
+
+public class ForbiddenException extends RuntimeException {
+
+    public ForbiddenException() {
+        super("요청하신 작업을 처리할 권한이 없습니다.");
+    }
+
+    public ForbiddenException(final String message) {
+        super(message);
+    }
+
+    public ForbiddenException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public ForbiddenException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/backend/src/main/java/com/staccato/exception/ForbiddenException.java
+++ b/backend/src/main/java/com/staccato/exception/ForbiddenException.java
@@ -1,7 +1,6 @@
 package com.staccato.exception;
 
 public class ForbiddenException extends RuntimeException {
-
     public ForbiddenException() {
         super("요청하신 작업을 처리할 권한이 없습니다.");
     }

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -68,7 +68,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UnauthorizedException.class)
     @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    public ResponseEntity<ExceptionResponse> handleUnauthorizedErrorException(UnauthorizedException e) {
+    public ResponseEntity<ExceptionResponse> handleUnauthorizedException(UnauthorizedException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
@@ -77,7 +77,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(ForbiddenException.class)
     @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
-    public ResponseEntity<ExceptionResponse> handleForbiddenErrorException(ForbiddenException e) {
+    public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                 .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -74,6 +74,15 @@ public class GlobalExceptionHandler {
                 .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
     }
 
+
+    @ExceptionHandler(ForbiddenException.class)
+    @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    public ResponseEntity<ExceptionResponse> handleForbiddenErrorException(ForbiddenException e) {
+        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleInternalServerErrorException(RuntimeException e) {

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -66,6 +66,14 @@ public class GlobalExceptionHandler {
                 .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage()));
     }
 
+    @ExceptionHandler(UnauthorizedException.class)
+    @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    public ResponseEntity<ExceptionResponse> handleUnauthorizedErrorException(UnauthorizedException e) {
+        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
+    }
+
     @ExceptionHandler(RuntimeException.class)
     @ApiResponse(responseCode = "500", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleInternalServerErrorException(RuntimeException e) {

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -67,12 +67,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    @ApiResponse(description = """
-            <발생 가능한 케이스>
-            
-            (1) 사용자 인증이 되지 않았을 때
-            """,
-            responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    @ApiResponse(description = "사용자 인증 실패", responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleUnauthorizedException(UnauthorizedException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -81,12 +76,7 @@ public class GlobalExceptionHandler {
 
 
     @ExceptionHandler(ForbiddenException.class)
-    @ApiResponse(description = """
-            <발생 가능한 케이스>
-            
-            (1) 해당 사용자가 권한을 가지고 있지 않은 작업을 시도했을 때
-            """,
-            responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    @ApiResponse(description = "사용자가 권한을 가지고 있지 않은 작업을 시도 시 발생", responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -67,7 +67,12 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    @ApiResponse(responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    @ApiResponse(description = """
+            <발생 가능한 케이스>
+            
+            (1) 사용자 인증이 되지 않았을 때
+            """,
+            responseCode = "401", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleUnauthorizedException(UnauthorizedException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
@@ -76,7 +81,12 @@ public class GlobalExceptionHandler {
 
 
     @ExceptionHandler(ForbiddenException.class)
-    @ApiResponse(responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
+    @ApiResponse(description = """
+            <발생 가능한 케이스>
+            
+            (1) 해당 사용자가 권한을 가지고 있지 않은 작업을 시도했을 때
+            """,
+            responseCode = "403", content = @Content(schema = @Schema(implementation = ExceptionResponse.class)))
     public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/backend/src/main/java/com/staccato/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/staccato/exception/UnauthorizedException.java
@@ -1,0 +1,20 @@
+package com.staccato.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException() {
+        super("인증되지 않은 사용자입니다.");
+    }
+
+    public UnauthorizedException(final String message) {
+        super(message);
+    }
+
+    public UnauthorizedException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public UnauthorizedException(final Throwable cause) {
+        super(cause);
+    }
+}

--- a/backend/src/main/java/com/staccato/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/staccato/exception/UnauthorizedException.java
@@ -1,7 +1,6 @@
 package com.staccato.exception;
 
 public class UnauthorizedException extends RuntimeException {
-
     public UnauthorizedException() {
         super("인증되지 않은 사용자입니다.");
     }

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -36,8 +36,4 @@ public class Member extends BaseEntity {
         this.nickname = new Nickname(nickname);
         this.imageUrl = imageUrl;
     }
-
-    public String getNickname() {
-        return nickname.getNickname();
-    }
 }

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.staccato.member.domain;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -25,13 +26,18 @@ public class Member extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(nullable = false, unique = true)
-    private String nickname;
+    @Embedded
+    private Nickname nickname;
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
 
     @Builder
     public Member(@NonNull String nickname, String imageUrl) {
-        this.nickname = nickname;
+        this.nickname = new Nickname(nickname);
         this.imageUrl = imageUrl;
+    }
+
+    public String getNickname() {
+        return nickname.getNickname();
     }
 }

--- a/backend/src/main/java/com/staccato/member/domain/Nickname.java
+++ b/backend/src/main/java/com/staccato/member/domain/Nickname.java
@@ -1,0 +1,46 @@
+package com.staccato.member.domain;
+
+import java.util.regex.Pattern;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import com.staccato.exception.StaccatoException;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Embeddable
+@EqualsAndHashCode
+public class Nickname {
+    public static final Pattern NICKNAME_REGEX = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z._]+$");
+    private static final int MAX_LENGTH = 20;
+
+    @Column(nullable = false, length = 20)
+    private String nickname;
+
+    public Nickname(String nickname){
+        validate(nickname);
+        this.nickname = nickname;
+    }
+
+    private void validate(String nickname) {
+        validateLength(nickname);
+        validateRegex(nickname);
+    }
+
+    private void validateLength(String nickname) {
+        if(nickname.isEmpty() || nickname.length()>MAX_LENGTH){
+            throw new StaccatoException("20자 이내의 닉네임으로 설정해주세요.");
+        }
+    }
+
+    private static void validateRegex(String nickname) {
+        if (!NICKNAME_REGEX.matcher(nickname).matches()) {
+            throw new StaccatoException("올바르지 않은 닉네임 형식입니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/staccato/member/domain/Nickname.java
+++ b/backend/src/main/java/com/staccato/member/domain/Nickname.java
@@ -19,7 +19,7 @@ public class Nickname {
     private static final Pattern NICKNAME_REGEX = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z._]+$");
     private static final int MAX_LENGTH = 20;
 
-    @Column(nullable = false, length = 20)
+    @Column(nullable = false, length = MAX_LENGTH)
     private String nickname;
 
     public Nickname(String nickname) {
@@ -34,7 +34,7 @@ public class Nickname {
 
     private void validateLength(String nickname) {
         if (nickname.isEmpty() || nickname.length() > MAX_LENGTH) {
-            throw new StaccatoException("20자 이내의 닉네임으로 설정해주세요.");
+            throw new StaccatoException(MAX_LENGTH + "자 이내의 닉네임으로 설정해주세요.");
         }
     }
 

--- a/backend/src/main/java/com/staccato/member/domain/Nickname.java
+++ b/backend/src/main/java/com/staccato/member/domain/Nickname.java
@@ -22,7 +22,7 @@ public class Nickname {
     @Column(nullable = false, length = 20)
     private String nickname;
 
-    public Nickname(String nickname){
+    public Nickname(String nickname) {
         validate(nickname);
         this.nickname = nickname;
     }
@@ -33,7 +33,7 @@ public class Nickname {
     }
 
     private void validateLength(String nickname) {
-        if(nickname.isEmpty() || nickname.length()>MAX_LENGTH){
+        if (nickname.isEmpty() || nickname.length() > MAX_LENGTH) {
             throw new StaccatoException("20자 이내의 닉네임으로 설정해주세요.");
         }
     }

--- a/backend/src/main/java/com/staccato/member/domain/Nickname.java
+++ b/backend/src/main/java/com/staccato/member/domain/Nickname.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 @EqualsAndHashCode
 public class Nickname {
-    public static final Pattern NICKNAME_REGEX = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z._]+$");
+    private static final Pattern NICKNAME_REGEX = Pattern.compile("^[ㄱ-ㅎㅏ-ㅣ가-힣a-zA-Z._]+$");
     private static final int MAX_LENGTH = 20;
 
     @Column(nullable = false, length = 20)

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -5,9 +5,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.staccato.member.domain.Member;
+import com.staccato.member.domain.Nickname;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIdAndIsDeletedIsFalse(long memberId);
 
-    boolean existsByNickname(String nickname);
+    boolean existsByNickname(Nickname nickname);
 }

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ import com.staccato.member.domain.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByIdAndIsDeletedIsFalse(long memberId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
@@ -9,6 +9,6 @@ public record MemberResponse(
         @JsonInclude(JsonInclude.Include.NON_NULL) String memberImage
 ) {
     public MemberResponse(Member member) {
-        this(member.getId(), member.getNickname(), member.getImageUrl());
+        this(member.getId(), member.getNickname().getNickname(), member.getImageUrl());
     }
 }

--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.staccato.config.auth.MemberId;
+import com.staccato.config.auth.LoginMember;
 import com.staccato.travel.controller.docs.TravelControllerDocs;
 import com.staccato.travel.service.TravelService;
 import com.staccato.travel.service.dto.request.TravelRequest;
@@ -34,14 +34,14 @@ public class TravelController implements TravelControllerDocs {
     private final TravelService travelService;
 
     @PostMapping
-    public ResponseEntity<Void> createTravel(@Valid @RequestBody TravelRequest travelRequest, @MemberId Long memberId) {
+    public ResponseEntity<Void> createTravel(@Valid @RequestBody TravelRequest travelRequest, @LoginMember Long memberId) {
         long travelId = travelService.createTravel(travelRequest, memberId);
         return ResponseEntity.created(URI.create("/travels/" + travelId)).build();
     }
 
     @GetMapping
     public ResponseEntity<TravelResponses> readAllTravels(
-            @MemberId Long memberId,
+            @LoginMember Long memberId,
             @RequestParam(value = "year", required = false) Integer year
     ) {
         return ResponseEntity.ok(travelService.readAllTravels(memberId, year));
@@ -49,7 +49,7 @@ public class TravelController implements TravelControllerDocs {
 
     @GetMapping("/{travelId}")
     public ResponseEntity<TravelDetailResponse> readTravel(
-            @MemberId Long memberId,
+            @LoginMember Long memberId,
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId) {
         return ResponseEntity.ok(travelService.readTravelById(travelId));
     }
@@ -58,7 +58,7 @@ public class TravelController implements TravelControllerDocs {
     public ResponseEntity<Void> updateTravel(
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
             @Valid @RequestBody TravelRequest travelRequest,
-            @MemberId Long memberId) {
+            @LoginMember Long memberId) {
         travelService.updateTravel(travelRequest, travelId);
         return ResponseEntity.ok().build();
     }
@@ -66,7 +66,7 @@ public class TravelController implements TravelControllerDocs {
     @DeleteMapping("/{travelId}")
     public ResponseEntity<Void> deleteTravel(
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
-            @MemberId Long memberId) {
+            @LoginMember Long memberId) {
         travelService.deleteTravel(travelId);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/staccato/travel/controller/TravelController.java
+++ b/backend/src/main/java/com/staccato/travel/controller/TravelController.java
@@ -18,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.staccato.config.auth.LoginMember;
+import com.staccato.member.domain.Member;
 import com.staccato.travel.controller.docs.TravelControllerDocs;
 import com.staccato.travel.service.TravelService;
 import com.staccato.travel.service.dto.request.TravelRequest;
@@ -34,22 +35,22 @@ public class TravelController implements TravelControllerDocs {
     private final TravelService travelService;
 
     @PostMapping
-    public ResponseEntity<Void> createTravel(@Valid @RequestBody TravelRequest travelRequest, @LoginMember Long memberId) {
-        long travelId = travelService.createTravel(travelRequest, memberId);
+    public ResponseEntity<Void> createTravel(@Valid @RequestBody TravelRequest travelRequest, @LoginMember Member member) {
+        long travelId = travelService.createTravel(travelRequest, member);
         return ResponseEntity.created(URI.create("/travels/" + travelId)).build();
     }
 
     @GetMapping
     public ResponseEntity<TravelResponses> readAllTravels(
-            @LoginMember Long memberId,
+            @LoginMember Member member,
             @RequestParam(value = "year", required = false) Integer year
     ) {
-        return ResponseEntity.ok(travelService.readAllTravels(memberId, year));
+        return ResponseEntity.ok(travelService.readAllTravels(member, year));
     }
 
     @GetMapping("/{travelId}")
     public ResponseEntity<TravelDetailResponse> readTravel(
-            @LoginMember Long memberId,
+            @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId) {
         return ResponseEntity.ok(travelService.readTravelById(travelId));
     }
@@ -58,7 +59,7 @@ public class TravelController implements TravelControllerDocs {
     public ResponseEntity<Void> updateTravel(
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
             @Valid @RequestBody TravelRequest travelRequest,
-            @LoginMember Long memberId) {
+            @LoginMember Member member) {
         travelService.updateTravel(travelRequest, travelId);
         return ResponseEntity.ok().build();
     }
@@ -66,7 +67,7 @@ public class TravelController implements TravelControllerDocs {
     @DeleteMapping("/{travelId}")
     public ResponseEntity<Void> deleteTravel(
             @PathVariable @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
-            @LoginMember Long memberId) {
+            @LoginMember Member member) {
         travelService.deleteTravel(travelId);
         return ResponseEntity.ok().build();
     }

--- a/backend/src/main/java/com/staccato/travel/controller/docs/TravelControllerDocs.java
+++ b/backend/src/main/java/com/staccato/travel/controller/docs/TravelControllerDocs.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
 
+import com.staccato.member.domain.Member;
 import com.staccato.travel.service.dto.request.TravelRequest;
 import com.staccato.travel.service.dto.response.TravelDetailResponse;
 import com.staccato.travel.service.dto.response.TravelResponses;
@@ -17,12 +18,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Travel", description = "Travel API")
 public interface TravelControllerDocs {
-    ResponseEntity<Void> createTravel(@Valid TravelRequest travelRequest, Long memberId);
+    ResponseEntity<Void> createTravel(@Valid TravelRequest travelRequest, Member member);
 
-    ResponseEntity<TravelResponses> readAllTravels(Long memberId, Integer year);
+    ResponseEntity<TravelResponses> readAllTravels(Member member, Integer year);
 
     ResponseEntity<TravelDetailResponse> readTravel(
-            Long memberId,
+            Member member,
             @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId);
 
     @Operation(summary = "여행 상세 수정", description = "여행 상세 정보(썸네일, 제목, 내용, 기간)를 수정합니다.")
@@ -52,9 +53,9 @@ public interface TravelControllerDocs {
     ResponseEntity<Void> updateTravel(
             @Parameter(description = "여행 상세 ID") @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
             @Valid TravelRequest travelRequest,
-            @Parameter(hidden = true) Long memberId);
+            @Parameter(hidden = true) Member member);
 
     ResponseEntity<Void> deleteTravel(
             @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.") Long travelId,
-            Long memberId);
+            Member member);
 }

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -35,14 +35,13 @@ public class TravelService {
     private final VisitImageRepository visitImageRepository;
 
     @Transactional
-    public long createTravel(TravelRequest travelRequest, Long memberId) {
+    public long createTravel(TravelRequest travelRequest, Member member) {
         Travel travel = travelRepository.save(travelRequest.toTravel());
-        saveTravelMember(memberId, travel);
+        saveTravelMember(member, travel);
         return travel.getId();
     }
 
-    private void saveTravelMember(Long memberId, Travel travel) {
-        Member member = getMemberById(memberId);
+    private void saveTravelMember(Member member, Travel travel) {
         TravelMember mate = TravelMember.builder()
                 .travel(travel)
                 .member(member)
@@ -50,24 +49,19 @@ public class TravelService {
         travelMemberRepository.save(mate);
     }
 
-    private Member getMemberById(long memberId) {
-        return memberRepository.findByIdAndIsDeletedIsFalse(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid Operation"));
-    }
-
-    public TravelResponses readAllTravels(long memberId, Integer year) {
+    public TravelResponses readAllTravels(Member member, Integer year) {
         return Optional.ofNullable(year)
-                .map(y -> readAllByYear(memberId, y))
-                .orElseGet(() -> readAll(memberId));
+                .map(y -> readAllByYear(member, y))
+                .orElseGet(() -> readAll(member));
     }
 
-    private TravelResponses readAll(long memberId) {
-        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdOrderByTravelStartAtDesc(memberId);
+    private TravelResponses readAllByYear(Member member, Integer year) {
+        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdAndStartAtYearDesc(member.getId(), year);
         return getTravelResponses(travelMembers);
     }
 
-    private TravelResponses readAllByYear(long memberId, Integer year) {
-        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdAndStartAtYearDesc(memberId, year);
+    private TravelResponses readAll(Member member) {
+        List<TravelMember> travelMembers = travelMemberRepository.findAllByMemberIdOrderByTravelStartAtDesc(member.getId());
         return getTravelResponses(travelMembers);
     }
 

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitLogResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitLogResponse.java
@@ -16,7 +16,7 @@ public record VisitLogResponse(
         this(
                 visitLog.getId(),
                 visitLog.getMember().getId(),
-                visitLog.getMember().getNickname(),
+                visitLog.getMember().getNickname().getNickname(),
                 visitLog.getMember().getImageUrl(),
                 visitLog.getContent()
         );

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -31,6 +31,10 @@ spring:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+security:
+  jwt:
+    token:
+      secret-key: ${SECRET_KEY}
 
 ---
 
@@ -59,3 +63,7 @@ spring:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+security:
+  jwt:
+    token:
+      secret-key: ${SECRET_KEY}

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -17,6 +18,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;
 import com.staccato.auth.service.request.LoginRequest;
 import com.staccato.auth.service.response.LoginResponse;
+import com.staccato.exception.ExceptionResponse;
 
 @WebMvcTest(AuthController.class)
 class AuthControllerTest {
@@ -43,5 +45,20 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(loginRequest)))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(loginResponse)));
+    }
+
+    @DisplayName("닉네임을 입력하지 않으면 400을 반환한다.")
+    @Test
+    void cannotLoginIfBadRequest() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest(null);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "닉네임을 입력해주세요.");
+
+        // when & then
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
     }
 }

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -16,8 +16,8 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;
-import com.staccato.auth.service.request.LoginRequest;
-import com.staccato.auth.service.response.LoginResponse;
+import com.staccato.auth.service.dto.request.LoginRequest;
+import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.exception.ExceptionResponse;
 
 @WebMvcTest(AuthController.class)

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -1,0 +1,47 @@
+package com.staccato.auth.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.staccato.auth.service.AuthService;
+import com.staccato.auth.service.request.LoginRequest;
+import com.staccato.auth.service.response.LoginResponse;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private AuthService authService;
+
+    @DisplayName("유효한 로그인 요청이 들어오면 성공 응답을 한다.")
+    @Test
+    void login() throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("staccato");
+        LoginResponse loginResponse = new LoginResponse("staccatotoken");
+
+        // when
+        when(authService.login(loginRequest)).thenReturn(loginResponse);
+
+        // then
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(content().json(objectMapper.writeValueAsString(loginResponse)));
+    }
+}

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.staccato.ServiceSliceTest;
-import com.staccato.auth.service.request.LoginRequest;
+import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -3,7 +3,6 @@ package com.staccato.auth.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +19,6 @@ class AuthServiceTest extends ServiceSliceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    @Disabled
     @DisplayName("입력받은 닉네임으로 멤버를 저장하고, 토큰을 생성한다.")
     @Test
     void login() {
@@ -35,7 +33,6 @@ class AuthServiceTest extends ServiceSliceTest {
         assertThat(memberRepository.findAll()).hasSize(1);
     }
 
-    @Disabled
     @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 예외가 발생한다.")
     @Test
     void cannotLogin() {

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -1,0 +1,52 @@
+package com.staccato.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.staccato.ServiceSliceTest;
+import com.staccato.auth.service.request.LoginRequest;
+import com.staccato.exception.StaccatoException;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+
+class AuthServiceTest extends ServiceSliceTest {
+    @Autowired
+    private AuthService authService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Disabled
+    @DisplayName("입력받은 닉네임으로 멤버를 저장하고, 토큰을 생성한다.")
+    @Test
+    void login() {
+        // given
+        String nickname = "staccato";
+        LoginRequest loginRequest = new LoginRequest(nickname);
+
+        // when
+        authService.login(loginRequest);
+
+        // then
+        assertThat(memberRepository.findAll()).hasSize(1);
+    }
+
+    @Disabled
+    @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 예외가 발생한다.")
+    @Test
+    void cannotLogin() {
+        // given
+        String nickname = "staccato";
+        memberRepository.save(Member.builder().nickname(nickname).build());
+        LoginRequest loginRequest = new LoginRequest(nickname);
+
+        // when
+        assertThatThrownBy(() -> authService.login(loginRequest))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
+    }
+}

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -2,6 +2,7 @@ package com.staccato.auth.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -9,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.staccato.ServiceSliceTest;
 import com.staccato.auth.service.dto.request.LoginRequest;
+import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
@@ -27,10 +29,13 @@ class AuthServiceTest extends ServiceSliceTest {
         LoginRequest loginRequest = new LoginRequest(nickname);
 
         // when
-        authService.login(loginRequest);
+        LoginResponse loginResponse = authService.login(loginRequest);
 
         // then
-        assertThat(memberRepository.findAll()).hasSize(1);
+        assertAll(
+                () -> assertThat(memberRepository.findAll()).hasSize(1),
+                () -> assertThat(loginResponse.token()).isNotNull()
+        );
     }
 
     @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 예외가 발생한다.")

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -35,13 +35,13 @@ class AuthServiceTest extends ServiceSliceTest {
 
     @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 예외가 발생한다.")
     @Test
-    void cannotLogin() {
+    void cannotLoginByDuplicated() {
         // given
         String nickname = "staccato";
         memberRepository.save(Member.builder().nickname(nickname).build());
         LoginRequest loginRequest = new LoginRequest(nickname);
 
-        // when
+        // when & then
         assertThatThrownBy(() -> authService.login(loginRequest))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("이미 존재하는 닉네임입니다. 다시 설정해주세요.");

--- a/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
+++ b/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import com.staccato.exception.StaccatoException;
 
 class NicknameTest {
-    @DisplayName("유효한닉네임을 생성한다.")
+    @DisplayName("유효한 닉네임을 생성한다.")
     @Test
     void CreateNickname() {
         assertThatNoException().isThrownBy(() -> new Nickname("가ㄱㅏㅣㅎ.AZaz_"));

--- a/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
+++ b/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
@@ -1,0 +1,36 @@
+package com.staccato.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.staccato.exception.StaccatoException;
+
+class NicknameTest {
+    @DisplayName("유효한닉네임을 생성한다.")
+    @Test
+    void CreateNickname() {
+        assertThatNoException().isThrownBy(() -> new Nickname("가ㄱㅏㅣㅎ.AZaz_"));
+    }
+
+    @DisplayName("닉네임의 길이가 잘못되었을 경우 예외를 발생시킨다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 21})
+    void cannotCreateNicknameByInvalidLength(int length) {
+        assertThatThrownBy(() -> new Nickname("가".repeat(length)))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("20자 이내의 닉네임으로 설정해주세요.");
+    }
+
+    @DisplayName("닉네임의 형식이 잘못되었을 경우 예외를 발생시킨다.")
+    @Test
+    void cannotCreateNicknameByInvalidFormat() {
+        assertThatThrownBy(() -> new Nickname("//"))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("올바르지 않은 닉네임 형식입니다.");
+    }
+}

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -19,6 +19,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 
 import com.staccato.IntegrationTest;
+import com.staccato.auth.service.AuthService;
+import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
 import com.staccato.travel.service.dto.request.TravelRequest;
@@ -27,10 +29,10 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 class TravelIntegrationTest extends IntegrationTest {
-    private static final String USER_AUTHORIZATION = "1";
-
     @Autowired
-    private MemberRepository memberRepository;
+    private AuthService authService;
+
+    private String memberToken;
 
     static Stream<TravelRequest> travelRequestProvider() {
         return Stream.of(
@@ -71,7 +73,8 @@ class TravelIntegrationTest extends IntegrationTest {
 
     @BeforeEach
     void init() {
-        memberRepository.save(Member.builder().nickname("staccato").build());
+        LoginRequest loginRequest = new LoginRequest("staccato");
+        memberToken = authService.login(loginRequest).token();
     }
 
     @DisplayName("사용자가 여행 상세 정보를 입력하면, 새로운 여행 상세를 생성한다.")
@@ -80,7 +83,7 @@ class TravelIntegrationTest extends IntegrationTest {
     void createTravel(TravelRequest travelRequest) {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .body(travelRequest)
                 .when().log().all()
                 .post("/travels")
@@ -95,7 +98,7 @@ class TravelIntegrationTest extends IntegrationTest {
     void failCreateTravel(TravelRequest travelRequest, String expectedMessage) {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .body(travelRequest)
                 .when().log().all()
                 .post("/travels")
@@ -116,7 +119,7 @@ class TravelIntegrationTest extends IntegrationTest {
         // when & then
         RestAssured.given().pathParam("travelId", travelId).log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .body(travelRequest)
                 .when().log().all()
                 .put("/travels/{travelId}")
@@ -136,7 +139,7 @@ class TravelIntegrationTest extends IntegrationTest {
         // when & then
         RestAssured.given().pathParam("travelId", travelId).log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .body(invalidTravelRequest)
                 .when().log().all()
                 .put("/travels/{travelId}")
@@ -156,7 +159,7 @@ class TravelIntegrationTest extends IntegrationTest {
         // when & then
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .pathParam("travelId", 0)
                 .body(travelRequest)
                 .when().log().all()
@@ -175,7 +178,7 @@ class TravelIntegrationTest extends IntegrationTest {
                 createTravel(2024),
                 DynamicTest.dynamicTest("사용자가 타임라인을 조회하면 2개의 여행 목록이 최신순으로 조회된다.", () ->
                         RestAssured.given().log().all()
-                                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                                .header(HttpHeaders.AUTHORIZATION, memberToken)
                                 .when().log().all()
                                 .get("/travels")
                                 .then().log().all()
@@ -192,7 +195,7 @@ class TravelIntegrationTest extends IntegrationTest {
                 createTravel(2024),
                 DynamicTest.dynamicTest("사용자가 타임라인에서 2023년도를 선택하면 1개의 여행 목록이 조회된다.", () ->
                         RestAssured.given().log().all()
-                                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                                .header(HttpHeaders.AUTHORIZATION, memberToken)
                                 .param("year", 2023)
                                 .when().log().all()
                                 .get("/travels")
@@ -209,7 +212,7 @@ class TravelIntegrationTest extends IntegrationTest {
                 createTravel(2023),
                 DynamicTest.dynamicTest("사용자가 타임라인에서 특정 여행 상세를 선택하여 조회한다.", () ->
                         RestAssured.given().log().all()
-                                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                                .header(HttpHeaders.AUTHORIZATION, memberToken)
                                 .pathParam("travelId", 1)
                                 .when().log().all()
                                 .get("/travels/{travelId}")
@@ -223,7 +226,7 @@ class TravelIntegrationTest extends IntegrationTest {
     void failFindTravelById() {
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .pathParam("travelId", 0)
                 .when().log().all()
                 .get("/travels/{travelId}")
@@ -237,7 +240,7 @@ class TravelIntegrationTest extends IntegrationTest {
         return DynamicTest.dynamicTest("사용자가 새로운 여행 상세를 추가한다.", () ->
                 RestAssured.given().log().all()
                         .contentType(ContentType.JSON)
-                        .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                        .header(HttpHeaders.AUTHORIZATION, memberToken)
                         .body(createTravelRequest(year))
                         .when().log().all()
                         .post("/travels")
@@ -265,7 +268,7 @@ class TravelIntegrationTest extends IntegrationTest {
 
         // when & then
         RestAssured.given().pathParam("travelId", travelId).log().all()
-                .header(HttpHeaders.AUTHORIZATION, USER_AUTHORIZATION)
+                .header(HttpHeaders.AUTHORIZATION, memberToken)
                 .contentType(ContentType.JSON)
                 .when().delete("/travels/{travelId}")
                 .then().log().all()

--- a/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelIntegrationTest.java
@@ -21,8 +21,6 @@ import org.springframework.http.HttpStatus;
 import com.staccato.IntegrationTest;
 import com.staccato.auth.service.AuthService;
 import com.staccato.auth.service.dto.request.LoginRequest;
-import com.staccato.member.domain.Member;
-import com.staccato.member.repository.MemberRepository;
 import com.staccato.travel.service.dto.request.TravelRequest;
 
 import io.restassured.RestAssured;

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -57,7 +57,7 @@ class TravelServiceTest extends ServiceSliceTest {
         Member member = saveMember();
 
         // when
-        long travelId = travelService.createTravel(travelRequest, member.getId());
+        long travelId = travelService.createTravel(travelRequest, member);
         TravelMember travelMember = travelMemberRepository.findAllByMemberIdOrderByTravelStartAtDesc(member.getId()).get(0);
 
         // then
@@ -73,11 +73,11 @@ class TravelServiceTest extends ServiceSliceTest {
     void readAllTravels(Integer year, int expectedSize) {
         // given
         Member member = saveMember();
-        travelService.createTravel(createTravelRequest(2023), member.getId());
-        travelService.createTravel(createTravelRequest(2024), member.getId());
+        travelService.createTravel(createTravelRequest(2023), member);
+        travelService.createTravel(createTravelRequest(2024), member);
 
         // when
-        TravelResponses travelResponses = travelService.readAllTravels(member.getId(), year);
+        TravelResponses travelResponses = travelService.readAllTravels(member, year);
 
         // then
         assertThat(travelResponses.travels()).hasSize(expectedSize);
@@ -89,10 +89,10 @@ class TravelServiceTest extends ServiceSliceTest {
         // given
         Member member = saveMember();
 
-        long targetId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        long targetId = travelService.createTravel(createTravelRequest(2023), member);
         Visit visit = saveVisit(LocalDate.of(2023, 7, 1), targetId);
 
-        long otherId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        long otherId = travelService.createTravel(createTravelRequest(2023), member);
         saveVisit(LocalDate.of(2023, 7, 1), otherId);
 
         // when
@@ -113,7 +113,7 @@ class TravelServiceTest extends ServiceSliceTest {
         // given
         Member member = saveMember();
 
-        long visitId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        long visitId = travelService.createTravel(createTravelRequest(2023), member);
         Visit visit = saveVisit(LocalDate.of(2023, 7, 1), visitId);
         Visit nextVisit = saveVisit(LocalDate.of(2023, 7, 5), visitId);
 
@@ -146,7 +146,7 @@ class TravelServiceTest extends ServiceSliceTest {
     void updateTravel() {
         // given
         Member member = saveMember();
-        Long travelId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        Long travelId = travelService.createTravel(createTravelRequest(2023), member);
         TravelRequest updatedTravel = new TravelRequest(
                 "https://example.com/travels/geumohrm.jpg",
                 "2023 신나는 여름 휴가",
@@ -196,7 +196,7 @@ class TravelServiceTest extends ServiceSliceTest {
     void deleteTravel() {
         // given
         Member member = saveMember();
-        Long travelId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        Long travelId = travelService.createTravel(createTravelRequest(2023), member);
 
         // when
         travelService.deleteTravel(travelId);
@@ -213,7 +213,7 @@ class TravelServiceTest extends ServiceSliceTest {
     void failDeleteTravel() {
         // given
         Member member = saveMember();
-        Long travelId = travelService.createTravel(createTravelRequest(2023), member.getId());
+        Long travelId = travelService.createTravel(createTravelRequest(2023), member);
         Travel foundTravel = travelRepository.findById(travelId).get();
         visitRepository.save(Visit.builder()
                 .visitedAt(LocalDate.now())

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -38,7 +38,7 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void deleteVisitById() {
         // given
-        Member member = memberRepository.save(Member.builder().nickname("Sample Member").build());
+        Member member = memberRepository.save(Member.builder().nickname("SampleMember").build());
         Travel travel = travelRepository.save(
                 Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build()
         );


### PR DESCRIPTION
## ⭐️ Issue Number
- #123 
## 🚩 Summary

- 처음 서비스를 실행할 때만 닉네임을 입력받아서 식별 코드를 생성합니다.
- 발급받은 식별코드는 기기에 저장해놓고 사용합니다.

## 🛠️ Technical Concerns
- jwt 토큰 발급을 위해서 `io.jsonwebtoken:jjwt:0.9.1` 의존성을 사용했습니다.
  - 버전은 이전에 사용해본 0.9.1을 사용했습니다. 과거 버전인 만큼 취약점이 있다면, 변경하겠습니다.
- (회원 등록 겸) 로그인을 auth 패키지를 만들어서 하위에 AuthController.login()을 생성하였습니다.
- 닉네임 관련 형식 및 예외 처리를 위해서 닉네임 VO를 생성했습니다.
- 기존에 ArgumentResolver에서 `@MemberId`로 처리하고 있었는데, `@LoginMember`로 변경하면서 `TravelController`에서 인자로 받던 `Long memberId` 대신 `Member member`를 받도록 변경했습니다.
  - 이 변경사항으로 인해 테스트 및 `TravelController`와 `TravelService`에도 수정이 있었습니다.
- 인증 관련 예외 처리를 위한 `UnauthorizedException`과 `ForbiddenException`을 추가하였습니다. 인자 없는 메서드를 호출하면 통일된 메시지를 던질 수 있도록 구현했습니다.
```java
public class ForbiddenException extends RuntimeException {

    public ForbiddenException() {
        super("요청하신 작업을 처리할 권한이 없습니다.");
    }
    ...
}
```

## 🙂 To Reviwer
- 변경 사항이 많아서, 커밋을 따라가면서 리뷰를 하는 것이 편할 수도 있어요!

## 📋 To Do
- 여행, 방문 기록 관련 인가 예외 처리 로직 구현