### PR TITLE
feat: 방문 기록 목록 조회시 시간 순으로도 정렬되는 기능 구현

### DIFF
--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.staccato.exception;
 
-import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 import jakarta.validation.ConstraintViolationException;
@@ -22,14 +21,14 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-    @ExceptionHandler(DateTimeParseException.class)
-    @ApiResponse(responseCode = "400")
-    public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
-        String errorMessage = "올바르지 않은 날짜 형식입니다.";
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
-        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
-        return ResponseEntity.badRequest().body(exceptionResponse);
-    }
+//    @ExceptionHandler(DateTimeParseException.class)
+//    @ApiResponse(responseCode = "400")
+//    public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
+//        String errorMessage = "올바르지 않은 날짜 형식입니다.";
+//        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
+//        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
+//        return ResponseEntity.badRequest().body(exceptionResponse);
+//    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ApiResponse(responseCode = "400")

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
@@ -13,7 +13,7 @@ public record MemberResponse(
         String nickname,
         @Schema(example = "https://example.com/members/profile.jpg")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String memberImage
+        String memberImageUrl
 ) {
     public MemberResponse(Member member) {
         this(member.getId(), member.getNickname().getNickname(), member.getImageUrl());

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -1,6 +1,8 @@
 package com.staccato.travel.domain;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.chrono.ChronoLocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -82,15 +84,15 @@ public class Travel extends BaseEntity {
 
     private void validateDuration(Travel updatedTravel, List<Visit> visits) {
         visits.stream()
-                .filter(visit -> updatedTravel.isWithoutDuration(visit.getVisitedAt().toLocalDate()))
+                .filter(visit -> updatedTravel.isWithoutDuration(visit.getVisitedAt()))
                 .findAny()
                 .ifPresent(visit -> {
                     throw new StaccatoException("변경하려는 여행 기간이 이미 존재하는 방문 기록을 포함하지 않습니다. 여행 기간을 다시 설정해주세요.");
                 });
     }
 
-    public boolean isWithoutDuration(LocalDate date) {
-        return startAt.isAfter(date) || endAt.isBefore(date);
+    public boolean isWithoutDuration(LocalDateTime date) {
+        return startAt.isAfter(ChronoLocalDate.from(date)) || endAt.isBefore(ChronoLocalDate.from(date));
     }
 
     public List<Member> getMates() {

--- a/backend/src/main/java/com/staccato/travel/domain/Travel.java
+++ b/backend/src/main/java/com/staccato/travel/domain/Travel.java
@@ -82,7 +82,7 @@ public class Travel extends BaseEntity {
 
     private void validateDuration(Travel updatedTravel, List<Visit> visits) {
         visits.stream()
-                .filter(visit -> updatedTravel.isWithoutDuration(visit.getVisitedAt()))
+                .filter(visit -> updatedTravel.isWithoutDuration(visit.getVisitedAt().toLocalDate()))
                 .findAny()
                 .ifPresent(visit -> {
                     throw new StaccatoException("변경하려는 여행 기간이 이미 존재하는 방문 기록을 포함하지 않습니다. 여행 기간을 다시 설정해주세요.");

--- a/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
@@ -14,7 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "여행 상세를 생성/수정하기 위한 요청 형식입니다.")
 public record TravelRequest(
         @Schema(example = "http://example.com/london.png")
-        String travelThumbnail,
+        String travelThumbnailUrl,
         @Schema(example = "런던 여행")
         @NotNull(message = "여행 제목을 입력해주세요.")
         @Size(max = 30, message = "제목의 최대 허용 글자수는 공백 포함 30자입니다.")
@@ -32,7 +32,7 @@ public record TravelRequest(
         LocalDate endAt) {
     public Travel toTravel() {
         return Travel.builder()
-                .thumbnailUrl(travelThumbnail)
+                .thumbnailUrl(travelThumbnailUrl)
                 .title(travelTitle)
                 .description(description)
                 .startAt(startAt)

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelDetailResponse.java
@@ -15,7 +15,7 @@ public record TravelDetailResponse(
         Long travelId,
         @Schema(example = "https://example.com/travels/geumohrm.jpg")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String travelThumbnail,
+        String travelThumbnailUrl,
         @Schema(example = "런던 여행")
         String travelTitle,
         @Schema(example = "런던 시내 탐방")

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/TravelResponse.java
@@ -16,7 +16,7 @@ public record TravelResponse(
         Long travelId,
         @Schema(example = "https://example.com/travels/geumohrm.jpg")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String travelThumbnail,
+        String travelThumbnailUrl,
         @Schema(example = "런던 여행")
         String travelTitle,
         @Schema(example = "런던 시내 탐방")

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/VisitResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/VisitResponse.java
@@ -15,7 +15,7 @@ public record VisitResponse(
         String placeName,
         @Schema(example = "https://example.com/travels/london_eye.jpg")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String visitImage,
+        String visitImageUrl,
         @Schema(example = "2024-07-27")
         LocalDate visitedAt
 ) {

--- a/backend/src/main/java/com/staccato/travel/service/dto/response/VisitResponse.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/response/VisitResponse.java
@@ -20,6 +20,6 @@ public record VisitResponse(
         LocalDate visitedAt
 ) {
     public VisitResponse(Visit visit, String visitImage) {
-        this(visit.getId(), visit.getPlaceName(), visitImage, visit.getVisitedAt());
+        this(visit.getId(), visit.getPlaceName(), visitImage, visit.getVisitedAt().toLocalDate());
     }
 }

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -66,7 +66,7 @@ public class Visit extends BaseEntity {
     }
 
     private void validateIsWithinTravelDuration(LocalDateTime visitedAt, Travel travel) {
-        if (travel.isWithoutDuration(visitedAt.toLocalDate())) {
+        if (travel.isWithoutDuration(visitedAt)) {
             throw new StaccatoException("여행에 포함되지 않는 날짜입니다.");
         }
     }

--- a/backend/src/main/java/com/staccato/visit/domain/Visit.java
+++ b/backend/src/main/java/com/staccato/visit/domain/Visit.java
@@ -1,7 +1,7 @@
 package com.staccato.visit.domain;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,7 +35,7 @@ public class Visit extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     @Column(nullable = false)
-    private LocalDate visitedAt;
+    private LocalDateTime visitedAt;
     @Column(nullable = false)
     private String placeName;
     @Column(nullable = false)
@@ -51,7 +51,7 @@ public class Visit extends BaseEntity {
 
     @Builder
     public Visit(
-            @NonNull LocalDate visitedAt,
+            @NonNull LocalDateTime visitedAt,
             @NonNull String placeName,
             @NonNull String address,
             @NonNull BigDecimal latitude,
@@ -65,8 +65,8 @@ public class Visit extends BaseEntity {
         this.travel = travel;
     }
 
-    private void validateIsWithinTravelDuration(LocalDate visitedAt, Travel travel) {
-        if (travel.isWithoutDuration(visitedAt)) {
+    private void validateIsWithinTravelDuration(LocalDateTime visitedAt, Travel travel) {
+        if (travel.isWithoutDuration(visitedAt.toLocalDate())) {
             throw new StaccatoException("여행에 포함되지 않는 날짜입니다.");
         }
     }

--- a/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
@@ -1,8 +1,7 @@
 package com.staccato.visit.service.dto.request;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.List;
+import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -31,7 +30,7 @@ public record VisitRequest(
         @Schema(example = "2024-07-27")
         @NotNull(message = "방문 날짜를 입력해주세요.")
         @DateTimeFormat(pattern = "yyyy-MM-dd")
-        LocalDate visitedAt,
+        LocalDateTime visitedAt,
         @Schema(example = "1")
         @NotNull(message = "여행 상세를 선택해주세요.")
         @Min(value = 1L, message = "여행 식별자는 양수로 이루어져야 합니다.")

--- a/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
@@ -29,7 +29,7 @@ public record VisitRequest(
         BigDecimal longitude,
         @Schema(example = "2024-07-27")
         @NotNull(message = "방문 날짜를 입력해주세요.")
-        @DateTimeFormat(pattern = "yyyy-MM-dd")
+        @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime visitedAt,
         @Schema(example = "1")
         @NotNull(message = "여행 상세를 선택해주세요.")

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitDetailResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitDetailResponse.java
@@ -29,7 +29,7 @@ public record VisitDetailResponse(
                 visit.getId(),
                 visit.getPlaceName(),
                 visit.getVisitImages().getImages().stream().map(VisitImage::getImageUrl).toList(),
-                visit.getVisitedAt(),
+                visit.getVisitedAt().toLocalDate(),
                 visit.getSpot().getAddress(),
                 visit.getVisitLogs().stream().map(VisitLogResponse::new).toList()
         );

--- a/backend/src/main/java/com/staccato/visit/service/dto/response/VisitLogResponse.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/response/VisitLogResponse.java
@@ -15,7 +15,7 @@ public record VisitLogResponse(
         String nickname,
         @Schema(example = "https://example.com/images/kargo.jpg")
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String memberImage,
+        String memberImageUrl,
         @Schema(example = "즐거운 여행")
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String content

--- a/backend/src/test/java/com/staccato/travel/controller/TravelControllerTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelControllerTest.java
@@ -92,7 +92,7 @@ class TravelControllerTest {
     @MethodSource("travelRequestProvider")
     void createTravel(TravelRequest travelRequest) throws Exception {
         // given
-        MockMultipartFile file = new MockMultipartFile("travelThumbnail", "example.jpg".getBytes());
+        MockMultipartFile file = new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes());
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
         when(travelService.createTravel(any(), any(), any())).thenReturn(new TravelIdResponse(1));
 
@@ -172,7 +172,7 @@ class TravelControllerTest {
     void updateTravel(TravelRequest travelRequest) throws Exception {
         // given
         long travelId = 1L;
-        MockMultipartFile file = new MockMultipartFile("travelThumbnail", "example.jpg".getBytes());
+        MockMultipartFile file = new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes());
         when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
 
         // when & then

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -40,7 +40,7 @@ class TravelTest {
                 .build();
 
         // when & then
-        assertThat(travel.isWithoutDuration(LocalDate.of(2023, 7, 11))).isTrue();
+        assertThat(travel.isWithoutDuration(LocalDateTime.of(2023, 7, 11, 10, 0))).isTrue();
     }
 
     @DisplayName("여행 상세를 수정 시 기존 방문 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")

--- a/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
+++ b/backend/src/test/java/com/staccato/travel/domain/TravelTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatCode;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -60,7 +61,7 @@ class TravelTest {
                 .nickname("staccato")
                 .build();
         Visit visit = Visit.builder()
-                .visitedAt(LocalDate.now())
+                .visitedAt(LocalDateTime.now())
                 .placeName("placeName")
                 .latitude(BigDecimal.ONE)
                 .longitude(BigDecimal.ONE)

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -57,7 +57,7 @@ class TravelServiceTest extends ServiceSliceTest {
         return Stream.of(
                 Arguments.of(
                         new TravelRequest("imageUrl", "2024 여름 휴가다!", "친한 친구들과 함께한 여름 휴가 여행", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 10)),
-                        new MockMultipartFile("travelThumbnail", "example.jpg".getBytes()), "fakeUrl"),
+                        new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes()), "fakeUrl"),
                 Arguments.of(
                         new TravelRequest(null, "2024 여름 휴가다!", "친한 친구들과 함께한 여름 휴가 여행", LocalDate.of(2024, 8, 1), LocalDate.of(2024, 8, 10)),
                         null, null),
@@ -179,7 +179,7 @@ class TravelServiceTest extends ServiceSliceTest {
     void updateTravel(TravelRequest updatedTravel, MockMultipartFile updatedFile, String expected) {
         // given
         Member member = saveMember();
-        MockMultipartFile file = new MockMultipartFile("travelThumbnail", "example.jpg".getBytes());
+        MockMultipartFile file = new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes());
         TravelIdResponse travelResponse = travelService.createTravel(createTravelRequest(2024), file, member);
 
         // when
@@ -203,7 +203,7 @@ class TravelServiceTest extends ServiceSliceTest {
         // given
         Member member = saveMember();
         TravelRequest travelRequest = createTravelRequest(2023);
-        MockMultipartFile file = new MockMultipartFile("travelThumbnail", "example.jpg".getBytes());
+        MockMultipartFile file = new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes());
 
         // when & then
         assertThatThrownBy(() -> travelService.updateTravel(travelRequest, 1L, file, member))
@@ -229,7 +229,7 @@ class TravelServiceTest extends ServiceSliceTest {
         Member otherMember = saveMember();
         TravelRequest updatedTravel = createTravelRequest(2023);
         TravelIdResponse travelIdResponse = travelService.createTravel(createTravelRequest(2023), null, member);
-        MockMultipartFile file = new MockMultipartFile("travelThumbnail", "example.jpg".getBytes());
+        MockMultipartFile file = new MockMultipartFile("travelThumbnailUrl", "example.jpg".getBytes());
 
         // when & then
         assertThatThrownBy(() -> travelService.updateTravel(updatedTravel, travelIdResponse.travelId(), file, otherMember))

--- a/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
+++ b/backend/src/test/java/com/staccato/travel/service/TravelServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.DisplayName;
@@ -139,8 +140,9 @@ class TravelServiceTest extends ServiceSliceTest {
         Member member = saveMember();
 
         TravelIdResponse travelIdResponse = travelService.createTravel(createTravelRequest(2023), null, member);
-        Visit visit = saveVisit(LocalDate.of(2023, 7, 1), travelIdResponse.travelId());
-        Visit nextVisit = saveVisit(LocalDate.of(2023, 7, 5), travelIdResponse.travelId());
+        Visit firstVisit = saveVisit(LocalDateTime.of(2023, 7, 1, 10, 0), travelIdResponse.travelId());
+        Visit secondVisit = saveVisit(LocalDateTime.of(2023, 7, 1, 10, 10), travelIdResponse.travelId());
+        Visit lastVisit = saveVisit(LocalDateTime.of(2023, 7, 5, 9, 0), travelIdResponse.travelId());
 
         // when
         TravelDetailResponse travelDetailResponse = travelService.readTravelById(travelIdResponse.travelId(), member);
@@ -148,13 +150,13 @@ class TravelServiceTest extends ServiceSliceTest {
         // then
         assertAll(
                 () -> assertThat(travelDetailResponse.travelId()).isEqualTo(travelIdResponse.travelId()),
-                () -> assertThat(travelDetailResponse.visits()).hasSize(2),
-                () -> assertThat(travelDetailResponse.visits().stream().map(VisitResponse::visitedAt).toList())
-                        .containsExactly(visit.getVisitedAt(), nextVisit.getVisitedAt())
+                () -> assertThat(travelDetailResponse.visits()).hasSize(3),
+                () -> assertThat(travelDetailResponse.visits().stream().map(VisitResponse::visitId).toList())
+                        .containsExactly(firstVisit.getId(), secondVisit.getId(), lastVisit.getId())
         );
     }
 
-    private Visit saveVisit(LocalDate visitedAt, long travelId) {
+    private Visit saveVisit(LocalDateTime visitedAt, long travelId) {
         return visitRepository.save(VisitFixture.create(travelRepository.findById(travelId).get(), visitedAt));
     }
 
@@ -272,7 +274,7 @@ class TravelServiceTest extends ServiceSliceTest {
         // given
         Member member = saveMember();
         TravelIdResponse travelIdResponse = travelService.createTravel(createTravelRequest(2023), null, member);
-        saveVisit(LocalDate.of(2024, 7, 10), travelIdResponse.travelId());
+        saveVisit(LocalDateTime.of(2024, 7, 10, 10, 0), travelIdResponse.travelId());
 
         // when & then
         assertThatThrownBy(() -> travelService.deleteTravel(travelIdResponse.travelId(), member))

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -13,6 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -56,23 +57,23 @@ class VisitControllerTest {
     static Stream<Arguments> invalidVisitRequestProvider() {
         return Stream.of(
                 Arguments.of(
-                        new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 0L),
+                        new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 0L),
                         "여행 식별자는 양수로 이루어져야 합니다."
                 ),
                 Arguments.of(
-                        new VisitRequest(null, "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest(null, "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
                         "방문한 장소의 이름을 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", "address", null, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", "address", null, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
                         "방문한 장소의 위도를 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", "address", BigDecimal.ONE, null, LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", "address", BigDecimal.ONE, null, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
                         "방문한 장소의 경도를 입력해주세요."
                 ),
                 Arguments.of(
-                        new VisitRequest("placeName", null, BigDecimal.ONE, BigDecimal.ONE, LocalDate.of(2023, 7, 1), 1L),
+                        new VisitRequest("placeName", null, BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
                         "방문한 장소의 주소를 입력해주세요."
                 ),
                 Arguments.of(
@@ -86,7 +87,7 @@ class VisitControllerTest {
     @Test
     void createVisit() throws Exception {
         // given
-        VisitRequest visitRequest = getVisitRequest(LocalDate.now());
+        VisitRequest visitRequest = getVisitRequest(LocalDateTime.now());
         String visitRequestJson = objectMapper.writeValueAsString(visitRequest);
         MockMultipartFile visitRequestPart = new MockMultipartFile("data", "visitRequest.json", "application/json", visitRequestJson.getBytes());
         MockMultipartFile file1 = new MockMultipartFile("visitImageFiles", "test-image1.jpg", "image/jpeg", "dummy image content".getBytes());
@@ -117,7 +118,7 @@ class VisitControllerTest {
     @Test
     void failCreateVisitByImageCount() throws Exception {
         // given
-        VisitRequest visitRequest = getVisitRequest(LocalDate.now());
+        VisitRequest visitRequest = getVisitRequest(LocalDateTime.now());
         String visitRequestJson = objectMapper.writeValueAsString(visitRequest);
         MockMultipartFile visitRequestPart = new MockMultipartFile("data", "visitRequest.json", "application/json", visitRequestJson.getBytes());
         MockMultipartFile file1 = new MockMultipartFile("visitImageFiles", "test-image1.jpg", "image/jpeg", "dummy image content".getBytes());
@@ -146,7 +147,7 @@ class VisitControllerTest {
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
     }
 
-    private static VisitRequest getVisitRequest(LocalDate visitedAt) {
+    private static VisitRequest getVisitRequest(LocalDateTime visitedAt) {
         return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, visitedAt, 1L);
     }
 

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.math.BigDecimal;
@@ -112,6 +113,45 @@ class VisitControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/visits/1"))
                 .andExpect(content().json(objectMapper.writeValueAsString(visitIdResponse)));
+    }
+
+    @DisplayName("올바르지 않은 날짜 형식으로 방문 기록 생성을 요청하면 예외가 발생한다.")
+    @Test
+    void failCreateVisitWithInvalidVistedAt() throws Exception {
+        // given
+        String visitRequestJson = """
+            {
+                "placeName": "런던 박물관",
+                "address": "Great Russell St, London WC1B 3DG",
+                "latitude": 51.51978412729915,
+                "longitude": -0.12712788587027796,
+                "visitedAt": "2024/07/27T10:00:00",
+                "travelId": 1
+            }
+        """;
+        MockMultipartFile visitRequestPart = new MockMultipartFile(
+                "data",
+                "",
+                "application/json",
+                visitRequestJson.getBytes()
+        );
+        MockMultipartFile visitImageFiles = new MockMultipartFile(
+                "visitImageFiles",
+                "",
+                "application/json",
+                objectMapper.writeValueAsString(List.of()).getBytes()
+        );
+        when(authService.extractFromToken(anyString())).thenReturn(Member.builder().nickname("staccato").build());
+        when(visitService.createVisit(any(VisitRequest.class), any(List.class), any(Member.class))).thenReturn(new VisitIdResponse(1L));
+
+        // when & then
+        mockMvc.perform(multipart("/visits")
+                        .file(visitRequestPart)
+                        .file(visitImageFiles)
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("요청 본문을 읽을 수 없습니다. 올바른 형식으로 데이터를 제공해주세요."));
     }
 
     @DisplayName("사진이 5장을 초과하면 방문 기록 생성에 실패한다.")

--- a/backend/src/test/java/com/staccato/visit/domain/VisitImagesTest.java
+++ b/backend/src/test/java/com/staccato/visit/domain/VisitImagesTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -45,7 +46,7 @@ class VisitImagesTest {
         VisitImages updatedImages = new VisitImages(List.of("picture1", "picture4"));
 
         // when
-        existingImages.update(updatedImages, VisitFixture.create(travel, LocalDate.now()));
+        existingImages.update(updatedImages, VisitFixture.create(travel, LocalDateTime.now()));
 
         // then
         List<String> images = existingImages.getImages().stream().map(VisitImage::getImageUrl).toList();

--- a/backend/src/test/java/com/staccato/visit/domain/VisitTest.java
+++ b/backend/src/test/java/com/staccato/visit/domain/VisitTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ class VisitTest {
 
         // when & then
         assertThatCode(() -> Visit.builder()
-                .visitedAt(LocalDate.now().plusDays(1))
+                .visitedAt(LocalDateTime.now().plusDays(1))
                 .placeName("placeName")
                 .latitude(BigDecimal.ONE)
                 .longitude(BigDecimal.ONE)
@@ -49,7 +50,7 @@ class VisitTest {
 
         // when & then
         assertThatThrownBy(() -> Visit.builder()
-                .visitedAt(LocalDate.now().plusDays(plusDays))
+                .visitedAt(LocalDateTime.now().plusDays(plusDays))
                 .placeName("placeName")
                 .latitude(BigDecimal.ONE)
                 .longitude(BigDecimal.ONE)

--- a/backend/src/test/java/com/staccato/visit/fixture/VisitFixture.java
+++ b/backend/src/test/java/com/staccato/visit/fixture/VisitFixture.java
@@ -1,7 +1,7 @@
 package com.staccato.visit.fixture;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.staccato.travel.domain.Travel;
 import com.staccato.visit.domain.Visit;
@@ -10,7 +10,7 @@ public class VisitFixture {
     private static final BigDecimal latitude = new BigDecimal("37.7749");
     private static final BigDecimal longitude = new BigDecimal("-122.4194");
 
-    public static Visit create(Travel travel, LocalDate visitedAt) {
+    public static Visit create(Travel travel, LocalDateTime visitedAt) {
         return Visit.builder()
                 .visitedAt(visitedAt)
                 .placeName("placeName")

--- a/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
+++ b/backend/src/test/java/com/staccato/visit/service/VisitServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -61,7 +62,7 @@ class VisitServiceTest extends ServiceSliceTest {
     }
 
     private VisitRequest getVisitRequestWithoutImage() {
-        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.now(), 1L);
+        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.now(), 1L);
     }
 
     @DisplayName("방문 기록을 생성하면 Visit과 VisitImage들이 함께 저장되고 id를 반환한다.")
@@ -109,7 +110,7 @@ class VisitServiceTest extends ServiceSliceTest {
     }
 
     private VisitRequest getVisitRequest() {
-        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDate.now(), 1L);
+        return new VisitRequest("placeName", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.now(), 1L);
     }
 
     @DisplayName("특정 방문 기록 조회에 성공한다.")
@@ -257,7 +258,7 @@ class VisitServiceTest extends ServiceSliceTest {
     }
 
     private Visit saveVisitWithImages(Travel travel) {
-        Visit visit = VisitFixture.create(travel, LocalDate.now());
+        Visit visit = VisitFixture.create(travel, LocalDateTime.now());
         visit.addVisitImages(new VisitImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
         return visitRepository.save(visit);
     }


### PR DESCRIPTION
## ⭐️ Issue Number
- #173 

## 🚩 Summary
- Visit의 visitedAt이 LocalDate -> LocalDateTime으로 변경
- 이에 따라 변경이 필요한 테스트 코드들 수정
- 시간까지 고려하여 정렬이 잘 되는지 테스트 코드 수정
- visitedAt이 포함된 각종 response dto의 경우, 시간까지는 필요하지 않으므로 기존과 같이 LocalDate 사용

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
`visitedAt`이 `yyyy-MM-dd'T'HH:mm:ss` 형식으로 오지 않았을 때, 아래의 `ExceptionHandler` 메서드가 동작할 것으로 기대했습니다.
```java
    @ExceptionHandler(DateTimeParseException.class)
    @ApiResponse(responseCode = "400")
    public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
        String errorMessage = "올바르지 않은 날짜 형식입니다.";
        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
        return ResponseEntity.badRequest().body(exceptionResponse);
    }
```
그런데 위 메서드가 작동하지 않고 아래 메서드가 작동합니다.
```java
    @ExceptionHandler(HttpMessageNotReadableException.class)
    @ApiResponse(responseCode = "400")
    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
        String errorMessage = "요청 본문을 읽을 수 없습니다. 올바른 형식으로 데이터를 제공해주세요.";
        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
        return ResponseEntity.badRequest().body(exceptionResponse);
    }
```

더 구체적인 예외 메시지를 던지기 위해 방법을 생각해봐야 할 것으로 보입니다.