### PR TITLE
refactor: member entity 외 논리적 삭제 제거 #132

### DIFF
--- a/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
+++ b/backend/src/main/java/com/staccato/config/domain/BaseEntity.java
@@ -19,5 +19,4 @@ public abstract class BaseEntity {
     private LocalDateTime createdAt;
     @LastModifiedDate
     private LocalDateTime updatedAt;
-    private Boolean isDeleted = false;
 }

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 import com.staccato.config.domain.BaseEntity;
 
@@ -21,6 +22,7 @@ import lombok.NonNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@SQLRestriction("is_deleted = false")
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,6 +32,7 @@ public class Member extends BaseEntity {
     private Nickname nickname;
     @Column(columnDefinition = "TEXT")
     private String imageUrl;
+    private Boolean isDeleted = false;
 
     @Builder
     public Member(@NonNull String nickname, String imageUrl) {

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -12,9 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
@@ -29,8 +26,6 @@ import lombok.NonNull;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE travel SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 public class Travel extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/travel/domain/TravelMember.java
+++ b/backend/src/main/java/com/staccato/travel/domain/TravelMember.java
@@ -8,9 +8,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
@@ -23,8 +20,6 @@ import lombok.NonNull;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE travel_member SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 public class TravelMember extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -17,9 +17,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.exception.StaccatoException;
 import com.staccato.travel.domain.Travel;
@@ -33,8 +30,6 @@ import lombok.NonNull;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE visit SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 public class Visit extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
+++ b/backend/src/main/java/com/staccato/visit/domain/VisitLog.java
@@ -10,9 +10,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.SQLRestriction;
-
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
 
@@ -27,8 +24,6 @@ import lombok.NonNull;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE visit_log SET is_deleted = true WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 public class VisitLog extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       hibernate:
         format_sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     database-platform: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
 springdoc:


### PR DESCRIPTION
## ⭐️ Issue Number
- #132 
## 🚩 Summary

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
- member에 남아있는 `@SqlRestriction`은 제거하는 방향으로 리팩터링 필요