### PR TITLE
feat: 로깅 프레임워크 적용 #134

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -3,6 +3,8 @@ name: Backend CI/CD dev
 on:
   push:
     branches: [ "develop-be" ]
+  pull_request:
+    branches: [ "develop-be" ]
 
 jobs:
   ci:

--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -3,8 +3,6 @@ name: Backend CI/CD dev
 on:
   push:
     branches: [ "develop-be" ]
-  pull_request:
-    branches: [ "develop-be" ]
 
 jobs:
   ci:

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -1,0 +1,8 @@
+package com.staccato.config.log;
+
+public class LogForm {
+    public static final String REQUEST_LOGGING_FORM =
+            "HTTP Method : {} " + "Request URI : {} " + "HTTP Status : {} " + "Processing Time(ms) : {}";
+    public static final String EXCEPTION_LOGGING_FORM = "Exception Response : {} ";
+    public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + "Exception Message : {}";
+}

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -1,8 +1,9 @@
 package com.staccato.config.log;
 
 public class LogForm {
+    private static final String DELIMITER = " | ";
     public static final String REQUEST_LOGGING_FORM =
-            "HTTP Method : {} " + "Request URI : {} " + "HTTP Status : {} " + "Processing Time(ms) : {}";
+            "HTTP Method : {}" + DELIMITER + "Request URI : {}" + DELIMITER + "Token : {}" + DELIMITER + "HTTP Status : {}" + DELIMITER + "Processing Time(ms) : {}";
     public static final String EXCEPTION_LOGGING_FORM = "Exception Response : {} ";
-    public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + "Exception Message : {}";
+    public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + DELIMITER + "Exception Message : {}";
 }

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -3,7 +3,7 @@ package com.staccato.config.log;
 public class LogForm {
     private static final String DELIMITER = " | ";
     public static final String REQUEST_LOGGING_FORM =
-            "HTTP Method : {}" + DELIMITER + "Request URI : {}" + DELIMITER + "Token : {}" + DELIMITER + "HTTP Status : {}" + DELIMITER + "Processing Time(ms) : {}";
+            "HTTP Method : {}" + DELIMITER + "Request URI : {}" + DELIMITER + "Token is Exist : {}" + DELIMITER + "HTTP Status : {}" + DELIMITER + "Processing Time(ms) : {}";
     public static final String EXCEPTION_LOGGING_FORM = "Exception Response : {} ";
     public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + DELIMITER + "Exception Message : {}";
 }

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -1,0 +1,31 @@
+package com.staccato.config.log;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class LoggingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        long startTime = System.currentTimeMillis();
+        filterChain.doFilter(request, response);
+        long endTime = System.currentTimeMillis();
+        long duration = endTime - startTime;
+
+        log.info(LogForm.REQUEST_LOGGING_FORM,
+                request.getMethod(),
+                request.getRequestURI(),
+                response.getStatus(),
+                duration);
+    }
+}

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -27,8 +27,12 @@ public class LoggingFilter extends OncePerRequestFilter {
         log.info(LogForm.REQUEST_LOGGING_FORM,
                 request.getMethod(),
                 request.getRequestURI(),
-                token,
+                tokenExists(token),
                 response.getStatus(),
                 duration);
+    }
+
+    private boolean tokenExists(String token) {
+        return !token.isBlank();
     }
 }

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -1,6 +1,7 @@
 package com.staccato.config.log;
 
 import java.io.IOException;
+import java.util.Objects;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -33,6 +34,6 @@ public class LoggingFilter extends OncePerRequestFilter {
     }
 
     private boolean tokenExists(String token) {
-        return !token.isBlank();
+        return !(Objects.isNull(token) || token.isBlank());
     }
 }

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -1,6 +1,7 @@
 package com.staccato.config.log;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Objects;
 
 import jakarta.servlet.FilterChain;
@@ -10,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
+    private static final List<String> WHITE_LIST = List.of("/h2-console/**", "/favicon/**", "/swagger-ui/**", "/v3/api-docs/**");
+
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         long startTime = System.currentTimeMillis();
@@ -35,5 +39,12 @@ public class LoggingFilter extends OncePerRequestFilter {
 
     private boolean tokenExists(String token) {
         return !(Objects.isNull(token) || token.isBlank());
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String requestURI = request.getRequestURI();
+        AntPathMatcher antPathMatcher = new AntPathMatcher();
+        return WHITE_LIST.stream().anyMatch(path -> antPathMatcher.match(path, requestURI));
     }
 }

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -7,6 +7,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -18,6 +19,7 @@ public class LoggingFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         long startTime = System.currentTimeMillis();
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
         filterChain.doFilter(request, response);
         long endTime = System.currentTimeMillis();
         long duration = endTime - startTime;
@@ -25,6 +27,7 @@ public class LoggingFilter extends OncePerRequestFilter {
         log.info(LogForm.REQUEST_LOGGING_FORM,
                 request.getMethod(),
                 request.getRequestURI(),
+                token,
                 response.getStatus(),
                 duration);
     }

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -26,8 +26,8 @@ public class GlobalExceptionHandler {
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
         String errorMessage = "올바르지 않은 날짜 형식입니다.";
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), errorMessage);
-        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
@@ -51,16 +51,15 @@ public class GlobalExceptionHandler {
                 .getMessage();
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
         log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
-        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         String errorMessage = "요청 본문을 읽을 수 없습니다. 올바른 형식으로 데이터를 제공해주세요.";
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
-        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
-        return ResponseEntity.badRequest().body(exceptionResponse);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), errorMessage);
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
     }
 
     @ExceptionHandler(S3Exception.class)

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -58,17 +58,16 @@ public class GlobalExceptionHandler {
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         String errorMessage = "요청 본문을 읽을 수 없습니다. 올바른 형식으로 데이터를 제공해주세요.";
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), errorMessage);
-        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
-        return ResponseEntity.internalServerError().body(exceptionResponse);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(S3Exception.class)
     public ResponseEntity<ExceptionResponse> handleS3Exception(S3Exception e) {
         String errorMessage = "이미지 처리에 실패했습니다.";
         log.warn("ExceptionType : {}, ExceptionMessage : {}", e, errorMessage);
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage));
+        return ResponseEntity.badRequest().body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage));
     }
 
     @ExceptionHandler(StaccatoException.class)

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -51,6 +51,7 @@ public class GlobalExceptionHandler {
                 .getMessage();
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
         log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -13,6 +13,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import com.staccato.config.log.LogForm;
+
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -24,20 +26,20 @@ public class GlobalExceptionHandler {
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
         String errorMessage = "올바르지 않은 날짜 형식입니다.";
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, errorMessage);
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleValidationException(MethodArgumentNotValidException e) {
-        String message = Optional.ofNullable(e.getBindingResult().getFieldError())
+        String errorMessage = Optional.ofNullable(e.getBindingResult().getFieldError())
                 .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .orElse("요청 형식이 잘못되었습니다.");
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, message);
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), message));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -47,18 +49,18 @@ public class GlobalExceptionHandler {
                 .iterator()
                 .next()
                 .getMessage();
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, errorMessage);
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
         String errorMessage = "요청 본문을 읽을 수 없습니다. 올바른 형식으로 데이터를 제공해주세요.";
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, errorMessage);
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(S3Exception.class)
@@ -72,33 +74,32 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(StaccatoException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleStaccatoException(StaccatoException e) {
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
-        return ResponseEntity.badRequest()
-                .body(new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage()));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 
     @ExceptionHandler(UnauthorizedException.class)
     @ApiResponse(description = "사용자 인증 실패", responseCode = "401")
     public ResponseEntity<ExceptionResponse> handleUnauthorizedException(UnauthorizedException e) {
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage());
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(exceptionResponse);
     }
-
 
     @ExceptionHandler(ForbiddenException.class)
     @ApiResponse(description = "사용자가 권한을 가지고 있지 않은 작업을 시도 시 발생", responseCode = "403")
     public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                .body(new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage()));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.FORBIDDEN.toString(), e.getMessage());
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
     }
 
     @ExceptionHandler(RuntimeException.class)
     @ApiResponse(responseCode = "500")
     public ResponseEntity<ExceptionResponse> handleInternalServerErrorException(RuntimeException e) {
-        log.warn("ExceptionType : {}, ExceptionMessage : {}", e, e.getMessage());
-        return ResponseEntity.internalServerError()
-                .body(new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), "예기치 못한 서버 오류입니다. 다시 시도해주세요."));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), "예기치 못한 서버 오류입니다. 다시 시도해주세요.");
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
     }
 }

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -26,8 +26,8 @@ public class GlobalExceptionHandler {
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
         String errorMessage = "올바르지 않은 날짜 형식입니다.";
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
-        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), errorMessage);
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
 

--- a/backend/src/main/resources/console-appender.xml
+++ b/backend/src/main/resources/console-appender.xml
@@ -1,0 +1,7 @@
+<included>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [%thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
+        </encoder>
+    </appender>
+</included>

--- a/backend/src/main/resources/console-appender.xml
+++ b/backend/src/main/resources/console-appender.xml
@@ -1,7 +1,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [%thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [thread = %thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
     </appender>
 </included>

--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -8,7 +8,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>

--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/error/error-${BY_DATE}.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>15</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/info/info-${BY_DATE}.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>INFO</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>15</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration>
+    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
+    <springProfile name="dev">
+        <include resource="error-appender.xml"/>
+        <include resource="warn-appender.xml"/>
+        <include resource="info-appender.xml"/>
+
+        <root level="info">
+            <appender-ref ref="INFO"/>
+            <appender-ref ref="ERROR"/>
+            <appender-ref ref="WARN"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="local">
+        <include resource="console-appender.xml"/>
+        <root level="info">
+            <appender-ref ref="STDOUT"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/backend/src/main/resources/warn-appender.xml
+++ b/backend/src/main/resources/warn-appender.xml
@@ -1,0 +1,20 @@
+<included>
+    <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>./logs/warn/warn-${BY_DATE}.log</file>
+
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>WARN</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>15</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+</included>

--- a/backend/src/main/resources/warn-appender.xml
+++ b/backend/src/main/resources/warn-appender.xml
@@ -8,7 +8,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level %logger{35} [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>


### PR DESCRIPTION
## ⭐️ Issue Number
- #134 

## 🚩 Summary

### 로깅 레벨
- `INFO`

### 로깅 단위
- filter에서 요청, 응답 → `INFO`
- application level error : 500 외 → `WARN`
- application level error : 500 → `ERROR`

## 🛠️ Technical Concerns
- `filter`에서 `memberId` 추출 방식 고민

## 🙂 To Reviwer

## 📋 To Do

- [ ]  request 로깅에 memberId가 함께 올 수 있도록
- [x]  로깅 제외 URI 목록 정하기
- [ ]  DEBUG 레벨 로깅
