### PR TITLE
feat: 사용자 로깅, Nginx 로깅, DB 로깅 #190

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -8,6 +8,7 @@ import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.config.auth.AdminProperties;
 import com.staccato.config.auth.TokenProvider;
+import com.staccato.config.log.LogForm;
 import com.staccato.exception.StaccatoException;
 import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
@@ -15,7 +16,9 @@ import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -48,7 +51,9 @@ public class AuthService {
     }
 
     public Member extractFromToken(String token) {
-        return memberRepository.findById(tokenProvider.extractMemberId(token))
+        Member member = memberRepository.findById(tokenProvider.extractMemberId(token))
                 .orElseThrow(UnauthorizedException::new);
+        log.info(LogForm.LOGIN_MEMBER_FORM, member.getId(), member.getNickname().getNickname());
+        return member;
     }
 }

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -1,9 +1,18 @@
 package com.staccato.config.log;
 
 public class LogForm {
+    private static final String START_DELIMITER = "[";
+    private static final String END_DELIMITER = "]";
     private static final String DELIMITER = " | ";
-    public static final String REQUEST_LOGGING_FORM =
-            "HTTP Method : {}" + DELIMITER + "Request URI : {}" + DELIMITER + "Token is Exist : {}" + DELIMITER + "HTTP Status : {}" + DELIMITER + "Processing Time(ms) : {}";
+    public static final String REQUEST_LOGGING_FORM = START_DELIMITER +
+            "HTTP Status : {}" + DELIMITER +
+            "HTTP Method : {}" + DELIMITER +
+            "Request URI : {}" + DELIMITER +
+            "Token is Exist : {}" + DELIMITER +
+            "Processing Time(ms) : {}" + END_DELIMITER;
+    public static final String LOGIN_MEMBER_FORM = START_DELIMITER +
+            "Login Member ID : {}" + DELIMITER +
+            "Login Member Nickname : {}" + END_DELIMITER;
     public static final String EXCEPTION_LOGGING_FORM = "Exception Response : {} ";
     public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + DELIMITER + "Exception Message : {}";
 }

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -1,18 +1,28 @@
 package com.staccato.config.log;
 
 public class LogForm {
-    private static final String START_DELIMITER = "[";
-    private static final String END_DELIMITER = "]";
-    private static final String DELIMITER = " | ";
-    public static final String REQUEST_LOGGING_FORM = START_DELIMITER +
-            "HTTP Status : {}" + DELIMITER +
-            "HTTP Method : {}" + DELIMITER +
-            "Request URI : {}" + DELIMITER +
-            "Token is Exist : {}" + DELIMITER +
-            "Processing Time(ms) : {}" + END_DELIMITER;
-    public static final String LOGIN_MEMBER_FORM = START_DELIMITER +
-            "Login Member ID : {}" + DELIMITER +
-            "Login Member Nickname : {}" + END_DELIMITER;
-    public static final String EXCEPTION_LOGGING_FORM = "Exception Response : {} ";
-    public static final String ERROR_LOGGING_FORM = "Exception Response : {} " + DELIMITER + "Exception Message : {}";
+    private static final String DELIMITER = ",\n    ";
+    private static final String INDENT = "    ";
+
+    public static final String REQUEST_LOGGING_FORM = "\n{\n" +
+            INDENT + "\"httpStatus\": \"{}\"" + DELIMITER +
+            "\"httpMethod\": \"{}\"" + DELIMITER +
+            "\"requestUri\": \"{}\"" + DELIMITER +
+            "\"tokenExists\": \"{}\"" + DELIMITER +
+            "\"processingTimeMs\": \"{}\"\n" +
+            "}";
+
+    public static final String LOGIN_MEMBER_FORM = "\n{\n" +
+            INDENT + "\"loginMemberId\": \"{}\"" + DELIMITER +
+            "\"loginMemberNickname\": \"{}\"\n" +
+            "}";
+
+    public static final String EXCEPTION_LOGGING_FORM = "\n{\n" +
+            INDENT + "\"exceptionResponse\": \"{}\"\n" +
+            "}";
+
+    public static final String ERROR_LOGGING_FORM = "\n{\n" +
+            INDENT + "\"exceptionResponse\": \"{}\"" + DELIMITER +
+            "\"exceptionMessage\": \"{}\"\n" +
+            "}";
 }

--- a/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
+++ b/backend/src/main/java/com/staccato/config/log/LoggingFilter.java
@@ -3,15 +3,18 @@ package com.staccato.config.log;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
+import java.util.UUID;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.slf4j.MDC;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StopWatch;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -19,22 +22,27 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Component
 public class LoggingFilter extends OncePerRequestFilter {
+    private static final String IDENTIFIER = "request_id";
     private static final List<String> WHITE_LIST = List.of("/h2-console/**", "/favicon/**", "/swagger-ui/**", "/v3/api-docs/**");
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        long startTime = System.currentTimeMillis();
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        MDC.put(IDENTIFIER, UUID.randomUUID().toString());
         String token = request.getHeader(HttpHeaders.AUTHORIZATION);
-        filterChain.doFilter(request, response);
-        long endTime = System.currentTimeMillis();
-        long duration = endTime - startTime;
-
-        log.info(LogForm.REQUEST_LOGGING_FORM,
-                request.getMethod(),
-                request.getRequestURI(),
-                tokenExists(token),
-                response.getStatus(),
-                duration);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            stopWatch.stop();
+            log.info(LogForm.REQUEST_LOGGING_FORM,
+                    response.getStatus(),
+                    request.getMethod(),
+                    request.getRequestURI(),
+                    tokenExists(token),
+                    stopWatch.getTotalTimeMillis());
+            MDC.clear();
+        }
     }
 
     private boolean tokenExists(String token) {

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -21,15 +21,6 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-//    @ExceptionHandler(DateTimeParseException.class)
-//    @ApiResponse(responseCode = "400")
-//    public ResponseEntity<ExceptionResponse> handleDateTimeParseException(DateTimeParseException e) {
-//        String errorMessage = "올바르지 않은 날짜 형식입니다.";
-//        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), errorMessage);
-//        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse);
-//        return ResponseEntity.badRequest().body(exceptionResponse);
-//    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleValidationException(MethodArgumentNotValidException e) {

--- a/backend/src/main/resources/console-appender.xml
+++ b/backend/src/main/resources/console-appender.xml
@@ -1,7 +1,7 @@
 <included>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [thread = %thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-4relative] [%thread] [request_id=%X{request_id:-startup}] %highlight(%-5level) [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
     </appender>
 </included>

--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -8,7 +8,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] [%thread] [request_id=%X{request_id:-startup}] %-5level [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./backup/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -8,7 +8,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] [%thread] [request_id=%X{request_id:-startup}] %-5level - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./backup/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>

--- a/backend/src/main/resources/warn-appender.xml
+++ b/backend/src/main/resources/warn-appender.xml
@@ -8,7 +8,7 @@
             <onMismatch>DENY</onMismatch>
         </filter>
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative][thread = %thread] %-5level [%C.%M.-%L] - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] [%thread] [request_id=%X{request_id:-startup}] %-5level [%C.%M.-%L] - %msg%n</pattern>
         </encoder>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./backup/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>


### PR DESCRIPTION
## ⭐️ Issue Number
- #190 

## 🚩 Summary
- MDC를 적용해서 request_id를 통해 사용자 요청을 추적가능하게 구성
  - (아래 사진은 `local` 환경이므로 `Info` 에 클래스, 메서드 등이 포함되는데 `stage`, `dev`에는 보이지 않게끔 설정해 놓았습니다.)
<img width="1319" alt="스크린샷 2024-08-12 오후 8 46 46" src="https://github.com/user-attachments/assets/f5313314-808a-4257-b35a-01ae7135884c">

- 사용자 인증 정보 로깅
  - `[2024-08-15 21:59:22:36083] [http-nio-8080-exec-3] [request_id=43abd78c-9257-4909-a54a-90147cdc33ce] INFO  [com.staccato.auth.service.AuthService.extractFromToken.-56] - [Login Member ID : 1 | Login Member Nickname : hotea]`

- 스프링 기본 로그들 중 크리티컬 하지 않은 로그들은 모두 로깅에서 제외

## 🛠️ Technical Concerns
- `Service CRUD` 메서드마다 로깅을 추가하게 된다면 무의미하고 방대한 로깅만 남겠다고 생각되어서 설정해놓지 않았습니다.
  - 추후에 필요한 경우 구성예정

## 🙂 To Reviewer


## 📋 To Do
