### PR TITLE
feat: 댓글 수정 API 구현 #245

### DIFF
--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -9,6 +9,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.staccato.comment.controller.docs.CommentControllerDocs;
 import com.staccato.comment.service.CommentService;
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.member.domain.Member;
@@ -47,5 +49,15 @@ public class CommentController implements CommentControllerDocs {
     ) {
         CommentResponses commentResponses = commentService.readAllCommentsByMomentId(member, momentId);
         return ResponseEntity.ok().body(commentResponses);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateComment(
+            @LoginMember Member member,
+            @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+    ) {
+       commentService.updateComment(member, commentId, commentUpdateRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -21,6 +21,7 @@ import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
+import com.staccato.exception.validation.ValidationSteps.ValidationSequence;
 import com.staccato.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -55,7 +56,7 @@ public class CommentController implements CommentControllerDocs {
     public ResponseEntity<Void> updateComment(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
-            @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+            @Validated(ValidationSequence.class) @RequestBody CommentUpdateRequest commentUpdateRequest
     ) {
        commentService.updateComment(member, commentId, commentUpdateRequest);
         return ResponseEntity.ok().build();

--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -21,7 +21,6 @@ import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
-import com.staccato.exception.validation.ValidationSteps.ValidationSequence;
 import com.staccato.member.domain.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -56,9 +55,9 @@ public class CommentController implements CommentControllerDocs {
     public ResponseEntity<Void> updateComment(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
-            @Validated(ValidationSequence.class) @RequestBody CommentUpdateRequest commentUpdateRequest
+            @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
     ) {
-       commentService.updateComment(member, commentId, commentUpdateRequest);
+        commentService.updateComment(member, commentId, commentUpdateRequest);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
+++ b/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
@@ -4,12 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.validation.annotation.Validated;
 
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
-import com.staccato.exception.validation.ValidationSteps.ValidationSequence;
 import com.staccato.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -70,5 +68,5 @@ public interface CommentControllerDocs {
     ResponseEntity<Void> updateComment(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
-            @Parameter(description = "댓글 수정 시 요구 형식") @Validated(ValidationSequence.class) CommentUpdateRequest commentUpdateRequest);
+            @Parameter(description = "댓글 수정 시 요구 형식") @Valid CommentUpdateRequest commentUpdateRequest);
 }

--- a/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
+++ b/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
@@ -4,10 +4,12 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
+import com.staccato.exception.validation.ValidationSteps.ValidationSequence;
 import com.staccato.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -68,5 +70,5 @@ public interface CommentControllerDocs {
     ResponseEntity<Void> updateComment(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
-            @Parameter(description = "댓글 수정 시 요구 형식") @Valid CommentUpdateRequest commentUpdateRequest);
+            @Parameter(description = "댓글 수정 시 요구 형식") @Validated(ValidationSequence.class) CommentUpdateRequest commentUpdateRequest);
 }

--- a/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
+++ b/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.member.domain.Member;
 
@@ -47,4 +48,25 @@ public interface CommentControllerDocs {
     ResponseEntity<CommentResponses> readCommentsByMomentId(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "댓글이 속한 순간 식별자", example = "1") @Min(value = 1L, message = "순간 식별자는 양수로 이루어져야 합니다.") long momentId);
+
+    @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "댓글 수정 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                                        
+                    (1) 댓글 식별자가 양수가 아닐 때
+                                        
+                    (2) 요청한 댓글을 찾을 수 없을 때
+                                        
+                    (3) 댓글 내용이 공백 뿐이거나 없을 때
+                                        
+                    (4) 댓글이 공백 포함 500자 초과일 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<Void> updateComment(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @Parameter(description = "댓글 수정 시 요구 형식") @Valid CommentUpdateRequest commentUpdateRequest);
 }

--- a/backend/src/main/java/com/staccato/comment/domain/Comment.java
+++ b/backend/src/main/java/com/staccato/comment/domain/Comment.java
@@ -1,5 +1,7 @@
 package com.staccato.comment.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -53,5 +55,9 @@ public class Comment extends BaseEntity {
 
     public void changeContent(String content) {
         this.content = content;
+    }
+
+    public boolean isNotOwnedBy(Member member) {
+        return !Objects.equals(this.member, member);
     }
 }

--- a/backend/src/main/java/com/staccato/comment/domain/Comment.java
+++ b/backend/src/main/java/com/staccato/comment/domain/Comment.java
@@ -50,4 +50,8 @@ public class Comment extends BaseEntity {
         this.member = member;
         moment.addComment(this);
     }
+
+    public void changeContent(String content) {
+        this.content = content;
+    }
 }

--- a/backend/src/main/java/com/staccato/comment/service/CommentService.java
+++ b/backend/src/main/java/com/staccato/comment/service/CommentService.java
@@ -44,8 +44,9 @@ public class CommentService {
     }
 
     @Transactional
-    public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
+    public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest, Member member) {
         Comment comment = getComment(commentId);
+        validateCommentOwner(comment, member);
         comment.changeContent(commentUpdateRequest.content());
     }
 
@@ -61,6 +62,12 @@ public class CommentService {
 
     private void validateOwner(Memory memory, Member member) {
         if (memory.isNotOwnedBy(member)) {
+            throw new ForbiddenException();
+        }
+    }
+
+    private void validateCommentOwner(Comment comment, Member member) {
+        if (comment.isNotOwnedBy(member)) {
             throw new ForbiddenException();
         }
     }

--- a/backend/src/main/java/com/staccato/comment/service/CommentService.java
+++ b/backend/src/main/java/com/staccato/comment/service/CommentService.java
@@ -44,7 +44,7 @@ public class CommentService {
     }
 
     @Transactional
-    public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest, Member member) {
+    public void updateComment(Member member, Long commentId, CommentUpdateRequest commentUpdateRequest) {
         Comment comment = getComment(commentId);
         validateCommentOwner(comment, member);
         comment.changeContent(commentUpdateRequest.content());

--- a/backend/src/main/java/com/staccato/comment/service/CommentService.java
+++ b/backend/src/main/java/com/staccato/comment/service/CommentService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.staccato.comment.domain.Comment;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
@@ -42,9 +43,20 @@ public class CommentService {
         return CommentResponses.from(comments);
     }
 
+    @Transactional
+    public void updateComment(Long commentId, CommentUpdateRequest commentUpdateRequest) {
+        Comment comment = getComment(commentId);
+        comment.changeContent(commentUpdateRequest.content());
+    }
+
     private Moment getMoment(long momentId) {
         return momentRepository.findById(momentId)
                 .orElseThrow(() -> new StaccatoException("요청하신 순간을 찾을 수 없어요."));
+    }
+
+    private Comment getComment(long commentId) {
+        return commentRepository.findById(commentId)
+                .orElseThrow(() -> new StaccatoException("요청하신 댓글을 찾을 수 없어요."));
     }
 
     private void validateOwner(Memory memory, Member member) {

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequest.java
@@ -19,7 +19,7 @@ public record CommentRequest(
         Long momentId,
         @Schema(example = "예시 댓글 내용")
         @NotBlank(message = "댓글 내용을 입력해주세요.")
-        @Size(min = 1, max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
+        @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
         String content
 ) {
         public Comment toComment(Moment moment, Member member) {

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.staccato.comment.service.dto.request;
+
+public record CommentUpdateRequest(String content) {
+}

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
@@ -3,7 +3,11 @@ package com.staccato.comment.service.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "댓글 수정 시 요청 형식입니다.")
 public record CommentUpdateRequest(
+        @Schema(example = "예시 수정된 댓글 내용")
         @NotBlank(message = "댓글 내용을 입력해주세요.")
         @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
         String content

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
@@ -3,12 +3,9 @@ package com.staccato.comment.service.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import com.staccato.exception.validation.ValidationSteps.FirstStep;
-import com.staccato.exception.validation.ValidationSteps.SecondStep;
-
 public record CommentUpdateRequest(
-        @NotBlank(message = "댓글 내용을 입력해주세요.", groups = FirstStep.class)
-        @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.", groups = SecondStep.class)
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
         String content
 ) {
 }

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
@@ -1,4 +1,14 @@
 package com.staccato.comment.service.dto.request;
 
-public record CommentUpdateRequest(String content) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import com.staccato.exception.validation.ValidationSteps.FirstStep;
+import com.staccato.exception.validation.ValidationSteps.SecondStep;
+
+public record CommentUpdateRequest(
+        @NotBlank(message = "댓글 내용을 입력해주세요.", groups = FirstStep.class)
+        @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.", groups = SecondStep.class)
+        String content
+) {
 }

--- a/backend/src/main/java/com/staccato/exception/validation/ValidationSteps.java
+++ b/backend/src/main/java/com/staccato/exception/validation/ValidationSteps.java
@@ -1,0 +1,15 @@
+package com.staccato.exception.validation;
+
+import jakarta.validation.GroupSequence;
+
+public class ValidationSteps {
+    public interface FirstStep {
+    }
+
+    public interface SecondStep {
+    }
+
+    @GroupSequence({FirstStep.class, SecondStep.class})
+    public interface ValidationSequence {
+    }
+}

--- a/backend/src/main/java/com/staccato/member/domain/Member.java
+++ b/backend/src/main/java/com/staccato/member/domain/Member.java
@@ -14,6 +14,7 @@ import com.staccato.config.domain.BaseEntity;
 
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -22,10 +23,12 @@ import lombok.NonNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLDelete(sql = "UPDATE member SET is_deleted = true WHERE id = ?")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @SQLRestriction("is_deleted = false")
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @EqualsAndHashCode.Include
     private Long id;
     @Column(nullable = false, unique = true)
     @Embedded

--- a/backend/src/main/java/com/staccato/memory/domain/MemoryMember.java
+++ b/backend/src/main/java/com/staccato/memory/domain/MemoryMember.java
@@ -1,5 +1,7 @@
 package com.staccato.memory.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -39,6 +41,6 @@ public class MemoryMember extends BaseEntity {
     }
 
     public boolean isMember(Member member) {
-        return this.member.getId().equals(member.getId());
+        return Objects.equals(this.member, member);
     }
 }

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -172,4 +172,22 @@ public class CommentControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());
     }
+
+    @DisplayName("댓글 식별자가 양수가 아닐 경우 댓글 수정에 실패한다.")
+    @Test
+    void updateCommentFail() throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(Member.builder().nickname("member").build());
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest("updated content");
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "댓글 식별자는 양수로 이루어져야 합니다.");
+
+        // when & then
+        mockMvc.perform(put("/comments")
+                        .param("commentId", "0")
+                        .content(objectMapper.writeValueAsString(commentUpdateRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
 }

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -184,6 +186,26 @@ public class CommentControllerTest {
         // when & then
         mockMvc.perform(put("/comments")
                         .param("commentId", "0")
+                        .content(objectMapper.writeValueAsString(commentUpdateRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
+
+    @DisplayName("댓글 내용을 입력하지 않을 경우 댓글 수정에 실패한다.")
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"", " "})
+    void updateCommentFailByBlank(String updatedContent) throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(Member.builder().nickname("member").build());
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "댓글 내용을 입력해주세요.");
+
+        // when & then
+        mockMvc.perform(put("/comments")
+                        .param("commentId", "1")
                         .content(objectMapper.writeValueAsString(commentUpdateRequest))
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "token"))

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -29,6 +30,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;
 import com.staccato.comment.service.CommentService;
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponse;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.exception.ExceptionResponse;
@@ -153,5 +155,21 @@ public class CommentControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
+
+    @DisplayName("올바른 형식으로 댓글 수정을 시도하면 성공한다.")
+    @Test
+    void updateComment() throws Exception {
+        // given
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest("updated content");
+        when(authService.extractFromToken(any())).thenReturn(Member.builder().nickname("member").build());
+
+        // when & then
+        mockMvc.perform(put("/comments")
+                        .param("commentId", "1")
+                        .content(objectMapper.writeValueAsString(commentUpdateRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -75,6 +75,10 @@ public class CommentControllerTest {
                         "댓글 내용을 입력해주세요."
                 ),
                 Arguments.of(
+                        new CommentRequest(MIN_MOMENT_ID, ""),
+                        "댓글 내용을 입력해주세요."
+                ),
+                Arguments.of(
                         new CommentRequest(MIN_MOMENT_ID, " "),
                         "댓글 내용을 입력해주세요."
                 ),

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -125,4 +125,18 @@ class CommentServiceTest extends ServiceSliceTest {
         // then
         assertThat(commentRepository.findById(comment.getId()).get().getContent()).isEqualTo(updatedContent);
     }
+
+    @DisplayName("댓글을 찾을 수 없는 경우 예외가 발생한다.")
+    @Test
+    void updateCommentFailByNotExist() {
+        // given
+        long notExistCommentId = 1;
+        String updatedContent = "updated content";
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
+
+        // when & then
+        assertThatThrownBy(() -> commentService.updateComment(notExistCommentId, commentUpdateRequest))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("요청하신 댓글을 찾을 수 없어요.");
+    }
 }

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -75,7 +75,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Member momentOwner = memberRepository.save(MemberFixture.create("momentOwner"));
         Member unexpectedMember = memberRepository.save(MemberFixture.create("unexpectedMember"));
         Memory memory = memoryRepository.save(MemoryFixture.create(momentOwner));
-        Moment moment = momentRepository.save(MomentFixture.create(memory));
+        momentRepository.save(MomentFixture.create(memory));
         CommentRequest commentRequest = new CommentRequest(1L, "content");
 
         // when & then
@@ -117,7 +117,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Moment moment = momentRepository.save(MomentFixture.create(memory));
         commentRepository.save(CommentFixture.create(moment, momentOwner));
 
-        // when
+        // when & then
         assertThatThrownBy(() -> commentService.readAllCommentsByMomentId(unexpectedMember, moment.getId()))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("요청하신 작업을 처리할 권한이 없습니다.");

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -107,6 +107,22 @@ class CommentServiceTest extends ServiceSliceTest {
                 .containsExactly(commentId1, commentId2);
     }
 
+    @DisplayName("조회 권한이 없는 순간에 달린 댓글들 조회를 시도하면 예외가 발생한다.")
+    @Test
+    void readAllByMomentIdFailByForbidden() {
+        // given
+        Member momentOwner = memberRepository.save(MemberFixture.create("momentOwner"));
+        Member unexpectedMember = memberRepository.save(MemberFixture.create("unexpectedMember"));
+        Memory memory = memoryRepository.save(MemoryFixture.create(momentOwner));
+        Moment moment = momentRepository.save(MomentFixture.create(memory));
+        commentRepository.save(CommentFixture.create(moment, momentOwner));
+
+        // when
+        assertThatThrownBy(() -> commentService.readAllCommentsByMomentId(unexpectedMember, moment.getId()))
+                .isInstanceOf(ForbiddenException.class)
+                .hasMessageContaining("요청하신 작업을 처리할 권한이 없습니다.");
+    }
+
     @DisplayName("본인이 쓴 댓글은 수정할 수 있다.")
     @Test
     void updateComment() {

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -8,14 +8,17 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import com.staccato.ServiceSliceTest;
+import com.staccato.comment.domain.Comment;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponse;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.fixture.Member.MemberFixture;
 import com.staccato.fixture.memory.MemoryFixture;
+import com.staccato.fixture.moment.CommentFixture;
 import com.staccato.fixture.moment.MomentFixture;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
@@ -102,5 +105,24 @@ class CommentServiceTest extends ServiceSliceTest {
         // then
         assertThat(commentResponses.comments().stream().map(CommentResponse::commentId).toList())
                 .containsExactly(commentId1, commentId2);
+    }
+
+    @DisplayName("본인이 쓴 댓글은 수정할 수 있다.")
+    @Test
+    void updateComment() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create("nickname"));
+        Memory memory = memoryRepository.save(MemoryFixture.create(member));
+        Moment moment = momentRepository.save(MomentFixture.create(memory));
+        Comment comment = commentRepository.save(CommentFixture.create(moment, member));
+
+        String updatedContent = "updated content";
+        CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
+
+        // when
+        commentService.updateComment(comment.getId(), commentUpdateRequest);
+
+        // then
+        assertThat(commentRepository.findById(comment.getId()).get().getContent()).isEqualTo(updatedContent);
     }
 }

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -136,7 +136,7 @@ class CommentServiceTest extends ServiceSliceTest {
         CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
 
         // when
-        commentService.updateComment(comment.getId(), commentUpdateRequest, member);
+        commentService.updateComment(member, comment.getId(), commentUpdateRequest);
 
         // then
         assertThat(commentRepository.findById(comment.getId()).get().getContent()).isEqualTo(updatedContent);
@@ -151,7 +151,7 @@ class CommentServiceTest extends ServiceSliceTest {
         CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
 
         // when & then
-        assertThatThrownBy(() -> commentService.updateComment(notExistCommentId, commentUpdateRequest, MemberFixture.create()))
+        assertThatThrownBy(() -> commentService.updateComment(MemberFixture.create(), notExistCommentId, commentUpdateRequest))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 댓글을 찾을 수 없어요.");
     }
@@ -170,7 +170,7 @@ class CommentServiceTest extends ServiceSliceTest {
         CommentUpdateRequest commentUpdateRequest = new CommentUpdateRequest(updatedContent);
 
         // when & then
-        assertThatThrownBy(() -> commentService.updateComment(comment.getId(), commentUpdateRequest, unexpectedMember))
+        assertThatThrownBy(() -> commentService.updateComment(unexpectedMember, comment.getId(), commentUpdateRequest))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessageContaining("요청하신 작업을 처리할 권한이 없습니다.");
     }

--- a/backend/src/test/java/com/staccato/fixture/memory/MemoryFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/memory/MemoryFixture.java
@@ -2,6 +2,7 @@ package com.staccato.fixture.memory;
 
 import java.time.LocalDate;
 
+import com.staccato.member.domain.Member;
 import com.staccato.memory.domain.Memory;
 
 public class MemoryFixture {
@@ -13,6 +14,19 @@ public class MemoryFixture {
                 .startAt(LocalDate.of(2024, 7, 1))
                 .endAt(LocalDate.of(2024, 7, 10))
                 .build();
+    }
+
+    public static Memory create(Member member) {
+        Memory memory = Memory.builder()
+                .thumbnailUrl("https://example.com/memorys/geumohrm.jpg")
+                .title("2024 여름 휴가")
+                .description("친구들과 함께한 여름 휴가 추억")
+                .startAt(LocalDate.of(2024, 7, 1))
+                .endAt(LocalDate.of(2024, 7, 10))
+                .build();
+        memory.addMemoryMember(member);
+
+        return memory;
     }
 
     public static Memory create(LocalDate startAt, LocalDate endAt) {

--- a/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
@@ -1,6 +1,7 @@
 package com.staccato.fixture.moment;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,6 +12,18 @@ import com.staccato.moment.domain.MomentImages;
 public class MomentFixture {
     private static final BigDecimal latitude = new BigDecimal("37.7749");
     private static final BigDecimal longitude = new BigDecimal("-122.4194");
+
+    public static Moment create(Memory memory) {
+        return Moment.builder()
+                .visitedAt(LocalDateTime.of(2024, 7, 1, 10, 0))
+                .placeName("placeName")
+                .latitude(latitude)
+                .longitude(longitude)
+                .address("address")
+                .memory(memory)
+                .momentImages(new MomentImages(List.of()))
+                .build();
+    }
 
     public static Moment create(Memory memory, LocalDateTime visitedAt) {
         return Moment.builder()


### PR DESCRIPTION
## ⭐️ Issue Number
- #245

## 🚩 Summary
- 댓글 수정 API 구현
- Controller, DTO 단에 Swagger 적용

## 🛠️ Technical Concerns


## 🙂 To Reviewer
댓글 생성 때 사용하는 CommentRequest를 댓글 수정을 요청하는 DTO로 재활용할 수도 있었는데요. 제 생각에는 API별로 DTO를 분리하는 것이 단일 책임 원칙에도 부합하고, API명세에 변경사항이 생겼을 때 유지보수 지점이 명확하여 관리하기가 더 쉬울 것이라 생각해서 분리했습니다. 이에 대해 어떻게 생각하시는지 궁금해요!

## 📋 To Do
