### PR TITLE
feat: 방문 기록 관련 인가 구현 #140

### DIFF
--- a/backend/src/main/java/com/staccato/visit/controller/VisitController.java
+++ b/backend/src/main/java/com/staccato/visit/controller/VisitController.java
@@ -40,10 +40,11 @@ public class VisitController implements VisitControllerDocs {
 
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<VisitIdResponse> createVisit(
+            @LoginMember Member member,
             @Valid @RequestPart(value = "data") VisitRequest visitRequest,
             @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.") @RequestPart(value = "visitImageFiles") List<MultipartFile> visitImageFiles
     ) {
-        VisitIdResponse visitIdResponse = visitService.createVisit(visitRequest);
+        VisitIdResponse visitIdResponse = visitService.createVisit(visitRequest, member);
         return ResponseEntity.created(URI.create("/visits/" + visitIdResponse.visitId()))
                 .body(visitIdResponse);
     }

--- a/backend/src/main/java/com/staccato/visit/controller/VisitController.java
+++ b/backend/src/main/java/com/staccato/visit/controller/VisitController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.staccato.config.auth.LoginMember;
+import com.staccato.member.domain.Member;
 import com.staccato.visit.controller.docs.VisitControllerDocs;
 import com.staccato.visit.service.VisitService;
 import com.staccato.visit.service.dto.request.VisitRequest;
@@ -48,8 +50,9 @@ public class VisitController implements VisitControllerDocs {
 
     @GetMapping("/{visitId}")
     public ResponseEntity<VisitDetailResponse> readVisitById(
+            @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId) {
-        VisitDetailResponse visitDetailResponse = visitService.readVisitById(visitId);
+        VisitDetailResponse visitDetailResponse = visitService.readVisitById(visitId, member);
         return ResponseEntity.ok().body(visitDetailResponse);
     }
 

--- a/backend/src/main/java/com/staccato/visit/controller/VisitController.java
+++ b/backend/src/main/java/com/staccato/visit/controller/VisitController.java
@@ -58,18 +58,21 @@ public class VisitController implements VisitControllerDocs {
 
     @PutMapping(path = "/{visitId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> updateVisitById(
+            @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId,
             @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.") @RequestPart("visitImageFiles") List<MultipartFile> visitImageFiles,
-            @Valid @RequestPart(value = "data") VisitUpdateRequest request) {
-        visitService.updateVisitById(visitId, request, visitImageFiles);
+            @Valid @RequestPart(value = "data") VisitUpdateRequest request
+    ) {
+        visitService.updateVisitById(visitId, request, visitImageFiles, member);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{visitId}")
     public ResponseEntity<Void> deleteVisitById(
+            @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId
     ) {
-        visitService.deleteVisitById(visitId);
+        visitService.deleteVisitById(visitId, member);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
+++ b/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
@@ -78,6 +78,7 @@ public interface VisitControllerDocs {
                     responseCode = "400")
     })
     ResponseEntity<Void> updateVisitById(
+            @Parameter(hidden = true) Member member,
             @Parameter(description = "방문 기록 ID", example = "1", required = true) @PathVariable @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId,
             @Parameter(description = "key = visitImageFiles") @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.") List<MultipartFile> visitImageFiles,
             @Parameter(description = "key = data", required = true) @Valid VisitUpdateRequest request);
@@ -88,6 +89,7 @@ public interface VisitControllerDocs {
             @ApiResponse(description = "방문 기록 식별자에 양수가 아닌 값을 기입했을 경우", responseCode = "400")
     })
     ResponseEntity<Void> deleteVisitById(
+            @Parameter(hidden = true) Member member,
             @Parameter(description = "방문 기록 ID", example = "1", required = true) @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId
     );
 }

--- a/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
+++ b/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
@@ -43,6 +43,7 @@ public interface VisitControllerDocs {
                     responseCode = "400")
     })
     ResponseEntity<VisitIdResponse> createVisit(
+            @Parameter(hidden = true) Member member,
             @Parameter(description = "key = data", required = true) @Valid VisitRequest visitRequest,
             @Parameter(description = "key = visitImageFiles") @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.") List<MultipartFile> visitImagesFile
     );

--- a/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
+++ b/backend/src/main/java/com/staccato/visit/controller/docs/VisitControllerDocs.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.staccato.member.domain.Member;
 import com.staccato.visit.service.dto.request.VisitRequest;
 import com.staccato.visit.service.dto.request.VisitUpdateRequest;
 import com.staccato.visit.service.dto.response.VisitDetailResponse;
@@ -59,6 +60,7 @@ public interface VisitControllerDocs {
                     responseCode = "400")
     })
     ResponseEntity<VisitDetailResponse> readVisitById(
+            @Parameter(hidden = true) Member member,
             @Parameter(description = "방문 기록 ID", example = "1", required = true) @PathVariable @Min(value = 1L, message = "방문 기록 식별자는 양수로 이루어져야 합니다.") long visitId);
 
     @Operation(summary = "특정 방문 기록 수정", description = "특정 방문 기록을 수정합니다.")

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -29,8 +29,9 @@ public class VisitService {
     private final TravelRepository travelRepository;
 
     @Transactional
-    public VisitIdResponse createVisit(VisitRequest visitRequest) {
+    public VisitIdResponse createVisit(VisitRequest visitRequest, Member member) {
         Travel travel = getTravelById(visitRequest.travelId());
+        validateOwner(travel, member);
         Visit visit = visitRequest.toVisit(travel);
         VisitImages visitImages = new VisitImages(visitRequest.visitImageUrls());
         visit.addVisitImages(visitImages);

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -6,7 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
+import com.staccato.member.domain.Member;
 import com.staccato.travel.domain.Travel;
 import com.staccato.travel.repository.TravelRepository;
 import com.staccato.visit.domain.Visit;
@@ -43,8 +45,9 @@ public class VisitService {
                 .orElseThrow(() -> new StaccatoException("요청하신 여행을 찾을 수 없어요."));
     }
 
-    public VisitDetailResponse readVisitById(long visitId) {
+    public VisitDetailResponse readVisitById(long visitId, Member member) {
         Visit visit = getVisitById(visitId);
+        validateOwner(visit.getTravel(), member);
         return new VisitDetailResponse(visit);
     }
 
@@ -68,5 +71,11 @@ public class VisitService {
     @Transactional
     public void deleteVisitById(long visitId) {
         visitRepository.deleteById(visitId);
+    }
+
+    private void validateOwner(Travel travel, Member member) {
+        if (travel.isNotOwnedBy(member)) {
+            throw new ForbiddenException();
+        }
     }
 }

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -52,8 +52,14 @@ public class VisitService {
     }
 
     @Transactional
-    public void updateVisitById(long visitId, VisitUpdateRequest visitUpdateRequest, List<MultipartFile> visitImageFiles) {
+    public void updateVisitById(
+            long visitId,
+            VisitUpdateRequest visitUpdateRequest,
+            List<MultipartFile> visitImageFiles,
+            Member member
+    ) {
         Visit visit = getVisitById(visitId);
+        validateOwner(visit.getTravel(), member);
         List<String> addedImages = List.of(visitImageFiles.get(0).getName()); // 새롭게 추가된 이미지 파일의 url을 가지고 오는 임시 로직
         VisitImages visitImages = VisitImages.builder()
                 .existingImages(visitUpdateRequest.visitImageUrls())
@@ -69,8 +75,11 @@ public class VisitService {
     }
 
     @Transactional
-    public void deleteVisitById(long visitId) {
-        visitRepository.deleteById(visitId);
+    public void deleteVisitById(long visitId, Member member) {
+        visitRepository.findById(visitId).ifPresent(visit -> {
+            validateOwner(visit.getTravel(), member);
+            visitRepository.deleteById(visitId);
+        });
     }
 
     private void validateOwner(Travel travel, Member member) {

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       hibernate:
         format_sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect
     defer-datasource-initialization: true
 springdoc:

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -2,6 +2,7 @@ package com.staccato.visit.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -34,6 +35,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;
 import com.staccato.exception.ExceptionResponse;
+import com.staccato.member.domain.Member;
 import com.staccato.visit.fixture.VisitDetailResponseFixture;
 import com.staccato.visit.service.VisitService;
 import com.staccato.visit.service.dto.request.VisitRequest;
@@ -170,13 +172,13 @@ class VisitControllerTest {
     void readVisitById() throws Exception {
         // given
         long visitId = 1L;
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
         VisitDetailResponse response = VisitDetailResponseFixture.create(visitId, LocalDate.now());
+        when(visitService.readVisitById(anyLong(), any(Member.class))).thenReturn(response);
 
-        // when
-        when(visitService.readVisitById(visitId)).thenReturn(response);
-
-        // then
-        mockMvc.perform(get("/visits/{visitId}", 1))
+        // when & then
+        mockMvc.perform(get("/visits/{visitId}", visitId)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(objectMapper.writeValueAsString(response)));
     }

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -207,7 +207,6 @@ class VisitControllerTest {
         long visitId = 1L;
         VisitUpdateRequest updateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
-
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then
@@ -237,7 +236,6 @@ class VisitControllerTest {
         MockMultipartFile file4 = new MockMultipartFile("visitImageFiles", "namsan_tower4.jpg".getBytes());
         MockMultipartFile file5 = new MockMultipartFile("visitImageFiles", "namsan_tower5.jpg".getBytes());
         MockMultipartFile file6 = new MockMultipartFile("visitImageFiles", "namsan_tower6.jpg".getBytes());
-
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then
@@ -268,7 +266,6 @@ class VisitControllerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "방문 기록 식별자는 양수로 이루어져야 합니다.");
         VisitUpdateRequest updateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
-
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then
@@ -294,7 +291,6 @@ class VisitControllerTest {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "방문한 장소의 이름을 입력해주세요.");
         VisitUpdateRequest updateRequest = new VisitUpdateRequest(null, List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
-
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -99,7 +100,7 @@ class VisitControllerTest {
         when(visitService.createVisit(any(VisitRequest.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.multipart("/visits")
+        mockMvc.perform(multipart("/visits")
                         .file(visitRequestPart)
                         .file(file1)
                         .file(file2)
@@ -125,12 +126,12 @@ class VisitControllerTest {
         MockMultipartFile file4 = new MockMultipartFile("visitImageFiles", "test-image4.jpg", "image/jpeg", "dummy image content".getBytes());
         MockMultipartFile file5 = new MockMultipartFile("visitImageFiles", "test-image5.jpg", "image/jpeg", "dummy image content".getBytes());
         MockMultipartFile file6 = new MockMultipartFile("visitImageFiles", "test-image6.jpg", "image/jpeg", "dummy image content".getBytes());
-        MockMultipartHttpServletRequestBuilder builder = MockMvcRequestBuilders.multipart("/visits");
+        MockMultipartHttpServletRequestBuilder builder = multipart("/visits");
         builder.file(visitRequestPart);
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "사진은 5장까지만 추가할 수 있어요.");
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.multipart("/visits")
+        mockMvc.perform(multipart("/visits")
                         .file(visitRequestPart)
                         .file(file1)
                         .file(file2)
@@ -159,7 +160,7 @@ class VisitControllerTest {
         when(visitService.createVisit(any(VisitRequest.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.multipart("/visits")
+        mockMvc.perform(multipart("/visits")
                         .file(visitRequestPart)
                         .file(imageFilePart)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
@@ -203,6 +204,8 @@ class VisitControllerTest {
         VisitUpdateRequest updateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
 
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+
         // when & then
         mockMvc.perform(multipart("/visits/{visitId}", visitId)
                         .file(file)
@@ -212,6 +215,7 @@ class VisitControllerTest {
                             request.setMethod("PUT");
                             return request;
                         })
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isOk());
     }
@@ -230,6 +234,8 @@ class VisitControllerTest {
         MockMultipartFile file5 = new MockMultipartFile("visitImageFiles", "namsan_tower5.jpg".getBytes());
         MockMultipartFile file6 = new MockMultipartFile("visitImageFiles", "namsan_tower6.jpg".getBytes());
 
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+
         // when & then
         mockMvc.perform(multipart("/visits/{visitId}", visitId)
                         .file(file1)
@@ -244,6 +250,7 @@ class VisitControllerTest {
                             request.setMethod("PUT");
                             return request;
                         })
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
@@ -258,6 +265,8 @@ class VisitControllerTest {
         VisitUpdateRequest updateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
 
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+
         // when & then
         mockMvc.perform(multipart("/visits/{visitId}", visitId)
                         .file(file)
@@ -267,6 +276,7 @@ class VisitControllerTest {
                             request.setMethod("PUT");
                             return request;
                         })
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
@@ -281,6 +291,8 @@ class VisitControllerTest {
         VisitUpdateRequest updateRequest = new VisitUpdateRequest(null, List.of("https://example1.com.jpg"));
         MockMultipartFile file = new MockMultipartFile("visitImageFiles", "namsan_tower.jpg".getBytes());
 
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+
         // when & then
         mockMvc.perform(multipart("/visits/{visitId}", visitId)
                         .file(file)
@@ -290,6 +302,7 @@ class VisitControllerTest {
                             request.setMethod("PUT");
                             return request;
                         })
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
@@ -300,10 +313,11 @@ class VisitControllerTest {
     void deleteVisitById() throws Exception {
         // given
         long visitId = 1L;
-        doNothing().when(visitService).deleteVisitById(anyLong());
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.delete("/visits/{id}", visitId))
+        mockMvc.perform(delete("/visits/{id}", visitId)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());
     }
 
@@ -313,10 +327,10 @@ class VisitControllerTest {
         // given
         long visitId = 0L;
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "방문 기록 식별자는 양수로 이루어져야 합니다.");
-        doNothing().when(visitService).deleteVisitById(anyLong());
 
         // when & then
-        mockMvc.perform(MockMvcRequestBuilders.delete("/visits/{id}", visitId))
+        mockMvc.perform(delete("/visits/{id}", visitId)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
     }

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -95,7 +95,8 @@ class VisitControllerTest {
         MockMultipartFile file4 = new MockMultipartFile("visitImageFiles", "test-image4.jpg", "image/jpeg", "dummy image content".getBytes());
         MockMultipartFile file5 = new MockMultipartFile("visitImageFiles", "test-image5.jpg", "image/jpeg", "dummy image content".getBytes());
         VisitIdResponse visitIdResponse = new VisitIdResponse(1L);
-        when(visitService.createVisit(any(VisitRequest.class))).thenReturn(new VisitIdResponse(1L));
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+        when(visitService.createVisit(any(VisitRequest.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
         mockMvc.perform(multipart("/visits")
@@ -105,6 +106,7 @@ class VisitControllerTest {
                         .file(file3)
                         .file(file4)
                         .file(file5)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/visits/1"))
@@ -127,6 +129,7 @@ class VisitControllerTest {
         MockMultipartHttpServletRequestBuilder builder = multipart("/visits");
         builder.file(visitRequestPart);
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "사진은 5장까지만 추가할 수 있어요.");
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then
         mockMvc.perform(multipart("/visits")
@@ -137,6 +140,7 @@ class VisitControllerTest {
                         .file(file4)
                         .file(file5)
                         .file(file6)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
@@ -155,12 +159,14 @@ class VisitControllerTest {
         MockMultipartFile visitRequestPart = new MockMultipartFile("data", "visitRequest.json", "application/json", visitRequestJson.getBytes());
         MockMultipartFile imageFilePart = new MockMultipartFile("visitImageFiles", "test-image1.jpg", "image/jpeg", "dummy image content".getBytes());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
-        when(visitService.createVisit(any(VisitRequest.class))).thenReturn(new VisitIdResponse(1L));
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+        when(visitService.createVisit(any(VisitRequest.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
         mockMvc.perform(multipart("/visits")
                         .file(visitRequestPart)
                         .file(imageFilePart)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -3,7 +3,6 @@ package com.staccato.visit.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -31,7 +30,6 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -50,10 +50,7 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void createVisit() {
         // given
-        travelRepository.save(
-                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1))
-                        .build()
-        );
+        saveTravel();
 
         // when
         long visitId = visitService.createVisit(getVisitRequestWithoutImage()).visitId();
@@ -70,10 +67,7 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void createVisitWithVisitImages() {
         // given
-        travelRepository.save(
-                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1))
-                        .build()
-        );
+        saveTravel();
 
         // when
         long visitId = visitService.createVisit(getVisitRequest()).visitId();
@@ -101,12 +95,9 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void readVisitById() {
         // given
-        Member member = memberRepository.save(Member.builder().nickname("member").build());
-        Travel travel = Travel.builder().title("Sample Travel").startAt(LocalDate.now())
-                .endAt(LocalDate.now().plusDays(1)).build();
-        travel.addTravelMember(member);
-        travelRepository.save(travel);
-        Visit visit = visitRepository.save(VisitFixture.create(travel, LocalDate.now()));
+        Member member = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
 
         // when
         VisitDetailResponse actual = visitService.readVisitById(visit.getId(), member);
@@ -119,18 +110,13 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void cannotReadVisitByIdIfNotOwner() {
         // given
-        Member member = memberRepository.save(Member.builder().nickname("member").build());
-        Travel travel = Travel.builder().title("Sample Travel").startAt(LocalDate.now())
-                .endAt(LocalDate.now().plusDays(1)).build();
-        travel.addTravelMember(member);
-        Visit visit = VisitFixture.create(travel, LocalDate.now());
-        travelRepository.save(travel);
-        Visit savedVisit = visitRepository.save(visit);
-
-        Member otherMember = memberRepository.save(Member.builder().nickname("otherMember").build());
+        Member member = saveMember();
+        Member otherMember = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
 
         // when & then
-        assertThatThrownBy(() -> visitService.readVisitById(savedVisit.getId(), otherMember))
+        assertThatThrownBy(() -> visitService.readVisitById(visit.getId(), otherMember))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
     }
@@ -148,18 +134,14 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void updateVisitById() {
         // given
-        Travel travel = travelRepository.save(
-                Travel.builder().title("Sample Travel").startAt(LocalDate.now().minusDays(1))
-                        .endAt(LocalDate.now().plusDays(1)).build()
-        );
-        Visit visit = VisitFixture.create(travel, LocalDate.now());
-        visit.addVisitImages(new VisitImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
-        visitRepository.save(visit);
+        Member member = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
 
         // when
         VisitUpdateRequest visitUpdateRequest = new VisitUpdateRequest("newPlaceName", List.of("https://existExample.com.jpg"));
         MockMultipartFile mockMultipartFile = new MockMultipartFile("visitImagesFile", "newExample.jpg".getBytes());
-        visitService.updateVisitById(visit.getId(), visitUpdateRequest, List.of(mockMultipartFile));
+        visitService.updateVisitById(visit.getId(), visitUpdateRequest, List.of(mockMultipartFile), member);
 
         // then
         Visit foundedVisit = visitRepository.findById(visit.getId()).get();
@@ -177,6 +159,23 @@ class VisitServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("본인 것이 아닌 특정 방문 기록을 수정하려고 하면 예외가 발생한다.")
+    @Test
+    void cannotUpdateVisitByIdIfNotOwner() {
+        // given
+        Member member = saveMember();
+        Member otherMember = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
+
+        VisitUpdateRequest visitUpdateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
+
+        // when & then
+        assertThatThrownBy(() -> visitService.updateVisitById(visit.getId(), visitUpdateRequest, List.of(new MockMultipartFile("visitImagesFile", "namsan_tower.jpg".getBytes())), otherMember))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
+    }
+
     @DisplayName("존재하지 않는 방문 기록을 수정하면 예외가 발생한다.")
     @Test
     void failUpdateVisitById() {
@@ -184,7 +183,7 @@ class VisitServiceTest extends ServiceSliceTest {
         VisitUpdateRequest visitUpdateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
 
         // when & then
-        assertThatThrownBy(() -> visitService.updateVisitById(1L, visitUpdateRequest, List.of(new MockMultipartFile("visitImagesFile", "namsan_tower.jpg".getBytes()))))
+        assertThatThrownBy(() -> visitService.updateVisitById(1L, visitUpdateRequest, List.of(new MockMultipartFile("visitImagesFile", "namsan_tower.jpg".getBytes())), null))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 방문 기록을 찾을 수 없어요.");
     }
@@ -193,17 +192,13 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void deleteVisitById() {
         // given
-        Member member = memberRepository.save(Member.builder().nickname("SampleMember").build());
-        Travel travel = travelRepository.save(
-                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1))
-                        .build()
-        );
-        Visit visit = visitRepository.save(VisitFixture.create(travel, LocalDate.now()));
+        Member member = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
         VisitLog visitLog = visitLogRepository.save(VisitLogFixture.create(visit, member));
-        visit.addVisitImages(new VisitImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
 
         // when
-        visitService.deleteVisitById(visit.getId());
+        visitService.deleteVisitById(visit.getId(), member);
 
         // then
         assertAll(
@@ -212,5 +207,43 @@ class VisitServiceTest extends ServiceSliceTest {
                 () -> assertThat(visitImageRepository.findById(0L)).isEmpty(),
                 () -> assertThat(visitImageRepository.findById(1L)).isEmpty()
         );
+    }
+
+    @DisplayName("본인 것이 아닌 특정 방문 기록을 삭제하려고 하면 예외가 발생한다.")
+    @Test
+    void cannotDeleteVisitByIdIfNotOwner() {
+        // given
+        Member member = saveMember();
+        Member otherMember = saveMember();
+        Travel travel = saveTravel(member);
+        Visit visit = saveVisitWithImages(travel);
+
+        // when & then
+        assertThatThrownBy(() -> visitService.deleteVisitById(visit.getId(), otherMember))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
+    }
+
+    private Member saveMember() {
+        return memberRepository.save(Member.builder().nickname("staccato").build());
+    }
+
+    private Travel saveTravel() {
+        return travelRepository.save(
+                Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build()
+        );
+    }
+
+    private Travel saveTravel(Member member) {
+        Travel travel = Travel.builder().title("Sample Travel").startAt(LocalDate.now()).endAt(LocalDate.now().plusDays(1)).build();
+        travel.addTravelMember(member);
+
+        return travelRepository.save(travel);
+    }
+
+    private Visit saveVisitWithImages(Travel travel) {
+        Visit visit = VisitFixture.create(travel, LocalDate.now());
+        visit.addVisitImages(new VisitImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
+        return visitRepository.save(visit);
     }
 }

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -145,8 +145,11 @@ class VisitServiceTest extends ServiceSliceTest {
     @DisplayName("존재하지 않는 방문 기록을 조회하면 예외가 발생한다.")
     @Test
     void failReadVisitById() {
-        // given & when & then
-        assertThatThrownBy(() -> visitService.readVisitById(1L, null))
+        // given
+        Member member = saveMember();
+
+        // when & then
+        assertThatThrownBy(() -> visitService.readVisitById(1L, member))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 방문 기록을 찾을 수 없어요.");
     }
@@ -185,7 +188,6 @@ class VisitServiceTest extends ServiceSliceTest {
         Member otherMember = saveMember();
         Travel travel = saveTravel(member);
         Visit visit = saveVisitWithImages(travel);
-
         VisitUpdateRequest visitUpdateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
 
         // when & then
@@ -198,10 +200,11 @@ class VisitServiceTest extends ServiceSliceTest {
     @Test
     void failUpdateVisitById() {
         // given
+        Member member = saveMember();
         VisitUpdateRequest visitUpdateRequest = new VisitUpdateRequest("placeName", List.of("https://example1.com.jpg"));
 
         // when & then
-        assertThatThrownBy(() -> visitService.updateVisitById(1L, visitUpdateRequest, List.of(new MockMultipartFile("visitImagesFile", "namsan_tower.jpg".getBytes())), null))
+        assertThatThrownBy(() -> visitService.updateVisitById(1L, visitUpdateRequest, List.of(new MockMultipartFile("visitImagesFile", "namsan_tower.jpg".getBytes())), member))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 방문 기록을 찾을 수 없어요.");
     }

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -169,13 +169,10 @@ class VisitServiceTest extends ServiceSliceTest {
         assertAll(
                 () -> assertThat(foundedVisit.getPlaceName()).isEqualTo("newPlaceName"),
                 () -> assertThat(visitImageRepository.findById(1L)).isEmpty(),
-                () -> assertThat(visitImageRepository.findById(2L).get()
-                        .getImageUrl()).isEqualTo("https://existExample.com.jpg"),
+                () -> assertThat(visitImageRepository.findById(2L).get().getImageUrl()).isEqualTo("https://existExample.com.jpg"),
                 () -> assertThat(visitImageRepository.findById(3L).get().getImageUrl()).isEqualTo("visitImagesFile"),
-                () -> assertThat(visitImageRepository.findById(2L).get().getVisit()
-                        .getId()).isEqualTo(foundedVisit.getId()),
-                () -> assertThat(visitImageRepository.findById(3L).get().getVisit()
-                        .getId()).isEqualTo(foundedVisit.getId()),
+                () -> assertThat(visitImageRepository.findById(2L).get().getVisit().getId()).isEqualTo(foundedVisit.getId()),
+                () -> assertThat(visitImageRepository.findById(3L).get().getVisit().getId()).isEqualTo(foundedVisit.getId()),
                 () -> assertThat(visitImageRepository.findAll().size()).isEqualTo(2)
         );
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- #140 
## 🚩 Summary

- 방문 기록 조회, 수정 삭제에 인가 구현
- 방문 기록 생성 시에도 여행의 소유자인지 확인하는 인가 절차 추가

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
