### PR TITLE
refactor: 파일 이름 및 형식 오류 수정 #176

### DIFF
--- a/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
+++ b/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
@@ -45,8 +45,7 @@ public class CloudStorageService {
 
     private String generateUniqueFileName(String fileName) {
         String fileExtension = getFileExtension(fileName);
-        String baseName = getBaseName(fileName);
-        return baseName + "_" + UUID.randomUUID() + fileExtension;
+        return UUID.randomUUID() + fileExtension;
     }
 
     private String getFileExtension(String fileName) {
@@ -55,14 +54,6 @@ public class CloudStorageService {
             return "";
         }
         return fileName.substring(dotIndex);
-    }
-
-    private String getBaseName(String fileName) {
-        int dotIndex = fileName.lastIndexOf('.');
-        if (dotIndex == -1) {
-            return fileName;
-        }
-        return fileName.substring(0, dotIndex);
     }
 
     public void deleteFiles(List<String> imageUrls) {

--- a/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
+++ b/backend/src/main/java/com/staccato/s3/service/CloudStorageService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class CloudStorageService {
+    private static final String CONTENT_TYPE = "multipart/formed-data";
     private static final String TEAM_FOLDER = "staccato/";
     private static final String IMAGE_FOLDER = "image/";
 
@@ -30,7 +31,7 @@ public class CloudStorageService {
     public String uploadFile(MultipartFile image) {
         String key = makeImagePath(image.getOriginalFilename());
         try {
-            cloudStorageClient.putS3Object(key, image.getContentType(), image.getBytes());
+            cloudStorageClient.putS3Object(key, CONTENT_TYPE, image.getBytes());
         } catch (IOException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
## ⭐️ Issue Number
- #176 

## 🚩 Summary
< 파일 이름을 `UUID`로만 구성하도록 수정 >
- 파일 이름에 한글이 들어가는 경우 깨지는 현상이 발생하여, UUID로만 파일 이름을 구성하도록 변경했습니다.
- 파일 이름이 깨지면, S3에서 url 클릭 시, 이미지를 띄우는 대신 이미지를 다운로드 해버리는 현상도 추가로 발견해서 고치고자 이를 수행했습니다.

< `Content-type`을 `multipart/formed-data`로 고정 >
- S3에서 파일 유형이 빈 채로 전달되는 것을 확인
- `Content-type`이 `multipart/formed-data`인 경우 파일 유형을 잘 인식했습니다.
- 따라서 값을 하나로 고정시켜 파일 형식을 자동으로 읽도록 변경했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
