### PR TITLE
feat: 방문 생성 화면, 방문 수정 화면에서 갤러리 사진 불러오기 구현 #150

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -1,11 +1,15 @@
 package com.woowacourse.staccato.presentation
 
 import android.graphics.drawable.Drawable
+import android.net.Uri
+import android.view.View
 import android.widget.Button
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.TextView
 import androidx.core.view.isGone
+import androidx.core.view.isInvisible
 import androidx.databinding.BindingAdapter
 import coil.load
 import coil.transform.RoundedCornersTransformation
@@ -217,4 +221,22 @@ fun TextView.combineVisitedAt(visitedAt: LocalDate) {
             visitedAt.monthValue,
             visitedAt.dayOfMonth,
         )
+}
+
+@BindingAdapter("setAttachedPhotoVisibility")
+fun ImageView.setAttachedPhotoVisibility(items: List<Uri>?) {
+    if (items.isNullOrEmpty()) {
+        visibility = View.GONE
+    } else {
+        visibility = View.VISIBLE
+        Glide.with(context)
+            .load(items[0])
+            .centerCrop()
+            .into(this)
+    }
+}
+
+@BindingAdapter("setAttachedPhotoVisibility")
+fun FrameLayout.setAttachedPhotoVisibility(items: List<Uri>?) {
+    isInvisible = !items.isNullOrEmpty()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -60,10 +60,9 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
 
     private fun launchGallery() {
         val intent =
-            Intent(Intent.ACTION_PICK).apply {
-                setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
-                putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-            }
+            Intent(Intent.ACTION_PICK)
+                .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
         galleryLauncher.launch(intent)
     }
 
@@ -77,7 +76,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         snackBar.setAction(R.string.snack_bar_move_to_setting) {
             val intent = Intent()
             intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-            val uri = Uri.fromParts(SCHEME, requireContext().packageName, null)
+            val uri = Uri.fromParts(PACKAGE_SCHEME, requireContext().packageName, null)
             intent.data = uri
             startActivity(intent)
         }
@@ -161,6 +160,6 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
 
     companion object {
         const val TAG = "PhotoAttachModalBottomSheet"
-        const val SCHEME = "package"
+        const val PACKAGE_SCHEME = "package"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -1,15 +1,63 @@
 package com.woowacourse.staccato.presentation.common
 
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
+import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.google.android.material.snackbar.Snackbar
+import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.FragmentPhotoAttachBinding
 
 class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private var _binding: FragmentPhotoAttachBinding? = null
     private val binding get() = _binding!!
+
+    private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        initRequestPermissionLauncher()
+    }
+
+    private fun initRequestPermissionLauncher() {
+        requestPermissionLauncher =
+            registerForActivityResult(ActivityResultContracts.RequestPermission()) { isPermissionGranted ->
+                if (isPermissionGranted) {
+                    // 갤러리 열기
+                } else {
+                    showPermissionSnackBar()
+                }
+            }
+    }
+
+    private fun showPermissionSnackBar() {
+        val snackBar =
+            Snackbar.make(
+                binding.root,
+                R.string.snack_bar_require_photo_album_permission,
+                Snackbar.LENGTH_LONG,
+            )
+        snackBar.setAction(R.string.snack_bar_move_to_setting) {
+            val intent = Intent()
+            intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+            val uri = Uri.fromParts(SCHEME, requireContext().packageName, null)
+            intent.data = uri
+            startActivity(intent)
+        }
+        snackBar.show()
+    }
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -37,10 +85,28 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     }
 
     override fun onGalleryClicked() {
-        // 갤러리 열기
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            checkPermissionsAndLaunch(READ_MEDIA_IMAGES)
+        } else {
+            checkPermissionsAndLaunch(READ_EXTERNAL_STORAGE)
+        }
+    }
+
+    private fun checkPermissionsAndLaunch(permission: String) {
+        val isPermissionGranted =
+            ContextCompat.checkSelfPermission(
+                requireContext(),
+                permission,
+            ) == PackageManager.PERMISSION_GRANTED
+        if (isPermissionGranted) {
+            // 갤러리 열기
+        } else {
+            requestPermissionLauncher.launch(permission)
+        }
     }
 
     companion object {
         const val TAG = "PhotoAttachModalBottomSheet"
+        const val SCHEME = "package"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -22,18 +22,29 @@ import com.google.android.material.snackbar.Snackbar
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.FragmentPhotoAttachBinding
 import com.woowacourse.staccato.presentation.util.showToast
+import com.woowacourse.staccato.presentation.visitcreation.OnUrisSelectedListener
 
 class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private var _binding: FragmentPhotoAttachBinding? = null
     private val binding get() = _binding!!
 
+    private lateinit var uriSelectedListener: OnUrisSelectedListener
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
     private lateinit var galleryLauncher: ActivityResultLauncher<Intent>
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
+        initUriSelectedListner(context)
         initRequestPermissionLauncher()
         initGalleryLauncher()
+    }
+
+    private fun initUriSelectedListner(context: Context) {
+        if (context is OnUrisSelectedListener) {
+            uriSelectedListener = context
+        } else {
+            throw RuntimeException()
+        }
     }
 
     private fun initRequestPermissionLauncher() {
@@ -79,7 +90,8 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
                 if (result.resultCode == RESULT_OK) {
                     val imageUris = extractImageUris(result.data)
                     if (imageUris.isNotEmpty()) {
-                        // URI 전달
+                        uriSelectedListener.onUrisSelected(imageUris)
+                        dismiss()
                     } else {
                         showToast("사진을 불러올 수 없습니다.")
                     }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -2,12 +2,14 @@ package com.woowacourse.staccato.presentation.common
 
 import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
+import android.app.Activity.RESULT_OK
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.provider.MediaStore
 import android.provider.Settings
 import android.view.LayoutInflater
 import android.view.View
@@ -19,27 +21,39 @@ import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.google.android.material.snackbar.Snackbar
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.databinding.FragmentPhotoAttachBinding
+import com.woowacourse.staccato.presentation.util.showToast
 
 class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private var _binding: FragmentPhotoAttachBinding? = null
     private val binding get() = _binding!!
 
     private lateinit var requestPermissionLauncher: ActivityResultLauncher<String>
+    private lateinit var galleryLauncher: ActivityResultLauncher<Intent>
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
         initRequestPermissionLauncher()
+        initGalleryLauncher()
     }
 
     private fun initRequestPermissionLauncher() {
         requestPermissionLauncher =
             registerForActivityResult(ActivityResultContracts.RequestPermission()) { isPermissionGranted ->
                 if (isPermissionGranted) {
-                    // 갤러리 열기
+                    launchGallery()
                 } else {
                     showPermissionSnackBar()
                 }
             }
+    }
+
+    private fun launchGallery() {
+        val intent =
+            Intent(Intent.ACTION_PICK).apply {
+                setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+            }
+        galleryLauncher.launch(intent)
     }
 
     private fun showPermissionSnackBar() {
@@ -57,6 +71,34 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
             startActivity(intent)
         }
         snackBar.show()
+    }
+
+    private fun initGalleryLauncher() {
+        galleryLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == RESULT_OK) {
+                    val imageUris = extractImageUris(result.data)
+                    if (imageUris.isNotEmpty()) {
+                        // URI 전달
+                    } else {
+                        showToast("사진을 불러올 수 없습니다.")
+                    }
+                }
+            }
+    }
+
+    private fun extractImageUris(intent: Intent?): List<Uri> {
+        val imageUris = mutableListOf<Uri>()
+        intent?.let {
+            it.clipData?.let { clipData ->
+                repeat(clipData.itemCount) { index ->
+                    imageUris.add(clipData.getItemAt(index).uri)
+                }
+            } ?: it.data?.let { uri ->
+                imageUris.add(uri)
+            }
+        }
+        return imageUris
     }
 
     override fun onCreateView(
@@ -99,7 +141,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
                 permission,
             ) == PackageManager.PERMISSION_GRANTED
         if (isPermissionGranted) {
-            // 갤러리 열기
+            launchGallery()
         } else {
             requestPermissionLauncher.launch(permission)
         }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -67,12 +67,20 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     }
 
     private fun showPermissionSnackBar() {
-        val snackBar =
-            Snackbar.make(
-                binding.root,
-                R.string.snack_bar_require_photo_album_permission,
-                Snackbar.LENGTH_LONG,
-            )
+        val snackBar = makeSnackBar()
+        setSnackBarAction(snackBar)
+        snackBar.show()
+    }
+
+    private fun makeSnackBar(): Snackbar {
+        return Snackbar.make(
+            binding.root,
+            R.string.snack_bar_require_photo_album_permission,
+            Snackbar.LENGTH_LONG,
+        )
+    }
+
+    private fun setSnackBarAction(snackBar: Snackbar) {
         snackBar.setAction(R.string.snack_bar_move_to_setting) {
             val intent = Intent()
             intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
@@ -80,7 +88,6 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
             intent.data = uri
             startActivity(intent)
         }
-        snackBar.show()
     }
 
     private fun initGalleryLauncher() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -7,7 +7,7 @@ import android.view.ViewGroup
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.woowacourse.staccato.databinding.FragmentPhotoAttachBinding
 
-class PhotoAttachFragment : BottomSheetDialogFragment() {
+class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private var _binding: FragmentPhotoAttachBinding? = null
     private val binding get() = _binding!!
 
@@ -20,9 +20,24 @@ class PhotoAttachFragment : BottomSheetDialogFragment() {
         return binding.root
     }
 
+    override fun onViewCreated(
+        view: View,
+        savedInstanceState: Bundle?,
+    ) {
+        binding.handler = this
+    }
+
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+    }
+
+    override fun onCameraClicked() {
+        // 카메라 열기
+    }
+
+    override fun onGalleryClicked() {
+        // 갤러리 열기
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachHandler.kt
@@ -1,0 +1,7 @@
+package com.woowacourse.staccato.presentation.common
+
+interface PhotoAttachHandler {
+    fun onCameraClicked()
+
+    fun onGalleryClicked()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/util/FileUtils.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/util/FileUtils.kt
@@ -1,0 +1,14 @@
+package com.woowacourse.staccato.presentation.util
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+
+fun Context.getFileFromUri(selectedImageUri: Uri): File {
+    val cursor = contentResolver.query(selectedImageUri, null, null, null, null)
+    cursor!!.moveToNext()
+    val dataIndex = cursor.getColumnIndex("_data").coerceAtLeast(0)
+    val path = cursor.getString(dataIndex)
+    cursor.close()
+    return File(path)
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/OnUrisSelectedListener.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/OnUrisSelectedListener.kt
@@ -1,0 +1,7 @@
+package com.woowacourse.staccato.presentation.visitcreation
+
+import android.net.Uri
+
+interface OnUrisSelectedListener {
+    fun onUrisSelected(uris: List<Uri>)
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
@@ -2,6 +2,7 @@ package com.woowacourse.staccato.presentation.visitcreation
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
@@ -17,6 +18,7 @@ import com.woowacourse.staccato.presentation.visitcreation.viewmodel.VisitCreati
 
 class VisitCreationActivity :
     BindingActivity<ActivityVisitCreationBinding>(),
+    OnUrisSelectedListener,
     VisitCreationHandler {
     override val layoutResourceId = R.layout.activity_visit_creation
     private val viewModel: VisitCreationViewModel by viewModels { VisitCreationViewModelFactory() }
@@ -79,6 +81,10 @@ class VisitCreationActivity :
             setResult(RESULT_OK, resultIntent)
             finish()
         }
+    }
+
+    override fun onUrisSelected(uris: List<Uri>) {
+        viewModel.setImageUris(uris)
     }
 
     override fun onTravelSelectionClicked() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/viewmodel/VisitCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/viewmodel/VisitCreationViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.presentation.visitcreation.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -33,6 +34,10 @@ class VisitCreationViewModel(
     private val _createdVisitId = MutableSingleLiveData<Long>()
     val createdVisitId: SingleLiveData<Long> get() = _createdVisitId
 
+    private val _selectedImages = MutableLiveData<List<Uri>>()
+
+    val selectedImages: LiveData<List<Uri>> get() = _selectedImages
+
     fun fetchInitData(pinId: Long) =
         viewModelScope.launch {
             loadAllTravels()
@@ -53,14 +58,6 @@ class VisitCreationViewModel(
             )
     }
 
-    fun updateSelectedTravel(newSelectedTravel: VisitTravelUiModel) {
-        _selectedTravel.value = newSelectedTravel
-    }
-
-    fun updateSelectedVisitedAt(newSelectedVisitedAt: LocalDate?) {
-        _selectedVisitedAt.value = newSelectedVisitedAt
-    }
-
     fun createVisit(pinId: Long) =
         viewModelScope.launch {
             if (selectedVisitedAt.value != null && selectedTravel.value != null) {
@@ -77,4 +74,16 @@ class VisitCreationViewModel(
                 }
             }
         }
+
+    fun updateSelectedTravel(newSelectedTravel: VisitTravelUiModel) {
+        _selectedTravel.value = newSelectedTravel
+    }
+
+    fun updateSelectedVisitedAt(newSelectedVisitedAt: LocalDate?) {
+        _selectedVisitedAt.value = newSelectedVisitedAt
+    }
+
+    fun setImageUris(uris: List<Uri>) {
+        _selectedImages.value = uris
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -2,6 +2,7 @@ package com.woowacourse.staccato.presentation.visitupdate
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
@@ -12,6 +13,7 @@ import com.woowacourse.staccato.databinding.ActivityVisitUpdateBinding
 import com.woowacourse.staccato.presentation.base.BindingActivity
 import com.woowacourse.staccato.presentation.common.PhotoAttachFragment
 import com.woowacourse.staccato.presentation.util.showToast
+import com.woowacourse.staccato.presentation.visitcreation.OnUrisSelectedListener
 import com.woowacourse.staccato.presentation.visitcreation.VisitCreationActivity
 import com.woowacourse.staccato.presentation.visitcreation.dialog.VisitedAtSelectionFragment
 import com.woowacourse.staccato.presentation.visitupdate.viewmodel.VisitUpdateViewModel
@@ -19,7 +21,10 @@ import com.woowacourse.staccato.presentation.visitupdate.viewmodel.VisitUpdateVi
 import kotlinx.coroutines.launch
 import kotlin.properties.Delegates
 
-class VisitUpdateActivity : BindingActivity<ActivityVisitUpdateBinding>(), VisitUpdateHandler {
+class VisitUpdateActivity :
+    BindingActivity<ActivityVisitUpdateBinding>(),
+    OnUrisSelectedListener,
+    VisitUpdateHandler {
     override val layoutResourceId = R.layout.activity_visit_update
     private val viewModel: VisitUpdateViewModel by viewModels { VisitUpdateViewModelFactory() }
 
@@ -98,6 +103,10 @@ class VisitUpdateActivity : BindingActivity<ActivityVisitUpdateBinding>(), Visit
             setResult(RESULT_OK, resultIntent)
             finish()
         }
+    }
+
+    override fun onUrisSelected(uris: List<Uri>) {
+        viewModel.setImageUris(uris)
     }
 
     override fun onVisitedAtClicked() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/viewmodel/VisitUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/viewmodel/VisitUpdateViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.presentation.visitupdate.viewmodel
 
+import android.net.Uri
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -31,6 +32,9 @@ class VisitUpdateViewModel(
 
     private val _isUpdateCompleted = MutableSingleLiveData(false)
     val isUpdateCompleted: SingleLiveData<Boolean> get() = _isUpdateCompleted
+
+    private val _selectedImages = MutableLiveData<List<Uri>>()
+    val selectedImages: LiveData<List<Uri>> get() = _selectedImages
 
     fun fetchInitData(
         visitId: Long,
@@ -76,5 +80,9 @@ class VisitUpdateViewModel(
 
     fun updateVisitedAt(newSelectedVisitedAt: LocalDate?) {
         _selectedVisitedAt.value = newSelectedVisitedAt
+    }
+
+    fun setImageUris(uris: List<Uri>) {
+        _selectedImages.value = uris
     }
 }

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -113,6 +113,7 @@
                     android:layout_marginTop="8dp"
                     android:background="@drawable/shape_button_gray1_5dp"
                     android:onClick="@{()->visitCreationHandler.onPhotoAttachClicked()}"
+                    bind:setAttachedPhotoVisibility="@{viewModel.selectedImages}"
                     app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
@@ -124,6 +125,16 @@
                         android:layout_gravity="center" />
 
                 </FrameLayout>
+
+                <ImageView
+                    android:id="@+id/iv_attached_photo"
+                    android:layout_width="0dp"
+                    android:layout_height="200dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_photo_title"
+                    bind:setAttachedPhotoVisibility="@{viewModel.selectedImages}" />
 
                 <TextView
                     android:id="@+id/tv_travel_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
@@ -112,6 +112,7 @@
                     android:layout_marginTop="8dp"
                     android:background="@drawable/shape_button_gray1_5dp"
                     android:onClick="@{()->visitUpdateHandler.onPhotoAttachClicked()}"
+                    bind:setAttachedPhotoVisibility="@{viewModel.selectedImages}"
                     app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/tv_photo_title">
@@ -123,6 +124,16 @@
                         android:layout_gravity="center" />
 
                 </FrameLayout>
+
+                <ImageView
+                    android:id="@+id/iv_attached_photo"
+                    android:layout_width="0dp"
+                    android:layout_height="200dp"
+                    android:layout_marginTop="8dp"
+                    app:layout_constraintEnd_toEndOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_photo_title"
+                    bind:setAttachedPhotoVisibility="@{viewModel.selectedImages}" />
 
                 <TextView
                     android:id="@+id/tv_travel_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_photo_attach.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_photo_attach.xml
@@ -4,6 +4,9 @@
 
     <data>
 
+        <variable
+            name="handler"
+            type="com.woowacourse.staccato.presentation.common.PhotoAttachHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -23,6 +26,7 @@
             android:id="@+id/tv_photo_attach_camera"
             style="@style/PhotoAttachMenuStyle"
             android:layout_marginTop="24dp"
+            android:onClick="@{()->handler.onCameraClicked()}"
             android:text="@string/photo_attach_camera"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -31,7 +35,6 @@
         <com.google.android.material.divider.MaterialDivider
             android:id="@+id/divider_photo_attach"
             style="@style/DividerStyle"
-            android:layout_marginTop="16dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/tv_photo_attach_camera" />
@@ -39,7 +42,7 @@
         <TextView
             android:id="@+id/tv_photo_attach_album"
             style="@style/PhotoAttachMenuStyle"
-            android:layout_marginTop="16dp"
+            android:onClick="@{()->handler.onGalleryClicked()}"
             android:text="@string/photo_attach_album"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -53,6 +53,8 @@
     <string name="photo_attach_title">사진을 등록해주세요</string>
     <string name="photo_attach_camera">카메라 열기</string>
     <string name="photo_attach_album">앨범에서 가져오기</string>
+    <string name="snack_bar_require_photo_album_permission">사진 및 동영상 액세스 권한을 허용해주세요.</string>
+    <string name="snack_bar_move_to_setting">설정으로 이동하기</string>
 
     // fragment_travel_selection
     <string name="travel_selection_period">%s.%s.%s - %s.%s.%s</string>

--- a/android/Staccato_AN/app/src/main/res/values/styles.xml
+++ b/android/Staccato_AN/app/src/main/res/values/styles.xml
@@ -86,6 +86,7 @@
     <style name="PhotoAttachMenuStyle">
         <item name="android:layout_width">0dp</item>
         <item name="android:clickable">true</item>
+        <item name="android:paddingVertical">16dp</item>
         <item name="android:focusable">true</item>
         <item name="android:layout_height">wrap_content</item>
         <item name="android:textAppearance">@style/Typography.Body1</item>


### PR DESCRIPTION
## ⭐️ Issue Number
- #150 

## 🚩 Summary

### PhotoAttachFragment의 변경사항
- [x] `앨범에서 가져오기`, `카메라 열기` 각 메뉴 클릭 시 동작 정의를 위한 `PhotoAttachHandler.kt` 추가
- [x] 앨범 접근 권한 관련 로직 구현
     - [x] 권한 허용 시 앨범으로 이동
     - [x] 권한 요청 거부 시 스낵바 띄우기
- [x] 앨범에서 불러온 이미지의 URI 추출하기

### VisitUpdateActivity.kt & VisitCreationActivity.kt의 변경사항
- [x] `PhotoAttachFragment`에서 선택된 이미지의 URI를 받아오기 위한 `OnUrisSelectedListener.kt` 추가

### VisitCreationViewModel.kt & VisitUpdateViewModel.kt의 변경사항
- [x] 이미지의 URI를 받아와 `LiveData<List<Uri>>`로 저장

### 기타 변경사항
- [x] Uri를 File로 변환하는 `getFileFromUri`메서드를 FileUtils에 추가

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
- 카메라 열기 플로우 구현
- 선택된 사진 가로 리사이클러뷰로 보여주기
- 선택된 사진을 선택 취소할 수 있도록 하기