### PR TITLE
refactor: 이미지 용량 제한 확장 #205

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -24,8 +24,8 @@ spring:
     defer-datasource-initialization: true
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 50MB
+      max-file-size: 20MB
+      max-request-size: 100MB
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -22,8 +22,8 @@ spring:
     defer-datasource-initialization: true
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 50MB
+      max-file-size: 20MB
+      max-request-size: 100MB
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8

--- a/backend/src/main/resources/application-stage.yml
+++ b/backend/src/main/resources/application-stage.yml
@@ -24,8 +24,8 @@ spring:
     defer-datasource-initialization: true
   servlet:
     multipart:
-      max-file-size: 10MB
-      max-request-size: 50MB
+      max-file-size: 20MB
+      max-request-size: 100MB
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8


### PR DESCRIPTION
## ⭐️ Issue Number
- #205 

## 🚩 Summary
- 이미지 용량 제한을 확장했습니다.
   - 한 장 용량 제한: 20MB
   - 한 번 요청 제한: 100MB

## 🛠️ Technical Concerns


## 🙂 To Reviewer

dev 서버와 stage 서버의 `nginx.conf` 파일의 http block에 내용 추가

```ssh
http {
	##
	# S3 Settings
	##
	
	client_max_body_size 100M;
	...
}
```

## 📋 To Do
