### PR TITLE
feat: 이미지가 필요한 API에 S3 적용 #166

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -3,6 +3,8 @@ name: Backend CI/CD dev
 on:
   push:
     branches: [ "develop-be" ]
+  pull_request:
+    branches: [ "develop-be" ]
 
 jobs:
   ci:

--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -3,8 +3,6 @@ name: Backend CI/CD dev
 on:
   push:
     branches: [ "develop-be" ]
-  pull_request:
-    branches: [ "develop-be" ]
 
 jobs:
   ci:

--- a/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
+++ b/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
@@ -27,7 +27,7 @@ public class CloudStorageService {
                 .toList();
     }
 
-    private String uploadFile(MultipartFile image) {
+    public String uploadFile(MultipartFile image) {
         String key = makeImagePath(image.getOriginalFilename());
         try {
             cloudStorageClient.putS3Object(key, image.getContentType(), image.getBytes());

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -103,8 +103,8 @@ public class TravelService {
         Travel originTravel = getTravelById(travelId);
         validateOwner(originTravel, member);
         if (!Objects.isNull(thumbnailFile)) {
-            // thumbnailFile을 Url로 변환해 가져오는 로직 추가 예정
-            updatedTravel.assignThumbnail(thumbnailFile.getName()); // 새롭게 추가된 이미지 파일의 url을 가지고 오는 임시 로직
+            String thumbnailUrl = uploadFile(thumbnailFile);
+            updatedTravel.assignThumbnail(thumbnailUrl);
         }
         List<Visit> visits = visitRepository.findAllByTravelIdOrderByVisitedAt(travelId);
         originTravel.update(updatedTravel, visits);

--- a/backend/src/main/java/com/staccato/travel/service/TravelService.java
+++ b/backend/src/main/java/com/staccato/travel/service/TravelService.java
@@ -45,15 +45,6 @@ public class TravelService {
         return new TravelIdResponse(travel.getId());
     }
 
-    private String uploadFile(MultipartFile thumbnailFile) {
-        if (thumbnailFile == null) {
-            return null;
-        }
-        String thumbnailUrl = cloudStorageService.uploadFile(thumbnailFile);
-
-        return thumbnailUrl;
-    }
-
     public TravelResponses readAllTravels(Member member, Integer year) {
         return Optional.ofNullable(year)
                 .map(y -> readAllByYear(member, y))
@@ -108,6 +99,15 @@ public class TravelService {
         }
         List<Visit> visits = visitRepository.findAllByTravelIdOrderByVisitedAt(travelId);
         originTravel.update(updatedTravel, visits);
+    }
+
+    private String uploadFile(MultipartFile thumbnailFile) {
+        if (Objects.isNull(thumbnailFile)) {
+            return null;
+        }
+        String thumbnailUrl = cloudStorageService.uploadFile(thumbnailFile);
+
+        return thumbnailUrl;
     }
 
     private Travel getTravelById(long travelId) {

--- a/backend/src/main/java/com/staccato/visit/controller/VisitController.java
+++ b/backend/src/main/java/com/staccato/visit/controller/VisitController.java
@@ -44,7 +44,7 @@ public class VisitController implements VisitControllerDocs {
             @Valid @RequestPart(value = "data") VisitRequest visitRequest,
             @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.") @RequestPart(value = "visitImageFiles") List<MultipartFile> visitImageFiles
     ) {
-        VisitIdResponse visitIdResponse = visitService.createVisit(visitRequest, member);
+        VisitIdResponse visitIdResponse = visitService.createVisit(visitRequest, visitImageFiles, member);
         return ResponseEntity.created(URI.create("/visits/" + visitIdResponse.visitId()))
                 .body(visitIdResponse);
     }

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -64,10 +64,10 @@ public class VisitService {
     ) {
         Visit visit = getVisitById(visitId);
         validateOwner(visit.getTravel(), member);
-        List<String> addedImages = List.of(visitImageFiles.get(0).getName()); // 새롭게 추가된 이미지 파일의 url을 가지고 오는 임시 로직
+        List<String> addedImageUrls = cloudStorageService.uploadFiles(visitImageFiles);
         VisitImages visitImages = VisitImages.builder()
                 .existingImages(visitUpdateRequest.visitImageUrls())
-                .addedImages(addedImages)
+                .addedImages(addedImageUrls)
                 .build();
 
         visit.update(visitUpdateRequest.placeName(), visitImages);

--- a/backend/src/main/java/com/staccato/visit/service/VisitService.java
+++ b/backend/src/main/java/com/staccato/visit/service/VisitService.java
@@ -9,6 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
+import com.staccato.s3.service.CloudStorageService;
 import com.staccato.travel.domain.Travel;
 import com.staccato.travel.repository.TravelRepository;
 import com.staccato.visit.domain.Visit;
@@ -27,13 +28,15 @@ import lombok.RequiredArgsConstructor;
 public class VisitService {
     private final VisitRepository visitRepository;
     private final TravelRepository travelRepository;
+    private final CloudStorageService cloudStorageService;
 
     @Transactional
-    public VisitIdResponse createVisit(VisitRequest visitRequest, Member member) {
+    public VisitIdResponse createVisit(VisitRequest visitRequest, List<MultipartFile> visitImageFiles, Member member) {
         Travel travel = getTravelById(visitRequest.travelId());
         validateOwner(travel, member);
         Visit visit = visitRequest.toVisit(travel);
-        VisitImages visitImages = new VisitImages(visitRequest.visitImageUrls());
+        List<String> visitImageUrls = cloudStorageService.uploadFiles(visitImageFiles);
+        VisitImages visitImages = new VisitImages(visitImageUrls);
         visit.addVisitImages(visitImages);
 
         visitRepository.save(visit);

--- a/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
@@ -28,8 +28,6 @@ public record VisitRequest(
         @Schema(example = "-0.12712788587027796")
         @NotNull(message = "방문한 장소의 경도를 입력해주세요.")
         BigDecimal longitude,
-        @Schema(example = "[\"http://example.com/image1.jpg\"]")
-        List<String> visitImageUrls,
         @Schema(example = "2024-07-27")
         @NotNull(message = "방문 날짜를 입력해주세요.")
         @DateTimeFormat(pattern = "yyyy-MM-dd")

--- a/backend/src/test/java/com/staccato/FakeCloudStorageClient.java
+++ b/backend/src/test/java/com/staccato/FakeCloudStorageClient.java
@@ -1,0 +1,18 @@
+package com.staccato;
+
+import com.staccato.s3.domain.CloudStorageClient;
+
+public class FakeCloudStorageClient extends CloudStorageClient {
+    public FakeCloudStorageClient() {
+        super("fakeBuket", "fakeEndPoint", "fakeCloudFrontEndPoint");
+    }
+
+    @Override
+    public void putS3Object(String objectKey, String contentType, byte[] imageBytes) {
+    }
+
+    @Override
+    public String getUrl(String keyName) {
+        return "fakeUrl";
+    }
+}

--- a/backend/src/test/java/com/staccato/ServiceSliceTest.java
+++ b/backend/src/test/java/com/staccato/ServiceSliceTest.java
@@ -2,10 +2,12 @@ package com.staccato;
 
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 
 import com.staccato.util.DatabaseCleanerExtension;
 
 @ExtendWith(DatabaseCleanerExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@Import({TestConfig.class})
 public abstract class ServiceSliceTest {
 }

--- a/backend/src/test/java/com/staccato/TestConfig.java
+++ b/backend/src/test/java/com/staccato/TestConfig.java
@@ -1,0 +1,14 @@
+package com.staccato;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import com.staccato.s3.domain.CloudStorageClient;
+
+@TestConfiguration
+public class TestConfig {
+    @Bean
+    public CloudStorageClient cloudStorageClient() {
+        return new FakeCloudStorageClient();
+    }
+}

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -56,7 +56,7 @@ class TravelServiceTest extends ServiceSliceTest {
         return Stream.of(
                 Arguments.of(
                         new TravelRequest("imageUrl", "2024 여름 휴가다!", "친한 친구들과 함께한 여름 휴가 여행", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 10)),
-                        new MockMultipartFile("travelThumbnail", "example.jpg".getBytes()), "travelThumbnail"),
+                        new MockMultipartFile("travelThumbnail", "example.jpg".getBytes()), "fakeUrl"),
                 Arguments.of(
                         new TravelRequest(null, "2024 여름 휴가다!", "친한 친구들과 함께한 여름 휴가 여행", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 10)),
                         null, null),

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -56,23 +56,23 @@ class VisitControllerTest {
     static Stream<Arguments> invalidVisitRequestProvider() {
         return Stream.of(
                 Arguments.of(
-                        new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, List.of("https://example1.com.jpg"), LocalDate.of(2023, 7, 1), 0L),
+                        new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 0L),
                         "여행 식별자는 양수로 이루어져야 합니다."
                 ),
                 Arguments.of(
-                        new VisitRequest(null, "address", BigDecimal.ONE, BigDecimal.ONE, List.of("https://example1.com.jpg"), LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest(null, "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
                         "방문한 장소의 이름을 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", "address", null, BigDecimal.ONE, List.of("https://example1.com.jpg"), LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", "address", null, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
                         "방문한 장소의 위도를 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", "address", BigDecimal.ONE, null, List.of("https://example1.com.jpg"), LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", "address", BigDecimal.ONE, null, LocalDate.of(2023, 7, 1), 1L),
                         "방문한 장소의 경도를 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", null, BigDecimal.ONE, BigDecimal.ONE, List.of("https://example1.com.jpg"), LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", null, BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
                         "방문한 장소의 주소를 입력해주세요."
                 ),
                 Arguments.of(
@@ -96,7 +96,7 @@ class VisitControllerTest {
         MockMultipartFile file5 = new MockMultipartFile("visitImageFiles", "test-image5.jpg", "image/jpeg", "dummy image content".getBytes());
         VisitIdResponse visitIdResponse = new VisitIdResponse(1L);
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
-        when(visitService.createVisit(any(VisitRequest.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
+        when(visitService.createVisit(any(VisitRequest.class), any(List.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
         mockMvc.perform(multipart("/visits")
@@ -147,7 +147,7 @@ class VisitControllerTest {
     }
 
     private static VisitRequest getVisitRequest(LocalDate visitedAt) {
-        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, List.of("https://example1.com.jpg"), visitedAt, 1L);
+        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, visitedAt, 1L);
     }
 
     @DisplayName("사용자가 잘못된 요청 형식으로 정보를 입력하면, 방문 기록을 생성할 수 없다.")
@@ -160,7 +160,7 @@ class VisitControllerTest {
         MockMultipartFile imageFilePart = new MockMultipartFile("visitImageFiles", "test-image1.jpg", "image/jpeg", "dummy image content".getBytes());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
-        when(visitService.createVisit(any(VisitRequest.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
+        when(visitService.createVisit(any(VisitRequest.class), any(List.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
 
         // when & then
         mockMvc.perform(multipart("/visits")

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -54,14 +54,14 @@ class VisitServiceTest extends ServiceSliceTest {
         saveTravel(member);
 
         // when
-        long visitId = visitService.createVisit(getVisitRequestWithoutImage(), member).visitId();
+        long visitId = visitService.createVisit(getVisitRequestWithoutImage(), List.of(), member).visitId();
 
         // then
         assertThat(visitRepository.findById(visitId)).isNotEmpty();
     }
 
     private VisitRequest getVisitRequestWithoutImage() {
-        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, List.of(), LocalDate.now(), 1L);
+        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.now(), 1L);
     }
 
     @DisplayName("방문 기록을 생성하면 Visit과 VisitImage들이 함께 저장되고 id를 반환한다.")
@@ -72,7 +72,7 @@ class VisitServiceTest extends ServiceSliceTest {
         saveTravel(member);
 
         // when
-        long visitId = visitService.createVisit(getVisitRequest(), member).visitId();
+        long visitId = visitService.createVisit(getVisitRequest(), List.of(new MockMultipartFile("visitImageFiles", "example.jpg".getBytes())), member).visitId();
 
         // then
         assertAll(
@@ -91,7 +91,7 @@ class VisitServiceTest extends ServiceSliceTest {
         VisitRequest visitRequest = getVisitRequest();
 
         // when & then
-        assertThatThrownBy(() -> visitService.createVisit(visitRequest, otherMember))
+        assertThatThrownBy(() -> visitService.createVisit(visitRequest, List.of(new MockMultipartFile("visitImageFiles", "example.jpg".getBytes())), otherMember))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
     }
@@ -103,13 +103,13 @@ class VisitServiceTest extends ServiceSliceTest {
         Member member = saveMember();
 
         // when & then
-        assertThatThrownBy(() -> visitService.createVisit(getVisitRequest(), member))
+        assertThatThrownBy(() -> visitService.createVisit(getVisitRequest(), List.of(new MockMultipartFile("visitImageFiles", "example.jpg".getBytes())), member))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 여행을 찾을 수 없어요.");
     }
 
     private VisitRequest getVisitRequest() {
-        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, List.of("https://example1.com.jpg"), LocalDate.now(), 1L);
+        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.now(), 1L);
     }
 
     @DisplayName("특정 방문 기록 조회에 성공한다.")

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -173,7 +173,7 @@ class VisitServiceTest extends ServiceSliceTest {
                 () -> assertThat(foundedVisit.getPlaceName()).isEqualTo("newPlaceName"),
                 () -> assertThat(visitImageRepository.findById(1L)).isEmpty(),
                 () -> assertThat(visitImageRepository.findById(2L).get().getImageUrl()).isEqualTo("https://existExample.com.jpg"),
-                () -> assertThat(visitImageRepository.findById(3L).get().getImageUrl()).isEqualTo("visitImagesFile"),
+                () -> assertThat(visitImageRepository.findById(3L).get().getImageUrl()).isEqualTo("fakeUrl"),
                 () -> assertThat(visitImageRepository.findById(2L).get().getVisit().getId()).isEqualTo(foundedVisit.getId()),
                 () -> assertThat(visitImageRepository.findById(3L).get().getVisit().getId()).isEqualTo(foundedVisit.getId()),
                 () -> assertThat(visitImageRepository.findAll().size()).isEqualTo(2)


### PR DESCRIPTION
## ⭐️ Issue Number
- #166 
## 🚩 Summary
S3 적용이 필요한 API들 변경
- 여행 상세 생성 API
- 여행 상세 수정 API
- 방문 기록 생성 API
- 방문 기록 수정 API

## 🛠️ Technical Concerns

## 🙂 To Reviwer

## 📋 To Do
썸네일 삭제 또는 방문 기록 사진 삭제 시 DB에는 URL이 삭제되지만 S3 파일 자체는 삭제되지 않습니다. S3에서 제공하는 delete 메서드가 우리의 service 메서드의 트랜잭션 안에 포함될 수 없어서 적용하지 못했는데, 이 문제를 고민해보고 적용해보면 좋겠어요.