### PR TITLE
feat: 여행 상세 수정 기능 api 변경 및 여행 리팩터링 #180

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/mapper/TravelMapper.kt
@@ -2,6 +2,7 @@ package com.woowacourse.staccato.data.dto.mapper
 
 import com.woowacourse.staccato.data.dto.travel.TravelRequest
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
+import com.woowacourse.staccato.data.dto.travel.TravelUpdateRequest
 import com.woowacourse.staccato.data.dto.travel.TravelVisitDto
 import com.woowacourse.staccato.domain.model.NewTravel
 import com.woowacourse.staccato.domain.model.Travel
@@ -30,6 +31,15 @@ fun TravelVisitDto.toDomain() =
 
 fun NewTravel.toDto() =
     TravelRequest(
+        travelTitle = travelTitle,
+        description = description,
+        startAt = startAt.toString(),
+        endAt = endAt.toString(),
+    )
+
+fun NewTravel.toTravelUpdateRequest() =
+    TravelUpdateRequest(
+        travelThumbnailUrl = travelThumbnail,
         travelTitle = travelTitle,
         description = description,
         startAt = startAt.toString(),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelUpdateRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/dto/travel/TravelUpdateRequest.kt
@@ -1,0 +1,13 @@
+package com.woowacourse.staccato.data.dto.travel
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class TravelUpdateRequest(
+    @SerialName("travelThumbnailUrl") val travelThumbnailUrl: String? = null,
+    @SerialName("travelTitle") val travelTitle: String,
+    @SerialName("description") val description: String? = null,
+    @SerialName("startAt") val startAt: String,
+    @SerialName("endAt") val endAt: String,
+)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelApiService.kt
@@ -2,9 +2,9 @@ package com.woowacourse.staccato.data.travel
 
 import com.woowacourse.staccato.data.dto.travel.TravelRequest
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
+import com.woowacourse.staccato.data.dto.travel.TravelUpdateRequest
 import okhttp3.MultipartBody
 import retrofit2.Response
-import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Multipart
@@ -26,10 +26,12 @@ interface TravelApiService {
         @Part thumbnailFile: MultipartBody.Part?,
     ): Response<String>
 
+    @Multipart
     @PUT(TRAVEL_PATH_WITH_ID)
     suspend fun putTravel(
         @Path("travelId") travelId: Long,
-        @Body travelRequest: TravelRequest,
+        @Part("data") data: TravelUpdateRequest,
+        @Part travelThumbnailFile: MultipartBody.Part?,
     ): Response<String>
 
     @DELETE(TRAVEL_PATH_WITH_ID)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDataSource.kt
@@ -16,6 +16,7 @@ interface TravelDataSource {
     suspend fun updateTravel(
         travelId: Long,
         newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
     ): ResponseResult<String>
 
     suspend fun deleteTravel(travelId: Long): ResponseResult<Unit>

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelDefaultRepository.kt
@@ -32,8 +32,9 @@ class TravelDefaultRepository(
     override suspend fun updateTravel(
         travelId: Long,
         newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
     ): ResponseResult<String> {
-        return when (val responseResult = travelDataSource.updateTravel(travelId, newTravel)) {
+        return when (val responseResult = travelDataSource.updateTravel(travelId, newTravel, thumbnailFile)) {
             is ResponseResult.Exception -> ResponseResult.Exception(responseResult.e, ERROR_MESSAGE)
             is ResponseResult.ServerError -> ResponseResult.ServerError(responseResult.status, responseResult.message)
             is ResponseResult.Success -> ResponseResult.Success(responseResult.data)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/data/travel/TravelRemoteDataSource.kt
@@ -3,6 +3,7 @@ package com.woowacourse.staccato.data.travel
 import com.woowacourse.staccato.data.ApiResponseHandler.handleApiResponse
 import com.woowacourse.staccato.data.ResponseResult
 import com.woowacourse.staccato.data.dto.mapper.toDto
+import com.woowacourse.staccato.data.dto.mapper.toTravelUpdateRequest
 import com.woowacourse.staccato.data.dto.travel.TravelResponse
 import com.woowacourse.staccato.domain.model.NewTravel
 import okhttp3.MultipartBody
@@ -24,9 +25,10 @@ class TravelRemoteDataSource(
     override suspend fun updateTravel(
         travelId: Long,
         newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
     ): ResponseResult<String> =
         handleApiResponse {
-            travelApiService.putTravel(travelId, newTravel.toDto())
+            travelApiService.putTravel(travelId, newTravel.toTravelUpdateRequest(), thumbnailFile)
         }
 
     override suspend fun deleteTravel(travelId: Long): ResponseResult<Unit> = handleApiResponse { travelApiService.deleteTravel(travelId) }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/domain/repository/TravelRepository.kt
@@ -16,6 +16,7 @@ interface TravelRepository {
     suspend fun updateTravel(
         travelId: Long,
         newTravel: NewTravel,
+        thumbnailFile: MultipartBody.Part?,
     ): ResponseResult<String>
 
     suspend fun deleteTravel(travelId: Long): ResponseResult<Unit>

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -64,6 +64,23 @@ fun ImageView.setRoundedCornerImageWithCoil(
 }
 
 @BindingAdapter(
+    value = ["coilImageUrl", "coilImageUri", "coilPlaceHolder", "coilRoundingRadius"],
+)
+fun ImageView.setRoundedCornerUpdateImageWithCoil(
+    url: String?,
+    uri: Uri?,
+    placeHolder: Drawable? = null,
+    roundingRadius: Float,
+) {
+    val image = url ?: uri
+    load(image) {
+        placeholder(placeHolder)
+        transformations(RoundedCornersTransformation(roundingRadius))
+        error(placeHolder)
+    }
+}
+
+@BindingAdapter(
     value = ["glideImageUrl", "glidePlaceHolder"],
 )
 fun ImageView.loadImageWithGlide(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travel/viewmodel/TravelViewModel.kt
@@ -1,6 +1,5 @@
 package com.woowacourse.staccato.presentation.travel.viewmodel
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -24,8 +23,8 @@ class TravelViewModel(
     private val _travel = MutableLiveData<TravelUiModel>()
     val travel: LiveData<TravelUiModel> get() = _travel
 
-    private val _errorMessage: MutableLiveData<String> = MutableLiveData()
-    val errorMessage: LiveData<String> get() = _errorMessage
+    private val _errorMessage = MutableSingleLiveData<String>()
+    val errorMessage: SingleLiveData<String> get() = _errorMessage
 
     private val _isDeleteSuccess = MutableSingleLiveData<Boolean>(false)
     val isDeleteSuccess: SingleLiveData<Boolean> get() = _isDeleteSuccess
@@ -61,15 +60,14 @@ class TravelViewModel(
         status: Status,
         message: String,
     ) {
-        _errorMessage.value = message
+        _errorMessage.setValue(message)
     }
 
     private fun handelException(
         e: Throwable,
         message: String,
     ) {
-        Log.d("hye", e.message.toString())
-        _errorMessage.value = TRAVEL_ERROR_MESSAGE
+        _errorMessage.setValue(TRAVEL_ERROR_MESSAGE)
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -23,9 +23,6 @@ import java.time.LocalDate
 class TravelCreationViewModel(
     private val travelRepository: TravelRepository,
 ) : ViewModel() {
-    private val _imageUrl = MutableLiveData<String>()
-    val imageUrl: LiveData<String> get() = _imageUrl
-
     val title = ObservableField<String>()
     val description = ObservableField<String>()
 
@@ -78,7 +75,6 @@ class TravelCreationViewModel(
 
     private fun makeNewTravel(): NewTravel =
         NewTravel(
-            travelThumbnail = imageUrl.value,
             travelTitle = title.get() ?: throw IllegalArgumentException(),
             startAt = startDate.value ?: throw IllegalArgumentException(),
             endAt = endDate.value ?: throw IllegalArgumentException(),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelcreation/viewmodel/TravelCreationViewModel.kt
@@ -78,7 +78,7 @@ class TravelCreationViewModel(
             travelTitle = title.get() ?: throw IllegalArgumentException(),
             startAt = startDate.value ?: throw IllegalArgumentException(),
             endAt = endDate.value ?: throw IllegalArgumentException(),
-            description = description.get() ?: throw IllegalArgumentException(),
+            description = description.get(),
         )
 
     private fun handleServerError(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
@@ -49,7 +49,7 @@ class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), Tra
     }
 
     override fun onSaveClicked() {
-        viewModel.updateTravel()
+        viewModel.updateTravel(this)
     }
 
     override fun onPhotoAttachClicked() {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
@@ -49,6 +49,7 @@ class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), Tra
     }
 
     override fun onSaveClicked() {
+        showToast(getString(R.string.travel_update_posting))
         viewModel.updateTravel(this)
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateActivity.kt
@@ -2,10 +2,12 @@ package com.woowacourse.staccato.presentation.travelupdate
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.core.util.Pair
+import androidx.fragment.app.FragmentManager
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.woowacourse.staccato.R
 import com.woowacourse.staccato.data.StaccatoClient.travelApiService
@@ -13,12 +15,14 @@ import com.woowacourse.staccato.data.travel.TravelDefaultRepository
 import com.woowacourse.staccato.data.travel.TravelRemoteDataSource
 import com.woowacourse.staccato.databinding.ActivityTravelUpdateBinding
 import com.woowacourse.staccato.presentation.base.BindingActivity
+import com.woowacourse.staccato.presentation.common.PhotoAttachFragment
 import com.woowacourse.staccato.presentation.travel.TravelFragment.Companion.TRAVEL_ID_KEY
 import com.woowacourse.staccato.presentation.travelupdate.viewmodel.TravelUpdateViewModel
 import com.woowacourse.staccato.presentation.travelupdate.viewmodel.TravelUpdateViewModelFactory
 import com.woowacourse.staccato.presentation.util.showToast
+import com.woowacourse.staccato.presentation.visitcreation.OnUrisSelectedListener
 
-class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), TravelUpdateHandler {
+class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), TravelUpdateHandler, OnUrisSelectedListener {
     override val layoutResourceId = R.layout.activity_travel_update
     private val travelId by lazy { intent.getLongExtra(TRAVEL_ID_KEY, DEFAULT_TRAVEL_ID) }
     private val viewModel: TravelUpdateViewModel by viewModels {
@@ -27,6 +31,8 @@ class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), Tra
             TravelDefaultRepository(TravelRemoteDataSource(travelApiService)),
         )
     }
+    private val photoAttachFragment = PhotoAttachFragment()
+    private val fragmentManager: FragmentManager = supportFragmentManager
     private val dateRangePicker = buildDateRangePicker()
 
     override fun initStartView(savedInstanceState: Bundle?) {
@@ -44,6 +50,14 @@ class TravelUpdateActivity : BindingActivity<ActivityTravelUpdateBinding>(), Tra
 
     override fun onSaveClicked() {
         viewModel.updateTravel()
+    }
+
+    override fun onPhotoAttachClicked() {
+        photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
+    }
+
+    override fun onUrisSelected(vararg uris: Uri) {
+        viewModel.setImage(uris.first())
     }
 
     private fun buildDateRangePicker() =

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/TravelUpdateHandler.kt
@@ -4,4 +4,6 @@ interface TravelUpdateHandler {
     fun onPeriodSelectionClicked()
 
     fun onSaveClicked()
+
+    fun onPhotoAttachClicked()
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
@@ -50,6 +50,9 @@ class TravelUpdateViewModel(
     private val _imageUri = MutableLiveData<Uri?>()
     val imageUri: LiveData<Uri?> get() = _imageUri
 
+    private val _isPosting = MutableLiveData<Boolean>()
+    val isPosting: LiveData<Boolean> get() = _isPosting
+
     fun fetchTravel() {
         viewModelScope.launch {
             val result = travelRepository.getTravel(travelId)
@@ -66,6 +69,7 @@ class TravelUpdateViewModel(
     }
 
     fun updateTravel(context: Context) {
+        _isPosting.value = true
         viewModelScope.launch {
             val newTravel: NewTravel = makeNewTravel()
             val thumbnailFile: MultipartBody.Part? = convertTravelUriToFile(context, _imageUri.value, TRAVEL_FILE_NAME)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/travelupdate/viewmodel/TravelUpdateViewModel.kt
@@ -1,5 +1,6 @@
 package com.woowacourse.staccato.presentation.travelupdate.viewmodel
 
+import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -43,6 +44,9 @@ class TravelUpdateViewModel(
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> get() = _errorMessage
 
+    private val _imageUri = MutableLiveData<Uri>()
+    val imageUri: LiveData<Uri> get() = _imageUri
+
     fun fetchTravel() {
         viewModelScope.launch {
             val result = travelRepository.getTravel(travelId)
@@ -51,6 +55,11 @@ class TravelUpdateViewModel(
                 .onServerError(::handleServerError)
                 .onException(::handelException)
         }
+    }
+
+    fun setImage(uri: Uri) {
+        _imageUri.value = uri
+        _imageUrl.value = null
     }
 
     fun updateTravel() {

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_creation.xml
@@ -50,6 +50,7 @@
                     android:layout_marginTop="12dp"
                     android:contentDescription="@string/all_image_content_description"
                     android:onClick="@{() -> handler.onPhotoAttachClicked()}"
+                    android:scaleType="centerCrop"
                     android:src="@{viewModel.imageUri}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_update.xml
@@ -6,6 +6,8 @@
 
     <data>
 
+        <import type="android.view.View" />
+
         <variable
             name="viewModel"
             type="com.woowacourse.staccato.presentation.travelupdate.viewmodel.TravelUpdateViewModel" />
@@ -158,6 +160,18 @@
             </androidx.constraintlayout.widget.ConstraintLayout>
 
         </ScrollView>
+
+        <ProgressBar
+            android:id="@+id/progress_bar_travel_update"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:progress="30"
+            android:visibility="@{viewModel.isPosting == true ? View.VISIBLE : View.GONE }"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_travel_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_travel_update.xml
@@ -47,13 +47,15 @@
                     android:layout_marginHorizontal="20dp"
                     android:layout_marginTop="12dp"
                     android:contentDescription="@string/all_image_content_description"
+                    android:onClick="@{() -> handler.onPhotoAttachClicked()}"
                     android:scaleType="centerCrop"
-                    app:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
-                    app:coilRoundedCornerImageUrl="@{viewModel.imageUrl}"
-                    app:coilRoundingRadius="@{12}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="parent" />
+                    app:layout_constraintTop_toTopOf="parent"
+                    bind:coilImageUri="@{viewModel.imageUri}"
+                    bind:coilImageUrl="@{viewModel.imageUrl}"
+                    bind:coilPlaceHolder="@{@drawable/shape_place_holder_rectangle}"
+                    bind:coilRoundingRadius="@{12}" />
 
                 <include
                     android:id="@+id/include_travel_update_photo_attach"

--- a/android/Staccato_AN/app/src/main/res/layout/item_visits.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/item_visits.xml
@@ -64,11 +64,12 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="8:5"
             app:layout_constraintEnd_toEndOf="parent"
+            android:scaleType="centerCrop"
             app:layout_constraintStart_toEndOf="@id/divider_visits"
             app:layout_constraintTop_toTopOf="parent"
-            bind:glidePlaceHolder="@{@drawable/shape_all_gray2_4dp}"
-            bind:glideRoundedCornerImageUrl="@{visit.visitImageUrl}"
-            bind:glideRoundingRadius="@{12}"
+            bind:coilPlaceHolder="@{@drawable/shape_all_gray2_4dp}"
+            bind:coilRoundedCornerImageUrl="@{visit.visitImageUrl}"
+            bind:coilRoundingRadius="@{12}"
             tools:src="@drawable/shape_all_gray2_4dp" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@
     <string name="travel_creation_period_hint">여행 기간을 선택해주세요</string>
     <string name="travel_creation_period_description">%s ~ %s</string>
     <string name="travel_creation_posting">여행을 생성하는 중이예요.. ✈️</string>
+    <string name="travel_update_posting">여행을 수정하는 중이예요.. 🧳️</string>
 
     // fragment_visit
     <string name="visit_history">%s년 %s월 %s일에 방문했어요</string>


### PR DESCRIPTION
## ⭐️ Issue Number

- #180 

<br>

## 🚩 Summary

- 이미지 파일 로드
- MultiPart
- 여행 상세 수정 로직 변경
- 로딩 view 추가
- 여행 기능 리팩터링

<br>

## 🛠️ Technical Concerns

<br>

## 🙂 To Reviewer
여행 상세 수정 기능 api 변경 중 아래 버그들을 발견해 수정했습니다.
- 삭제 불가능한 여행 삭제 시도 관련 에러 토스트 문제 해결
- 여행 소개 미입력 시 여행이 생성 되지 않는 오류 해결

<br>

## 📋 To Do
