### PR TITLE
feat: 특정 여행 상세 삭제 api 연결 #153

### DIFF
--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -29,6 +29,7 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigField("String", "BASE_URL", "${localProperties["base_url"]}")
+        buildConfigField("String", "TOKEN", "${localProperties["token"]}")
     }
 
     buildFeatures {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
@@ -4,7 +4,7 @@ import com.woowacourse.staccato.BuildConfig
 import okhttp3.Interceptor
 import okhttp3.Response
 
-class HeaderInterceptor(private val headerValue: String = DEFAULT_VALUE) : Interceptor {
+class HeaderInterceptor(private val headerValue: String = BuildConfig.TOKEN) : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
         val request =
             chain.request()
@@ -16,6 +16,5 @@ class HeaderInterceptor(private val headerValue: String = DEFAULT_VALUE) : Inter
 
     companion object {
         const val AUTHORIZATION_HEADER = "Authorization"
-        const val DEFAULT_VALUE = BuildConfig.TOKEN
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.data
 
+import com.woowacourse.staccato.BuildConfig
 import okhttp3.Interceptor
 import okhttp3.Response
 
@@ -15,9 +16,6 @@ class HeaderInterceptor(private val headerValue: String = DEFAULT_VALUE) : Inter
 
     companion object {
         const val AUTHORIZATION_HEADER = "Authorization"
-        const val DEFAULT_VALUE =
-            "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmlja25hbWUiOnsibmlja25hb" +
-                "WUiOiJzdGFjY2F0byJ9LCJjcmVhdGVkQXQiOiIyMDI0LTA4LTA2VDE0OjUwOjMwLjI2MDI2NzMwM" +
-                "CJ9.UI2PJ1xjSM5ySG8q1KuDj_mPb9Xv2KyGbc2krPCKjFU"
+        const val DEFAULT_VALUE = BuildConfig.TOKEN
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/HeaderInterceptor.kt
@@ -15,6 +15,9 @@ class HeaderInterceptor(private val headerValue: String = DEFAULT_VALUE) : Inter
 
     companion object {
         const val AUTHORIZATION_HEADER = "Authorization"
-        const val DEFAULT_VALUE = "1"
+        const val DEFAULT_VALUE =
+            "eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwibmlja25hbWUiOnsibmlja25hb" +
+                "WUiOiJzdGFjY2F0byJ9LCJjcmVhdGVkQXQiOiIyMDI0LTA4LTA2VDE0OjUwOjMwLjI2MDI2NzMwM" +
+                "CJ9.UI2PJ1xjSM5ySG8q1KuDj_mPb9Xv2KyGbc2krPCKjFU"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/ResponseResult.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/ResponseResult.kt
@@ -1,9 +1,11 @@
 package com.woowacourse.staccato.data
 
+import com.woowacourse.staccato.data.dto.Status
+
 sealed interface ResponseResult<T : Any> {
     class Success<T : Any>(val data: T) : ResponseResult<T>
 
-    class ServerError<T : Any>(val code: Int, val message: String) : ResponseResult<T>
+    class ServerError<T : Any>(val status: Status, val message: String) : ResponseResult<T>
 
     class Exception<T : Any>(val e: Throwable, val message: String) : ResponseResult<T>
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/StaccatoClient.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/StaccatoClient.kt
@@ -2,12 +2,14 @@ package com.woowacourse.staccato.data
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.woowacourse.staccato.BuildConfig
+import com.woowacourse.staccato.data.dto.ErrorResponse
 import com.woowacourse.staccato.data.timeline.TimeLineApiService
 import com.woowacourse.staccato.data.travel.TravelApiService
 import com.woowacourse.staccato.data.visit.VisitApiService
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.ResponseBody
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.scalars.ScalarsConverterFactory
@@ -50,6 +52,13 @@ object StaccatoClient {
                 jsonBuilder.asConverterFactory("application/json".toMediaType()),
             )
             .build()
+
+    fun getErrorResponse(errorBody: ResponseBody): ErrorResponse {
+        return provideRetrofit.responseBodyConverter<ErrorResponse>(
+            ErrorResponse::class.java,
+            ErrorResponse::class.java.annotations,
+        ).convert(errorBody) ?: throw IllegalArgumentException("errorBody를 변환할 수 없습니다.")
+    }
 
     private fun <T> create(service: Class<T>): T {
         return provideRetrofit.create(service)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/ErrorResponse.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/ErrorResponse.kt
@@ -1,0 +1,9 @@
+package com.woowacourse.staccato.data.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ErrorResponse(
+    val status: String,
+    val message: String,
+)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/Status.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/Status.kt
@@ -1,0 +1,7 @@
+package com.woowacourse.staccato.data.dto
+
+sealed class Status {
+    data class Code(val code: Int) : Status()
+
+    data class Message(val message: String) : Status()
+}

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
@@ -11,17 +11,17 @@ import retrofit2.http.PUT
 import retrofit2.http.Path
 
 interface TravelApiService {
-    @GET("/travels/{travelId}")
+    @GET(TRAVEL_PATH_WITH_ID)
     suspend fun getTravel(
         @Path("travelId") travelId: Long,
     ): Response<TravelResponse>
 
-    @POST("/travels")
+    @POST(TRAVELS_PATH)
     suspend fun postTravel(
         @Body travelRequest: TravelRequest,
     ): Response<String>
 
-    @PUT("/travels/{travelId}")
+    @PUT(TRAVEL_PATH_WITH_ID)
     suspend fun putTravel(
         @Path("travelId") travelId: Long,
         @Body travelRequest: TravelRequest,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
@@ -4,6 +4,7 @@ import com.woowacourse.staccato.data.dto.travel.TravelRequest
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -25,4 +26,15 @@ interface TravelApiService {
         @Path("travelId") travelId: Long,
         @Body travelRequest: TravelRequest,
     ): Response<String>
+
+    @DELETE(TRAVEL_PATH_WITH_ID)
+    suspend fun deleteTravel(
+        @Path("travelId") travelId: Long,
+    ): Response<Unit>
+
+    companion object {
+        private const val TRAVELS_PATH = "/travels"
+        private const val TRAVEL_ID = "/{travelId}"
+        private const val TRAVEL_PATH_WITH_ID = "$TRAVELS_PATH$TRAVEL_ID"
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
@@ -13,4 +13,6 @@ interface TravelDataSource {
         travelId: Long,
         newTravel: NewTravel,
     ): ResponseResult<String>
+
+    suspend fun deleteTravel(travelId: Long): ResponseResult<Unit>
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
@@ -12,7 +12,7 @@ class TravelDefaultRepository(
     override suspend fun getTravel(travelId: Long): ResponseResult<Travel> {
         return when (val responseResult = travelDataSource.getTravel(travelId)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
-            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.code, responseResult.message)
+            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(responseResult.data.toDomain())
         }
     }
@@ -20,7 +20,7 @@ class TravelDefaultRepository(
     override suspend fun createTravel(newTravel: NewTravel): ResponseResult<String> {
         return when (val responseResult = travelDataSource.createTravel(newTravel)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
-            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.code, responseResult.message)
+            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(responseResult.data)
         }
     }
@@ -31,7 +31,7 @@ class TravelDefaultRepository(
     ): ResponseResult<String> {
         return when (val responseResult = travelDataSource.updateTravel(travelId, newTravel)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
-            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.code, responseResult.message)
+            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(responseResult.data)
         }
     }
@@ -39,7 +39,7 @@ class TravelDefaultRepository(
     override suspend fun deleteTravel(travelId: Long): ResponseResult<Unit> {
         return when (val responseResult = travelDataSource.deleteTravel(travelId)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
-            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.code, responseResult.message)
+            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(Unit)
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
@@ -36,6 +36,14 @@ class TravelDefaultRepository(
         }
     }
 
+    override suspend fun deleteTravel(travelId: Long): ResponseResult<Unit> {
+        return when (val responseResult = travelDataSource.deleteTravel(travelId)) {
+            is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
+            is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.code, responseResult.message)
+            is ResponseResult.Success -> ResponseResult.Success(Unit)
+        }
+    }
+
     companion object {
         const val ERROR_MESSAGE = "예기치 않은 오류가 발생했습니다"
     }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
@@ -24,4 +24,6 @@ class TravelRemoteDataSource(
         handleApiResponse {
             travelApiService.putTravel(travelId, newTravel.toDto())
         }
+
+    override suspend fun deleteTravel(travelId: Long): ResponseResult<Unit> = handleApiResponse { travelApiService.deleteTravel(travelId) }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
@@ -13,4 +13,6 @@ interface TravelRepository {
         travelId: Long,
         newTravel: NewTravel,
     ): ResponseResult<String>
+
+    suspend fun deleteTravel(travelId: Long): ResponseResult<Unit>
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelFragment.kt
@@ -29,7 +29,7 @@ class TravelFragment :
     private val viewModel: TravelViewModel by viewModels {
         TravelViewModelFactory(TravelDefaultRepository(TravelRemoteDataSource(travelApiService)))
     }
-    private val deleteDialog = DeleteDialogFragment { findNavController().popBackStack() }
+    private val deleteDialog = DeleteDialogFragment { onConfirmClicked() }
 
     private lateinit var matesAdapter: MatesAdapter
     private lateinit var visitsAdapter: VisitsAdapter
@@ -43,6 +43,7 @@ class TravelFragment :
         initMatesAdapter()
         initVisitsAdapter()
         observeTravel()
+        observeIsDeleteSuccess()
         showErrorToast()
         viewModel.loadTravel(travelId)
     }
@@ -68,6 +69,10 @@ class TravelFragment :
         findNavController().navigate(R.id.action_travelFragment_to_visitFragment, bundle)
     }
 
+    override fun onConfirmClicked() {
+        viewModel.deleteTravel(travelId)
+    }
+
     private fun initBinding() {
         binding.lifecycleOwner = this
         binding.viewModel = viewModel
@@ -84,6 +89,15 @@ class TravelFragment :
         viewModel.travel.observe(viewLifecycleOwner) { travel ->
             matesAdapter.updateMates(travel.mates)
             visitsAdapter.updateVisits(travel.visits)
+        }
+    }
+
+    private fun observeIsDeleteSuccess() {
+        viewModel.isDeleteSuccess.observe(viewLifecycleOwner) { isDeleteSuccess ->
+            if (isDeleteSuccess) {
+                findNavController().popBackStack()
+                showToast(getString(R.string.travel_delete_complete))
+            }
         }
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelFragment.kt
@@ -12,6 +12,7 @@ import com.woowacourse.staccato.data.travel.TravelRemoteDataSource
 import com.woowacourse.staccato.databinding.FragmentTravelBinding
 import com.woowacourse.staccato.presentation.base.BindingFragment
 import com.woowacourse.staccato.presentation.common.DeleteDialogFragment
+import com.woowacourse.staccato.presentation.common.DialogHandler
 import com.woowacourse.staccato.presentation.common.ToolbarHandler
 import com.woowacourse.staccato.presentation.main.MainActivity
 import com.woowacourse.staccato.presentation.travel.adapter.MatesAdapter
@@ -24,7 +25,8 @@ import com.woowacourse.staccato.presentation.util.showToast
 class TravelFragment :
     BindingFragment<FragmentTravelBinding>(R.layout.fragment_travel),
     ToolbarHandler,
-    TravelHandler {
+    TravelHandler,
+    DialogHandler {
     private val travelId by lazy { arguments?.getLong(TRAVEL_ID_KEY) ?: throw IllegalArgumentException() }
     private val viewModel: TravelViewModel by viewModels {
         TravelViewModelFactory(TravelDefaultRepository(TravelRemoteDataSource(travelApiService)))

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelHandler.kt
@@ -1,7 +1,5 @@
 package com.woowacourse.staccato.presentation.travel
 
-import com.woowacourse.staccato.presentation.common.DialogHandler
-
-interface TravelHandler : DialogHandler {
+interface TravelHandler {
     fun onVisitClicked(visitId: Long)
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/TravelHandler.kt
@@ -1,5 +1,7 @@
 package com.woowacourse.staccato.presentation.travel
 
-interface TravelHandler {
+import com.woowacourse.staccato.presentation.common.DialogHandler
+
+interface TravelHandler : DialogHandler {
     fun onVisitClicked(visitId: Long)
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
@@ -11,6 +11,8 @@ import com.woowacourse.staccato.data.ApiResponseHandler.onSuccess
 import com.woowacourse.staccato.data.ResponseResult
 import com.woowacourse.staccato.domain.model.Travel
 import com.woowacourse.staccato.domain.repository.TravelRepository
+import com.woowacourse.staccato.presentation.common.MutableSingleLiveData
+import com.woowacourse.staccato.presentation.common.SingleLiveData
 import com.woowacourse.staccato.presentation.mapper.toUiModel
 import com.woowacourse.staccato.presentation.travel.model.TravelUiModel
 import kotlinx.coroutines.launch
@@ -24,6 +26,9 @@ class TravelViewModel(
     private val _errorMessage: MutableLiveData<String> = MutableLiveData()
     val errorMessage: LiveData<String> get() = _errorMessage
 
+    private val _isDeleteSuccess = MutableSingleLiveData<Boolean>(false)
+    val isDeleteSuccess: SingleLiveData<Boolean> get() = _isDeleteSuccess
+
     fun loadTravel(travelId: Long) {
         viewModelScope.launch {
             val result: ResponseResult<Travel> = travelRepository.getTravel(travelId)
@@ -34,8 +39,21 @@ class TravelViewModel(
         }
     }
 
+    fun deleteTravel(travelId: Long) {
+        viewModelScope.launch {
+            val result: ResponseResult<Unit> = travelRepository.deleteTravel(travelId)
+            result.onSuccess { updateIsDeleteSuccess() }
+                .onServerError(::handleServerError)
+                .onException(::handelException)
+        }
+    }
+
     private fun setTravel(travel: Travel) {
         _travel.value = travel.toUiModel()
+    }
+
+    private fun updateIsDeleteSuccess() {
+        _isDeleteSuccess.setValue(true)
     }
 
     private fun handleServerError(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
@@ -9,6 +9,7 @@ import com.woowacourse.staccato.data.ApiResponseHandler.onException
 import com.woowacourse.staccato.data.ApiResponseHandler.onServerError
 import com.woowacourse.staccato.data.ApiResponseHandler.onSuccess
 import com.woowacourse.staccato.data.ResponseResult
+import com.woowacourse.staccato.data.dto.Status
 import com.woowacourse.staccato.domain.model.Travel
 import com.woowacourse.staccato.domain.repository.TravelRepository
 import com.woowacourse.staccato.presentation.common.MutableSingleLiveData
@@ -57,22 +58,21 @@ class TravelViewModel(
     }
 
     private fun handleServerError(
-        code: Int,
+        status: Status,
         message: String,
     ) {
-        Log.d("hye: 여행 조회 실패", "$code : $message $TRAVEL_ERROR_MESSAGE")
-        _errorMessage.value = "$code : $TRAVEL_ERROR_MESSAGE"
+        _errorMessage.value = message
     }
 
     private fun handelException(
         e: Throwable,
         message: String,
     ) {
-        Log.d("hye: 여행 생성 실패 - 예외", "${e.message}")
+        Log.d("hye", e.message.toString())
         _errorMessage.value = TRAVEL_ERROR_MESSAGE
     }
 
     companion object {
-        const val TRAVEL_ERROR_MESSAGE = "여행을 조회할 수 없습니다"
+        private const val TRAVEL_ERROR_MESSAGE = "여행을 조회할 수 없습니다"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -1,6 +1,5 @@
 package com.woowacourse.staccato.presentation.travelcreation.viewmodel
 
-import android.util.Log
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -10,6 +9,7 @@ import com.woowacourse.staccato.data.ApiResponseHandler.onException
 import com.woowacourse.staccato.data.ApiResponseHandler.onServerError
 import com.woowacourse.staccato.data.ApiResponseHandler.onSuccess
 import com.woowacourse.staccato.data.ResponseResult
+import com.woowacourse.staccato.data.dto.Status
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.repository.TravelRepository
 import com.woowacourse.staccato.presentation.travelcreation.DateConverter.convertLongToLocalDate
@@ -70,11 +70,10 @@ class TravelCreationViewModel(
         )
 
     private fun handleServerError(
-        code: Int,
+        status: Status,
         message: String,
     ) {
-        _errorMessage.value = "$code : $TRAVEL_CREATION_ERROR_MESSAGE"
-        Log.d("hye: 여행 생성 실패", "$code : $message $TRAVEL_CREATION_ERROR_MESSAGE")
+        _errorMessage.value = message
     }
 
     private fun handelException(
@@ -82,7 +81,6 @@ class TravelCreationViewModel(
         message: String,
     ) {
         _errorMessage.value = TRAVEL_CREATION_ERROR_MESSAGE
-        Log.d("hye: 여행 생성 실패 - 예외", "${e.message}")
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
@@ -1,6 +1,5 @@
 package com.woowacourse.staccato.presentation.travelupdate.viewmodel
 
-import android.util.Log
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -9,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import com.woowacourse.staccato.data.ApiResponseHandler.onException
 import com.woowacourse.staccato.data.ApiResponseHandler.onServerError
 import com.woowacourse.staccato.data.ApiResponseHandler.onSuccess
+import com.woowacourse.staccato.data.dto.Status
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.model.Travel
 import com.woowacourse.staccato.domain.repository.TravelRepository
@@ -94,11 +94,10 @@ class TravelUpdateViewModel(
     }
 
     private fun handleServerError(
-        code: Int,
+        status: Status,
         message: String,
     ) {
-        _errorMessage.value = "$code: $TRAVEL_UPDATE_ERROR_MESSAGE"
-        Log.d("hye: 여행 수정 실패", "$code : $message $TRAVEL_UPDATE_ERROR_MESSAGE")
+        _errorMessage.value = message
     }
 
     private fun handelException(
@@ -106,7 +105,6 @@ class TravelUpdateViewModel(
         message: String,
     ) {
         _errorMessage.value = TRAVEL_UPDATE_ERROR_MESSAGE
-        Log.d("hye: 여행 수정 실패 - 예외", "${e.message}")
     }
 
     companion object {


### PR DESCRIPTION
## ⭐️ Issue Number

- #153 

<br>

## 🚩 Summary

https://github.com/user-attachments/assets/3970aad9-73fc-4e70-ba48-51683192aa57

- api service 구현
- data source 구현
- repository 구현
- api 연결

<br>

## 🙂 To Reviwer

- 방문 기록이 없을 때만 여행 상세가 삭제됩니다.
- To. @Junyoung-WON 
  - 여행 상세 삭제 후 타임라인에 변경된 데이터가 실시간으로 반영되지 않고 있습니다. 해당 부분 수정 부탁드려요!

<br>

## 📋 To Do

- api 명세 변경에 따른 로직 수정
