### PR TITLE
feat: 여행 생성 기능 api 수정 #169

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TimelineMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TimelineMapper.kt
@@ -17,7 +17,7 @@ fun TimelineResponse.toDomain(): Timeline {
 fun TimelineTravelDto.toDomain(): Travel {
     return Travel(
         travelId = travelId,
-        travelThumbnailUrl = travelThumbnail,
+        travelThumbnailUrl = travelThumbnailUrl,
         travelTitle = travelTitle,
         startAt = LocalDate.parse(startAt),
         endAt = LocalDate.parse(endAt),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TimelineMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TimelineMapper.kt
@@ -17,7 +17,7 @@ fun TimelineResponse.toDomain(): Timeline {
 fun TimelineTravelDto.toDomain(): Travel {
     return Travel(
         travelId = travelId,
-        travelThumbnail = travelThumbnail,
+        travelThumbnailUrl = travelThumbnail,
         travelTitle = travelTitle,
         startAt = LocalDate.parse(startAt),
         endAt = LocalDate.parse(endAt),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
@@ -30,7 +30,6 @@ fun TravelVisitDto.toDomain() =
 
 fun NewTravel.toDto() =
     TravelRequest(
-        travelThumbnail = travelThumbnail,
         travelTitle = travelTitle,
         description = description,
         startAt = startAt.toString(),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 fun TravelResponse.toDomain() =
     Travel(
         travelId = travelId,
-        travelThumbnail = travelThumbnail,
+        travelThumbnailUrl = travelThumbnail,
         travelTitle = travelTitle,
         startAt = LocalDate.parse(startAt),
         endAt = LocalDate.parse(endAt),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
@@ -11,7 +11,7 @@ import java.time.LocalDate
 fun TravelResponse.toDomain() =
     Travel(
         travelId = travelId,
-        travelThumbnailUrl = travelThumbnail,
+        travelThumbnailUrl = travelThumbnailUrl,
         travelTitle = travelTitle,
         startAt = LocalDate.parse(startAt),
         endAt = LocalDate.parse(endAt),
@@ -24,7 +24,7 @@ fun TravelVisitDto.toDomain() =
     TravelVisit(
         visitId = visitId,
         placeName = placeName,
-        visitImage = visitImage,
+        visitImageUrl = visitImageUrl,
         visitedAt = LocalDate.parse(visitedAt),
     )
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/VisitMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/VisitMapper.kt
@@ -21,6 +21,6 @@ fun VisitLogDto.toDomain() =
         visitLogId = visitLogId,
         memberId = memberId,
         nickname = nickname,
-        memberImage = memberImage,
+        memberImageUrl = memberImageUrl,
         content = content,
     )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/member/MemberDto.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/member/MemberDto.kt
@@ -7,5 +7,5 @@ import kotlinx.serialization.Serializable
 data class MemberDto(
     @SerialName("memberId") val memberId: Long,
     @SerialName("nickname") val nickname: String,
-    @SerialName("memberImage") val memberImage: String? = null,
+    @SerialName("memberImageUrl") val memberImage: String? = null,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/timeline/TimelineMemberDto.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/timeline/TimelineMemberDto.kt
@@ -6,5 +6,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TimelineMemberDto(
     @SerialName("memberId") val memberId: Long,
-    @SerialName("memberImage") val memberImage: String,
+    @SerialName("memberImageUrl") val memberImageUrl: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/timeline/TimelineTravelDto.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/timeline/TimelineTravelDto.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
 data class TimelineTravelDto(
     @SerialName("travelId") val travelId: Long,
     @SerialName("travelTitle") val travelTitle: String,
-    @SerialName("travelThumbnail") val travelThumbnail: String? = null,
+    @SerialName("travelThumbnailUrl") val travelThumbnailUrl: String? = null,
     @SerialName("startAt") val startAt: String,
     @SerialName("endAt") val endAt: String,
     @SerialName("description") val description: String? = null,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelRequest.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class TravelRequest(
-    @SerialName("travelThumbnail") val travelThumbnail: String? = null,
     @SerialName("travelTitle") val travelTitle: String,
     @SerialName("description") val description: String? = null,
     @SerialName("startAt") val startAt: String,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelResponse.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelResponse.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class TravelResponse(
     @SerialName("travelId") val travelId: Long,
-    @SerialName("travelThumbnail") val travelThumbnail: String? = null,
+    @SerialName("travelThumbnailUrl") val travelThumbnailUrl: String? = null,
     @SerialName("travelTitle") val travelTitle: String,
     @SerialName("startAt") val startAt: String,
     @SerialName("endAt") val endAt: String,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelVisitDto.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelVisitDto.kt
@@ -7,6 +7,6 @@ import kotlinx.serialization.Serializable
 data class TravelVisitDto(
     @SerialName("visitId") val visitId: Long,
     @SerialName("placeName") val placeName: String,
-    @SerialName("visitImage") val visitImage: String? = null,
+    @SerialName("visitImageUrl") val visitImageUrl: String? = null,
     @SerialName("visitedAt") val visitedAt: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitCreationRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitCreationRequest.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class VisitCreationRequest(
     @SerialName("pinId") val pinId: Long,
-    @SerialName("visitImages") val visitImages: List<String>,
+    @SerialName("visitImageUrls") val visitImageUrls: List<String>,
     @SerialName("visitedAt") val visitedAt: String,
     @SerialName("travelId") val travelId: Long,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitLogDto.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitLogDto.kt
@@ -8,6 +8,6 @@ data class VisitLogDto(
     @SerialName("visitLogId") val visitLogId: Long,
     @SerialName("memberId") val memberId: Long,
     @SerialName("nickname") val nickname: String,
-    @SerialName("memberImage") val memberImage: String,
+    @SerialName("memberImageUrl") val memberImageUrl: String,
     @SerialName("content") val content: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitUpdateRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/visit/VisitUpdateRequest.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class VisitUpdateRequest(
-    @SerialName("visitImages") val visitImages: List<String>,
+    @SerialName("visitImageUrls") val visitImageUrls: List<String>,
     @SerialName("visitedAt") val visitedAt: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
@@ -2,12 +2,15 @@ package com.woowacourse.staccato.data.travel
 
 import com.woowacourse.staccato.data.dto.travel.TravelRequest
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
+import okhttp3.MultipartBody
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface TravelApiService {
@@ -16,9 +19,11 @@ interface TravelApiService {
         @Path("travelId") travelId: Long,
     ): Response<TravelResponse>
 
+    @Multipart
     @POST(TRAVELS_PATH)
     suspend fun postTravel(
-        @Body travelRequest: TravelRequest,
+        @Part("data") data: TravelRequest,
+        @Part thumbnailFile: MultipartBody.Part?,
     ): Response<String>
 
     @PUT(TRAVEL_PATH_WITH_ID)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
@@ -3,11 +3,15 @@ package com.woowacourse.staccato.data.travel
 import com.woowacourse.staccato.data.ResponseResult
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
 import com.woowacourse.staccato.domain.model.NewTravel
+import okhttp3.MultipartBody
 
 interface TravelDataSource {
     suspend fun getTravel(travelId: Long): ResponseResult<TravelResponse>
 
-    suspend fun createTravel(newTravel: NewTravel): ResponseResult<String>
+    suspend fun createTravel(
+        newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
+    ): ResponseResult<String>
 
     suspend fun updateTravel(
         travelId: Long,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
@@ -5,6 +5,7 @@ import com.woowacourse.staccato.data.dto.mapper.toDomain
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.model.Travel
 import com.woowacourse.staccato.domain.repository.TravelRepository
+import okhttp3.MultipartBody
 
 class TravelDefaultRepository(
     private val travelDataSource: TravelDataSource,
@@ -17,8 +18,11 @@ class TravelDefaultRepository(
         }
     }
 
-    override suspend fun createTravel(newTravel: NewTravel): ResponseResult<String> {
-        return when (val responseResult = travelDataSource.createTravel(newTravel)) {
+    override suspend fun createTravel(
+        newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
+    ): ResponseResult<String> {
+        return when (val responseResult = travelDataSource.createTravel(newTravel, thumbnailFile)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
             is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(responseResult.data)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
@@ -5,6 +5,7 @@ import com.woowacourse.staccato.data.ResponseResult
 import com.woowacourse.staccato.data.dto.mapper.toDto
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
 import com.woowacourse.staccato.domain.model.NewTravel
+import okhttp3.MultipartBody
 
 class TravelRemoteDataSource(
     private val travelApiService: TravelApiService,
@@ -12,9 +13,12 @@ class TravelRemoteDataSource(
     override suspend fun getTravel(travelId: Long): ResponseResult<TravelResponse> =
         handleApiResponse { travelApiService.getTravel(travelId) }
 
-    override suspend fun createTravel(newTravel: NewTravel): ResponseResult<String> =
+    override suspend fun createTravel(
+        newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
+    ): ResponseResult<String> =
         handleApiResponse {
-            travelApiService.postTravel(newTravel.toDto())
+            travelApiService.postTravel(newTravel.toDto(), thumbnailFile)
         }
 
     override suspend fun updateTravel(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/visit/VisitDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/visit/VisitDefaultRepository.kt
@@ -17,7 +17,7 @@ class VisitDefaultRepository(private val remoteDataSource: VisitRemoteDataSource
 
     override suspend fun createVisit(
         pinId: Long,
-        visitImages: List<String>,
+        visitImageUrls: List<String>,
         visitedAt: String,
         travelId: Long,
     ): Result<Response<String>> {
@@ -25,7 +25,7 @@ class VisitDefaultRepository(private val remoteDataSource: VisitRemoteDataSource
             remoteDataSource.createVisit(
                 VisitCreationRequest(
                     pinId = pinId,
-                    visitImages = visitImages,
+                    visitImageUrls = visitImageUrls,
                     visitedAt = visitedAt,
                     travelId = travelId,
                 ),
@@ -34,13 +34,13 @@ class VisitDefaultRepository(private val remoteDataSource: VisitRemoteDataSource
     }
 
     override suspend fun updateVisit(
-        visitImages: List<String>,
+        visitImageUrls: List<String>,
         visitedAt: String,
     ): Result<Unit> {
         return runCatching {
             remoteDataSource.updateVisit(
                 VisitUpdateRequest(
-                    visitImages = visitImages,
+                    visitImageUrls = visitImageUrls,
                     visitedAt = visitedAt,
                 ),
             )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/Travel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/Travel.kt
@@ -4,7 +4,7 @@ import java.time.LocalDate
 
 data class Travel(
     val travelId: Long,
-    val travelThumbnail: String? = null,
+    val travelThumbnailUrl: String? = null,
     val travelTitle: String,
     val startAt: LocalDate,
     val endAt: LocalDate,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/TravelVisit.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/TravelVisit.kt
@@ -5,6 +5,6 @@ import java.time.LocalDate
 data class TravelVisit(
     val visitId: Long,
     val placeName: String,
-    val visitImage: String? = null,
+    val visitImageUrl: String? = null,
     val visitedAt: LocalDate,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/VisitLog.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/model/VisitLog.kt
@@ -4,6 +4,6 @@ data class VisitLog(
     val visitLogId: Long,
     val memberId: Long,
     val nickname: String,
-    val memberImage: String,
+    val memberImageUrl: String,
     val content: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
@@ -3,11 +3,15 @@ package com.woowacourse.staccato.domain.repository
 import com.woowacourse.staccato.data.ResponseResult
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.model.Travel
+import okhttp3.MultipartBody
 
 interface TravelRepository {
     suspend fun getTravel(travelId: Long): ResponseResult<Travel>
 
-    suspend fun createTravel(newTravel: NewTravel): ResponseResult<String>
+    suspend fun createTravel(
+        newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
+    ): ResponseResult<String>
 
     suspend fun updateTravel(
         travelId: Long,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -224,7 +224,7 @@ fun TextView.combineVisitedAt(visitedAt: LocalDate) {
 }
 
 @BindingAdapter("setAttachedPhotoVisibility")
-fun ImageView.setAttachedPhotoVisibility(items: List<Uri>?) {
+fun ImageView.setAttachedPhotoVisibility(items: Array<Uri>?) {
     if (items.isNullOrEmpty()) {
         visibility = View.GONE
     } else {
@@ -237,6 +237,6 @@ fun ImageView.setAttachedPhotoVisibility(items: List<Uri>?) {
 }
 
 @BindingAdapter("setAttachedPhotoVisibility")
-fun FrameLayout.setAttachedPhotoVisibility(items: List<Uri>?) {
+fun FrameLayout.setAttachedPhotoVisibility(items: Array<Uri>?) {
     isInvisible = !items.isNullOrEmpty()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -96,7 +96,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
                 if (result.resultCode == RESULT_OK) {
                     val imageUris = extractImageUris(result.data)
                     if (imageUris.isNotEmpty()) {
-                        uriSelectedListener.onUrisSelected(imageUris)
+                        uriSelectedListener.onUrisSelected(*imageUris.toTypedArray())
                         dismiss()
                     } else {
                         showToast("사진을 불러올 수 없습니다.")

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -82,10 +82,8 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
 
     private fun setSnackBarAction(snackBar: Snackbar) {
         snackBar.setAction(R.string.snack_bar_move_to_setting) {
-            val intent = Intent()
-            intent.action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
             val uri = Uri.fromParts(PACKAGE_SCHEME, requireContext().packageName, null)
-            intent.data = uri
+            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).setData(uri)
             startActivity(intent)
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/common/PhotoAttachFragment.kt
@@ -34,12 +34,12 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
-        initUriSelectedListner(context)
+        initUrisSelectedListener(context)
         initRequestPermissionLauncher()
         initGalleryLauncher()
     }
 
-    private fun initUriSelectedListner(context: Context) {
+    private fun initUrisSelectedListener(context: Context) {
         if (context is OnUrisSelectedListener) {
             uriSelectedListener = context
         } else {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TimelineMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TimelineMapper.kt
@@ -14,7 +14,7 @@ fun Timeline.toTimelineTravelUiModel(): List<TimelineTravelUiModel> {
 fun Travel.toTimelineTravelUiModel(): TimelineTravelUiModel {
     return TimelineTravelUiModel(
         travelId = travelId,
-        travelThumbnail = travelThumbnail,
+        travelThumbnailUrl = travelThumbnailUrl,
         travelPeriod = convertLocalDateToDatePeriodString(startAt, endAt),
         travelTitle = travelTitle,
     )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TravelMapper.kt
@@ -11,7 +11,7 @@ fun Travel.toUiModel() =
     TravelUiModel(
         id = travelId,
         title = travelTitle,
-        thumbnail = travelThumbnail,
+        travelThumbnailUrl = travelThumbnailUrl,
         startAt = startAt,
         endAt = endAt,
         description = description,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/TravelMapper.kt
@@ -30,6 +30,6 @@ fun TravelVisit.toUiModel() =
     TravelVisitUiModel(
         id = visitId,
         placeName = placeName,
-        visitImage = visitImage,
+        visitImageUrl = visitImageUrl,
         visitedAt = visitedAt,
     )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/VisitUiModelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/mapper/VisitUiModelMapper.kt
@@ -13,7 +13,7 @@ fun Visit.toVisitDefaultUiModel(): VisitDetailUiModel.VisitDefaultUiModel {
     return VisitDetailUiModel.VisitDefaultUiModel(
         id = visitId,
         placeName = placeName,
-        visitImage = visitImage,
+        visitImageUrls = visitImage,
         address = address,
         visitedAt = visitedAt,
     )
@@ -30,7 +30,7 @@ fun VisitLog.toVisitLogUiModel() =
         id = visitLogId,
         memberId = memberId,
         nickname = nickname,
-        memberImage = memberImage,
+        memberImageUrl = memberImageUrl,
         content = content,
     )
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/timeline/model/TimelineTravelUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/timeline/model/TimelineTravelUiModel.kt
@@ -2,7 +2,7 @@ package com.woowacourse.staccato.presentation.timeline.model
 
 data class TimelineTravelUiModel(
     val travelId: Long,
-    val travelThumbnail: String? = null,
+    val travelThumbnailUrl: String? = null,
     val travelPeriod: String,
     val travelTitle: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/model/TravelUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/model/TravelUiModel.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 data class TravelUiModel(
     val id: Long,
     val title: String,
-    val thumbnail: String? = null,
+    val travelThumbnailUrl: String? = null,
     val startAt: LocalDate,
     val endAt: LocalDate,
     val description: String? = null,
@@ -19,7 +19,7 @@ val dummyTravel: TravelUiModel =
     TravelUiModel(
         id = 1L,
         title = "제주도 여행",
-        thumbnail = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSA8EwTvV8MvmnT5SHmZVbqaPVflGBSRsj-uA&s",
+        travelThumbnailUrl = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSA8EwTvV8MvmnT5SHmZVbqaPVflGBSRsj-uA&s",
         startAt = LocalDate.of(2024, 6, 15),
         endAt = LocalDate.of(2024, 6, 17),
         description = "우테코 친구들과 제주도 여행!",

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/model/TravelVisitUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/model/TravelVisitUiModel.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 data class TravelVisitUiModel(
     val id: Long,
     val placeName: String,
-    val visitImage: String? = null,
+    val visitImageUrl: String? = null,
     val visitedAt: LocalDate,
 )
 
@@ -14,19 +14,19 @@ val dummyVisits: List<TravelVisitUiModel> =
         TravelVisitUiModel(
             id = 1L,
             placeName = "곽지 해수욕장",
-            visitImage = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvaUxFadnGqvUfuzK67Bf-R-2UdJAs_EJH2A&s",
+            visitImageUrl = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTvaUxFadnGqvUfuzK67Bf-R-2UdJAs_EJH2A&s",
             visitedAt = LocalDate.of(2024, 6, 15),
         ),
         TravelVisitUiModel(
             id = 2L,
             placeName = "섭지 코지",
-            visitImage = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS67vss2wQ541Dj1PqyQjjJHdOYPa4cGtqyGg&s",
+            visitImageUrl = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcS67vss2wQ541Dj1PqyQjjJHdOYPa4cGtqyGg&s",
             visitedAt = LocalDate.of(2024, 6, 15),
         ),
         TravelVisitUiModel(
             id = 3L,
             placeName = "금오름",
-            visitImage = "https://www.ktsketch.co.kr/news/photo/202309/7714_39717_1352.jpg",
+            visitImageUrl = "https://www.ktsketch.co.kr/news/photo/202309/7714_39717_1352.jpg",
             visitedAt = LocalDate.of(2024, 6, 17),
         ),
     )

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
@@ -44,6 +44,7 @@ class TravelCreationActivity : BindingActivity<ActivityTravelCreationBinding>(),
     }
 
     override fun onSaveClicked() {
+        showToast(getString(R.string.travel_creation_posting))
         viewModel.createTravel(this)
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
@@ -2,10 +2,12 @@ package com.woowacourse.staccato.presentation.travelcreation
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.core.util.Pair
+import androidx.fragment.app.FragmentManager
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.data.StaccatoClient.travelApiService
@@ -13,16 +15,20 @@ import com.woowacourse.staccato.data.travel.TravelDefaultRepository
 import com.woowacourse.staccato.data.travel.TravelRemoteDataSource
 import com.woowacourse.staccato.databinding.ActivityTravelCreationBinding
 import com.woowacourse.staccato.presentation.base.BindingActivity
+import com.woowacourse.staccato.presentation.common.PhotoAttachFragment
 import com.woowacourse.staccato.presentation.timeline.TimelineFragment.Companion.TRAVEL_ID_KEY
 import com.woowacourse.staccato.presentation.travelcreation.viewmodel.TravelCreationViewModel
 import com.woowacourse.staccato.presentation.travelcreation.viewmodel.TravelCreationViewModelFactory
 import com.woowacourse.staccato.presentation.util.showToast
+import com.woowacourse.staccato.presentation.visitcreation.OnUrisSelectedListener
 
-class TravelCreationActivity : BindingActivity<ActivityTravelCreationBinding>(), TravelCreationHandler {
+class TravelCreationActivity : BindingActivity<ActivityTravelCreationBinding>(), TravelCreationHandler, OnUrisSelectedListener {
     override val layoutResourceId = R.layout.activity_travel_creation
     private val viewModel: TravelCreationViewModel by viewModels {
         TravelCreationViewModelFactory(TravelDefaultRepository(TravelRemoteDataSource(travelApiService)))
     }
+    private val photoAttachFragment = PhotoAttachFragment()
+    private val fragmentManager: FragmentManager = supportFragmentManager
     private val dateRangePicker = buildDateRangePicker()
 
     override fun initStartView(savedInstanceState: Bundle?) {
@@ -40,6 +46,14 @@ class TravelCreationActivity : BindingActivity<ActivityTravelCreationBinding>(),
     // TODO: viewModel 이 핸들러 가지도록 수정
     override fun onSaveClicked() {
         viewModel.createTravel()
+    }
+
+    override fun onPhotoAttachClicked() {
+        photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
+    }
+
+    override fun onUrisSelected(vararg uris: Uri) {
+        viewModel.setImageUri(uris.first())
     }
 
     private fun buildDateRangePicker() =

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationActivity.kt
@@ -43,9 +43,8 @@ class TravelCreationActivity : BindingActivity<ActivityTravelCreationBinding>(),
         dateRangePicker.show(supportFragmentManager, dateRangePicker.toString())
     }
 
-    // TODO: viewModel 이 핸들러 가지도록 수정
     override fun onSaveClicked() {
-        viewModel.createTravel()
+        viewModel.createTravel(this)
     }
 
     override fun onPhotoAttachClicked() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/TravelCreationHandler.kt
@@ -4,4 +4,6 @@ interface TravelCreationHandler {
     fun onPeriodSelectionClicked()
 
     fun onSaveClicked()
+
+    fun onPhotoAttachClicked()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.presentation.travelcreation.viewmodel
 
+import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -36,6 +37,13 @@ class TravelCreationViewModel(
 
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> get() = _errorMessage
+
+    private val _imageUri = MutableLiveData<Uri>()
+    val imageUri: LiveData<Uri> get() = _imageUri
+
+    fun setImageUri(uri: Uri) {
+        _imageUri.value = uri
+    }
 
     fun setTravelPeriod(
         startAt: Long,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.presentation.travelcreation.viewmodel
 
+import android.content.Context
 import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
@@ -14,7 +15,9 @@ import com.woowacourse.staccato.data.dto.Status
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.repository.TravelRepository
 import com.woowacourse.staccato.presentation.travelcreation.DateConverter.convertLongToLocalDate
+import com.woowacourse.staccato.presentation.util.convertTravelUriToFile
 import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
 import java.time.LocalDate
 
 class TravelCreationViewModel(
@@ -53,10 +56,11 @@ class TravelCreationViewModel(
         _endDate.value = convertLongToLocalDate(endAt)
     }
 
-    fun createTravel() {
+    fun createTravel(context: Context) {
         viewModelScope.launch {
-            val travel = makeNewTravel()
-            val result: ResponseResult<String> = travelRepository.createTravel(travel)
+            val travel: NewTravel = makeNewTravel()
+            val thumbnailFile: MultipartBody.Part? = convertTravelUriToFile(context, _imageUri.value, name = TRAVEL_FILE_NAME)
+            val result: ResponseResult<String> = travelRepository.createTravel(travel, thumbnailFile)
             result
                 .onSuccess(::setCreatedTravelId)
                 .onServerError(::handleServerError)
@@ -92,6 +96,7 @@ class TravelCreationViewModel(
     }
 
     companion object {
+        private const val TRAVEL_FILE_NAME = "travelThumbnailFile"
         private const val TRAVEL_CREATION_ERROR_MESSAGE = "여행 생성에 실패했습니다"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -44,6 +44,9 @@ class TravelCreationViewModel(
     private val _imageUri = MutableLiveData<Uri>()
     val imageUri: LiveData<Uri> get() = _imageUri
 
+    private val _isPosting = MutableLiveData<Boolean>(false)
+    val isPosting: LiveData<Boolean> get() = _isPosting
+
     fun setImageUri(uri: Uri) {
         _imageUri.value = uri
     }
@@ -57,6 +60,7 @@ class TravelCreationViewModel(
     }
 
     fun createTravel(context: Context) {
+        _isPosting.value = true
         viewModelScope.launch {
             val travel: NewTravel = makeNewTravel()
             val thumbnailFile: MultipartBody.Part? = convertTravelUriToFile(context, _imageUri.value, name = TRAVEL_FILE_NAME)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
@@ -73,7 +73,7 @@ class TravelUpdateViewModel(
     }
 
     private fun initializeTravel(travel: Travel) {
-        _imageUrl.value = travel.travelThumbnail
+        _imageUrl.value = travel.travelThumbnailUrl
         title.set(travel.travelTitle)
         description.set(travel.description)
         _startDate.value = travel.startAt

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/util/FileUtils.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/util/FileUtils.kt
@@ -1,14 +1,33 @@
 package com.woowacourse.staccato.presentation.util
 
+import android.content.ContentResolver
 import android.content.Context
 import android.net.Uri
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
 
-fun Context.getFileFromUri(selectedImageUri: Uri): File {
-    val cursor = contentResolver.query(selectedImageUri, null, null, null, null)
-    cursor!!.moveToNext()
-    val dataIndex = cursor.getColumnIndex("_data").coerceAtLeast(0)
-    val path = cursor.getString(dataIndex)
-    cursor.close()
-    return File(path)
+fun convertTravelUriToFile(
+    context: Context,
+    uri: Uri?,
+    name: String,
+): MultipartBody.Part? {
+    uri ?: return null
+
+    val contextResolver: ContentResolver = context.contentResolver
+    // 파일 이름과 MIME 타입 가져오기
+    val contentType = contextResolver.getType(uri)?.toMediaTypeOrNull()
+    // Uri로부터 InputStream을 얻고, 임시 파일로 복사
+    val inputStream = contextResolver.openInputStream(uri)
+
+    val file = File(context.cacheDir, "travel")
+    inputStream.use { input ->
+        file.outputStream().use { output ->
+            input?.copyTo(output)
+        }
+    }
+
+    val requestFile = file.asRequestBody(contentType)
+    return MultipartBody.Part.createFormData(name, file.name, requestFile)
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/model/VisitDetailUiModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visit/model/VisitDetailUiModel.kt
@@ -6,7 +6,7 @@ sealed class VisitDetailUiModel {
     data class VisitDefaultUiModel(
         val id: Long,
         val placeName: String,
-        val visitImage: String,
+        val visitImageUrls: String,
         val address: String,
         val visitedAt: LocalDate,
     ) : VisitDetailUiModel()
@@ -15,7 +15,7 @@ sealed class VisitDetailUiModel {
         val id: Long = 0,
         val memberId: Long = 0,
         val nickname: String,
-        val memberImage: String,
+        val memberImageUrl: String,
         val content: String,
     ) : VisitDetailUiModel()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/OnUrisSelectedListener.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/OnUrisSelectedListener.kt
@@ -3,5 +3,5 @@ package com.woowacourse.staccato.presentation.visitcreation
 import android.net.Uri
 
 interface OnUrisSelectedListener {
-    fun onUrisSelected(uris: List<Uri>)
+    fun onUrisSelected(vararg uris: Uri)
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/VisitCreationActivity.kt
@@ -83,7 +83,7 @@ class VisitCreationActivity :
         }
     }
 
-    override fun onUrisSelected(uris: List<Uri>) {
+    override fun onUrisSelected(vararg uris: Uri) {
         viewModel.setImageUris(uris)
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/viewmodel/VisitCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitcreation/viewmodel/VisitCreationViewModel.kt
@@ -34,9 +34,9 @@ class VisitCreationViewModel(
     private val _createdVisitId = MutableSingleLiveData<Long>()
     val createdVisitId: SingleLiveData<Long> get() = _createdVisitId
 
-    private val _selectedImages = MutableLiveData<List<Uri>>()
+    private val _selectedImages = MutableLiveData<Array<out Uri>>()
 
-    val selectedImages: LiveData<List<Uri>> get() = _selectedImages
+    val selectedImages: LiveData<Array<out Uri>> get() = _selectedImages
 
     fun fetchInitData(pinId: Long) =
         viewModelScope.launch {
@@ -83,7 +83,7 @@ class VisitCreationViewModel(
         _selectedVisitedAt.value = newSelectedVisitedAt
     }
 
-    fun setImageUris(uris: List<Uri>) {
+    fun setImageUris(uris: Array<out Uri>) {
         _selectedImages.value = uris
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -105,7 +105,7 @@ class VisitUpdateActivity :
         }
     }
 
-    override fun onUrisSelected(uris: List<Uri>) {
+    override fun onUrisSelected(vararg uris: Uri) {
         viewModel.setImageUris(uris)
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/viewmodel/VisitUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/visitupdate/viewmodel/VisitUpdateViewModel.kt
@@ -33,8 +33,8 @@ class VisitUpdateViewModel(
     private val _isUpdateCompleted = MutableSingleLiveData(false)
     val isUpdateCompleted: SingleLiveData<Boolean> get() = _isUpdateCompleted
 
-    private val _selectedImages = MutableLiveData<List<Uri>>()
-    val selectedImages: LiveData<List<Uri>> get() = _selectedImages
+    private val _selectedImages = MutableLiveData<Array<out Uri>>()
+    val selectedImages: LiveData<Array<out Uri>> get() = _selectedImages
 
     fun fetchInitData(
         visitId: Long,
@@ -82,7 +82,7 @@ class VisitUpdateViewModel(
         _selectedVisitedAt.value = newSelectedVisitedAt
     }
 
-    fun setImageUris(uris: List<Uri>) {
+    fun setImageUris(uris: Array<out Uri>) {
         _selectedImages.value = uris
     }
 }

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
@@ -6,6 +6,8 @@
 
     <data>
 
+        <import type="android.view.View"/>
+
         <variable
             name="viewModel"
             type="com.woowacourse.staccato.presentation.travelcreation.viewmodel.TravelCreationViewModel" />
@@ -153,6 +155,18 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </ScrollView>
+
+        <ProgressBar
+            android:id="@+id/progress_bar_travel_creation"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:progress="30"
+            android:visibility="@{viewModel.isPosting == true ? View.VISIBLE : View.GONE }"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
@@ -6,7 +6,7 @@
 
     <data>
 
-        <import type="android.view.View"/>
+        <import type="android.view.View" />
 
         <variable
             name="viewModel"
@@ -60,6 +60,7 @@
                     layout="@layout/layout_photo_attach"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:visibility="@{viewModel.imageUri == null ? View.VISIBLE : View.GONE }"
                     app:layout_constraintBottom_toBottomOf="@id/iv_travel_creation_photo_attach"
                     app:layout_constraintEnd_toEndOf="@id/iv_travel_creation_photo_attach"
                     app:layout_constraintStart_toStartOf="@id/iv_travel_creation_photo_attach"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
@@ -47,6 +47,8 @@
                     android:layout_marginHorizontal="20dp"
                     android:layout_marginTop="12dp"
                     android:contentDescription="@string/all_image_content_description"
+                    android:onClick="@{() -> handler.onPhotoAttachClicked()}"
+                    android:src="@{viewModel.imageUri}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_travel.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_travel.xml
@@ -55,7 +55,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    bind:coilImageUrl="@{viewModel.travel.thumbnail}"
+                    bind:coilImageUrl="@{viewModel.travel.travelThumbnailUrl}"
                     bind:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
                     tools:src="@drawable/shape_place_holder_rectangle" />
 

--- a/android/Staccato_AN/app/src/main/res/layout/item_my_visit_log.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_my_visit_log.xml
@@ -26,7 +26,7 @@
             android:elevation="8dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            bind:coilCircleImageUrl="@{visitLog.memberImage}"
+            bind:coilCircleImageUrl="@{visitLog.memberImageUrl}"
             bind:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}" />
 
         <TextView

--- a/android/Staccato_AN/app/src/main/res/layout/item_others_visit_log.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_others_visit_log.xml
@@ -26,7 +26,7 @@
             android:elevation="8dp"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            bind:coilCircleImageUrl="@{visitLog.memberImage}"
+            bind:coilCircleImageUrl="@{visitLog.memberImageUrl}"
             bind:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}" />
 
         <TextView

--- a/android/Staccato_AN/app/src/main/res/layout/item_visit_default.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_visit_default.xml
@@ -28,7 +28,7 @@
             app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            bind:coilImageUrl="@{visitDefault.visitImage}"
+            bind:coilImageUrl="@{visitDefault.visitImageUrls}"
             bind:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}" />
 
         <TextView

--- a/android/Staccato_AN/app/src/main/res/layout/item_visits.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_visits.xml
@@ -67,7 +67,7 @@
             app:layout_constraintStart_toEndOf="@id/divider_visits"
             app:layout_constraintTop_toTopOf="parent"
             bind:glidePlaceHolder="@{@drawable/shape_all_gray2_4dp}"
-            bind:glideRoundedCornerImageUrl="@{visit.visitImage}"
+            bind:glideRoundedCornerImageUrl="@{visit.visitImageUrl}"
             bind:glideRoundingRadius="@{12}"
             tools:src="@drawable/shape_all_gray2_4dp" />
 

--- a/android/Staccato_AN/app/src/main/res/layout/layout_timeline.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/layout_timeline.xml
@@ -55,14 +55,14 @@
             android:layout_height="0dp"
             android:contentDescription="@string/all_image_content_description"
             android:scaleType="centerCrop"
-            android:visibility="@{travel.travelThumbnail == null ? View.GONE : View.VISIBLE}"
+            android:visibility="@{travel.travelThumbnailUrl == null ? View.GONE : View.VISIBLE}"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="8:5"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintWidth_percent="0.527"
             bind:coilPlaceHolder="@{@drawable/shape_all_gray2_4dp}"
-            bind:coilRoundedCornerImageUrl="@{travel.travelThumbnail}"
+            bind:coilRoundedCornerImageUrl="@{travel.travelThumbnailUrl}"
             bind:coilRoundingRadius="@{12f}"
             tools:src="@drawable/shape_all_gray2_4dp" />
 

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -34,6 +34,7 @@
     <string name="travel_creation_period">여행 기간</string>
     <string name="travel_creation_period_hint">여행 기간을 선택해주세요</string>
     <string name="travel_creation_period_description">%s ~ %s</string>
+    <string name="travel_creation_posting">여행을 생성하는 중이예요.. ✈️</string>
 
     // fragment_visit
     <string name="visit_history">%s년 %s월 %s일에 방문했어요</string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #169 

<br>

## 🚩 Summary

https://github.com/user-attachments/assets/41f1fbf9-77ed-4ce0-85b1-0fe6c2550ece

- 이미지 파일 로드
- MultiPart
- 여행 생성 로직 수정
- 로딩 view 추가
- 서버 도메인 변수명 변경에 따라 dto 수정

<br>

## 🛠️ Technical Concerns
- onUrisSelected의 매개변수를 가변인자로 변경했습니다. [c9b0066](https://github.com/woowacourse-teams/2024-staccato/pull/178/commits/c9b0066e498824baedd8b01ee471cd95d91a595f)
  - 여행 생성 시에는 사진을 1장만 업로드 가능하고, 방문 생성 시에는 사진을 5장까지 업로드가 할 수 있기 때문에 uris를 가변인자로 변경했습니다.

<br>

## 🙂 To Reviewer
- 여행 생성 시 사진을 s3에 업로드하는 과정 때문에 여행이 생성되는 때까지 시간이 꽤 오래 걸려요. 이를 개선하기 위해 우선 progressBar와 toast를 활용해 사용자가 불편함을 덜 느낄 수 있도록 처리했습니다.
- 사진 첨부 아이콘 가시성을 관리하지 않은 채 영상을 촬영해 영상에서는 사진을 불러와도 사진 첨부 아이콘이 없어지지 않습니다.
- 현재 코드에는 사진 첨부 아이콘 가시성을 관리하고 있어, 사진을 불러오면 아래와 같이 사진 첨부 아이콘이 보이지 않습니다!

<img src="https://github.com/user-attachments/assets/ba6692a9-d08b-40a7-b233-4a6bf4c099a4" height="600" width="320"/>

<br>
<br>

## 📋 To Do

- 여행 수정 기능 api 수정