### PR TITLE
feat: 빈/공백 문자열 예외 처리 #186

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -1,6 +1,7 @@
 package com.staccato.auth.service.dto.request;
 
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import com.staccato.member.domain.Member;
 
@@ -9,7 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "회원을 등록하기 위한 요청 형식입니다.")
 public record LoginRequest(
         @Schema(example = "hi_staccato")
-        @NotNull(message = "닉네임을 입력해주세요.")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(min = 1, max = 20, message = "1자 이상 20자 이하의 닉네임으로 설정해주세요.")
         String nickname
 ) {
     public Member toMember() {

--- a/backend/src/main/java/com/staccato/member/domain/Nickname.java
+++ b/backend/src/main/java/com/staccato/member/domain/Nickname.java
@@ -23,19 +23,8 @@ public class Nickname {
     private String nickname;
 
     public Nickname(String nickname) {
-        validate(nickname);
-        this.nickname = nickname;
-    }
-
-    private void validate(String nickname) {
-        validateLength(nickname);
         validateRegex(nickname);
-    }
-
-    private void validateLength(String nickname) {
-        if (nickname.isEmpty() || nickname.length() > MAX_LENGTH) {
-            throw new StaccatoException(MAX_LENGTH + "자 이내의 닉네임으로 설정해주세요.");
-        }
+        this.nickname = nickname;
     }
 
     private static void validateRegex(String nickname) {

--- a/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
+++ b/backend/src/main/java/com/staccato/travel/service/dto/request/TravelRequest.java
@@ -2,6 +2,7 @@ package com.staccato.travel.service.dto.request;
 
 import java.time.LocalDate;
 
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
@@ -16,8 +17,8 @@ public record TravelRequest(
         @Schema(example = "http://example.com/london.png")
         String travelThumbnailUrl,
         @Schema(example = "런던 여행")
-        @NotNull(message = "여행 제목을 입력해주세요.")
-        @Size(max = 30, message = "제목의 최대 허용 글자수는 공백 포함 30자입니다.")
+        @NotBlank(message = "여행 제목을 입력해주세요.")
+        @Size(min = 1, max = 30, message = "제목은 공백 포함 1자 이상 30자 이하로 설정해주세요.")
         String travelTitle,
         @Schema(example = "런던 시내 탐방")
         @Size(max = 500, message = "내용의 최대 허용 글자수는 공백 포함 500자입니다.")

--- a/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
+++ b/backend/src/main/java/com/staccato/visit/service/dto/request/VisitRequest.java
@@ -4,7 +4,9 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -16,7 +18,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(description = "방문 기록 생성 시 요청 형식입니다. 단, 멀티파트로 보내는 사진 파일은 여기에 포함되지 않습니다.")
 public record VisitRequest(
         @Schema(example = "런던 박물관")
-        @NotNull(message = "방문한 장소의 이름을 입력해주세요.")
+        @NotBlank(message = "방문한 장소의 이름을 입력해주세요.")
+        @Size(min = 1, max = 30, message = "방문한 장소의 이름은 공백 포함 1자 이상 30자 이하로 설정해주세요.")
         String placeName,
         @Schema(example = "Great Russell St, London WC1B 3DG")
         @NotNull(message = "방문한 장소의 주소를 입력해주세요.")

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -7,6 +7,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -51,6 +53,22 @@ class AuthControllerTest {
         // given
         LoginRequest loginRequest = new LoginRequest(null);
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "닉네임을 입력해주세요.");
+
+        // when & then
+        mockMvc.perform(post("/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
+
+    @DisplayName("닉네임을 입력하지 않으면 400을 반환한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 30})
+    void cannotLoginIfBadRequest(int count) throws Exception {
+        // given
+        LoginRequest loginRequest = new LoginRequest("가".repeat(count));
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "1자 이상 20자 이하의 닉네임으로 설정해주세요.");
 
         // when & then
         mockMvc.perform(post("/login")

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -62,7 +62,7 @@ class AuthControllerTest {
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
     }
 
-    @DisplayName("닉네임을 입력하지 않으면 400을 반환한다.")
+    @DisplayName("닉네임을 입력하지 않거나 20자를 초과하면 400을 반환한다.")
     @ParameterizedTest
     @ValueSource(ints = {0, 30})
     void cannotLoginIfBadRequest(int count) throws Exception {

--- a/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
+++ b/backend/src/test/java/com/staccato/member/domain/NicknameTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 import com.staccato.exception.StaccatoException;
 
@@ -15,15 +13,6 @@ class NicknameTest {
     @Test
     void CreateNickname() {
         assertThatNoException().isThrownBy(() -> new Nickname("가ㄱㅏㅣㅎ.AZ1az_"));
-    }
-
-    @DisplayName("닉네임의 길이가 잘못되었을 경우 예외를 발생시킨다.")
-    @ParameterizedTest
-    @ValueSource(ints = {0, 21})
-    void cannotCreateNicknameByInvalidLength(int length) {
-        assertThatThrownBy(() -> new Nickname("가".repeat(length)))
-                .isInstanceOf(StaccatoException.class)
-                .hasMessage("20자 이내의 닉네임으로 설정해주세요.");
     }
 
     @DisplayName("닉네임의 형식이 잘못되었을 경우 예외를 발생시킨다.")

--- a/backend/src/test/java/com/staccato/travel/controller/TravelControllerTest.java
+++ b/backend/src/test/java/com/staccato/travel/controller/TravelControllerTest.java
@@ -69,6 +69,10 @@ class TravelControllerTest {
                         "여행 제목을 입력해주세요."
                 ),
                 Arguments.of(
+                        new TravelRequest("https://example.com/travels/geumohrm.jpg", "  ", "친구들과 함께한 여름 휴가 여행", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),
+                        "여행 제목을 입력해주세요."
+                ),
+                Arguments.of(
                         new TravelRequest("https://example.com/travels/geumohrm.jpg", "2023 여름 휴가", "친구들과 함께한 여름 휴가 여행", null, LocalDate.of(2023, 7, 10)),
                         "여행 시작 날짜를 입력해주세요."
                 ),
@@ -78,7 +82,7 @@ class TravelControllerTest {
                 ),
                 Arguments.of(
                         new TravelRequest("https://example.com/travels/geumohrm.jpg", "가".repeat(31), "친구들과 함께한 여름 휴가 여행", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),
-                        "제목의 최대 허용 글자수는 공백 포함 30자입니다."
+                        "제목은 공백 포함 1자 이상 30자 이하로 설정해주세요."
                 ),
                 Arguments.of(
                         new TravelRequest("https://example.com/travels/geumohrm.jpg", "2023 여름 휴가", "가".repeat(501), LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),

--- a/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
+++ b/backend/src/test/java/com/staccato/visit/controller/VisitControllerTest.java
@@ -4,7 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -66,6 +66,14 @@ class VisitControllerTest {
                         "방문한 장소의 이름을 입력해주세요."
                 ),
                 Arguments.of(
+                        new VisitRequest("  ", "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
+                        "방문한 장소의 이름을 입력해주세요."
+                ),
+                Arguments.of(
+                        new VisitRequest("가".repeat(31), "address", BigDecimal.ONE, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
+                        "방문한 장소의 이름은 공백 포함 1자 이상 30자 이하로 설정해주세요."
+                ),
+                Arguments.of(
                         new VisitRequest("placeName", "address", null, BigDecimal.ONE, LocalDateTime.of(2023, 7, 1, 10, 0), 1L),
                         "방문한 장소의 위도를 입력해주세요."
                 ),
@@ -120,15 +128,15 @@ class VisitControllerTest {
     void failCreateVisitWithInvalidVistedAt() throws Exception {
         // given
         String visitRequestJson = """
-            {
-                "placeName": "런던 박물관",
-                "address": "Great Russell St, London WC1B 3DG",
-                "latitude": 51.51978412729915,
-                "longitude": -0.12712788587027796,
-                "visitedAt": "2024/07/27T10:00:00",
-                "travelId": 1
-            }
-        """;
+                    {
+                        "placeName": "런던 박물관",
+                        "address": "Great Russell St, London WC1B 3DG",
+                        "latitude": 51.51978412729915,
+                        "longitude": -0.12712788587027796,
+                        "visitedAt": "2024/07/27T10:00:00",
+                        "travelId": 1
+                    }
+                """;
         MockMultipartFile visitRequestPart = new MockMultipartFile(
                 "data",
                 "",


### PR DESCRIPTION
## ⭐️ Issue Number
- #186 

## 🚩 Summary
- NotNull -> NotBlank : 공백, 빈, null 문자열이 오지 못하도록 예외 처리
- Size(max= -) -> Size(min=-, max=-) : 최소도 체크하고, 메세지에도 반영

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
