### PR TITLE
feat: 서버 별로 이미지 저장 경로 설정

### DIFF
--- a/backend/src/main/java/com/staccato/image/service/ImageService.java
+++ b/backend/src/main/java/com/staccato/image/service/ImageService.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -17,8 +18,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class ImageService {
-    private static final String TEAM_FOLDER = "staccato/";
-    private static final String IMAGE_FOLDER = "image/";
+    private static final String TEAM_FOLDER_NAME = "staccato/";
+
+    @Value("${image.folder.name}")
+    private String imageFolderName;
 
     private final S3ObjectClient s3ObjectClient;
 
@@ -30,7 +33,7 @@ public class ImageService {
 
     public ImageUrlResponse uploadImage(MultipartFile image) {
         String imageExtension = getImageExtension(image);
-        String key = TEAM_FOLDER + IMAGE_FOLDER + UUID.randomUUID() + imageExtension;
+        String key = TEAM_FOLDER_NAME + imageFolderName + UUID.randomUUID() + imageExtension;
         String contentType = ImageExtension.getContentType(imageExtension);
         byte[] imageBytes = getImageBytes(image);
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -47,3 +47,6 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+image:
+  folder:
+    name: image/

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -45,3 +45,6 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+image:
+  folder:
+    name: image/

--- a/backend/src/main/resources/application-stage.yml
+++ b/backend/src/main/resources/application-stage.yml
@@ -47,3 +47,6 @@ cloud:
       static: ap-northeast-2
     stack:
       auto: false
+image:
+  folder:
+    name: image/


### PR DESCRIPTION
## ⭐️ Issue Number
- #271 

## 🚩 Summary
- 서버 별로 이미지 저장 경로 설정
   - `dev`, `stage` -> staccato/image
   - `prod` -> staccato/image-prod

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
