### PR TITLE
feat: 추억 이름 중복 불가 예외 처리 #280

### DIFF
--- a/backend/src/main/java/com/staccato/memory/controller/docs/MemoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/memory/controller/docs/MemoryControllerDocs.java
@@ -34,6 +34,8 @@ public interface MemoryControllerDocs {
                     (4) 내용이 공백 포함 500자를 초과했을 때
                                         
                     (5) 기간 설정이 잘못되었을 때
+                    
+                    (6) 이미 존재하는 추억 이름일 때
                     """,
                     responseCode = "400")
     })

--- a/backend/src/main/java/com/staccato/memory/domain/Memory.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Memory.java
@@ -95,4 +95,8 @@ public class Memory extends BaseEntity {
         return memoryMembers.stream()
                 .noneMatch(memoryMember -> memoryMember.isMember(member));
     }
+
+    public boolean isNotSameTitle(String title) {
+        return !this.title.equals(title);
+    }
 }

--- a/backend/src/main/java/com/staccato/memory/repository/MemoryRepository.java
+++ b/backend/src/main/java/com/staccato/memory/repository/MemoryRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.staccato.memory.domain.Memory;
 
 public interface MemoryRepository extends JpaRepository<Memory, Long> {
+    boolean existsByTitle(String title);
 }

--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -1,12 +1,10 @@
 package com.staccato.memory.service;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
@@ -22,7 +20,6 @@ import com.staccato.memory.service.dto.response.MemoryResponses;
 import com.staccato.memory.service.dto.response.MomentResponse;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.repository.MomentRepository;
-import com.staccato.image.service.ImageService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,14 +30,20 @@ public class MemoryService {
     private final MemoryRepository memoryRepository;
     private final MemoryMemberRepository memoryMemberRepository;
     private final MomentRepository momentRepository;
-    private final ImageService imageService;
 
     @Transactional
     public MemoryIdResponse createMemory(MemoryRequest memoryRequest, Member member) {
+        validateMemoryTitle(memoryRequest.memoryTitle());
         Memory memory = memoryRequest.toMemory();
         memory.addMemoryMember(member);
         memoryRepository.save(memory);
         return new MemoryIdResponse(memory.getId());
+    }
+
+    private void validateMemoryTitle(String title) {
+        if (memoryRepository.existsByTitle(title)) {
+            throw new StaccatoException("같은 이름을 가진 추억이 있어요. 다른 이름으로 설정해주세요.");
+        }
     }
 
     public MemoryResponses readAllMemories(Member member, Integer year) {

--- a/backend/src/test/java/com/staccato/fixture/memory/MemoryRequestFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/memory/MemoryRequestFixture.java
@@ -15,6 +15,16 @@ public class MemoryRequestFixture {
         );
     }
 
+    public static MemoryRequest create(LocalDate startAt, LocalDate endAt, String title) {
+        return new MemoryRequest(
+                "https://example.com/memorys/geumohrm.jpg",
+                title,
+                "친구들과 함께한 여름 휴가 추억",
+                startAt,
+                endAt
+        );
+    }
+
     public static MemoryRequest create(String imageUrl, LocalDate startAt, LocalDate endAt) {
         return new MemoryRequest(
                 imageUrl,

--- a/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
@@ -1,5 +1,6 @@
 package com.staccato.memory.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
@@ -27,5 +28,19 @@ class MemoryTest {
         assertThatThrownBy(() -> memory.update(updatedMemory, List.of(moment)))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("변경하려는 추억 기간이 이미 존재하는 순간을 포함하지 않습니다. 추억 기간을 다시 설정해주세요.");
+    }
+
+    @DisplayName("주어진 문자열과 제목이 같으면 거짓을 반환한다.")
+    @Test
+    void isNotSameTitle(){
+        // given
+        String title = "title";
+        Memory memory = Memory.builder().title(title).build();
+
+        // when
+        boolean result = memory.isNotSameTitle(title);
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -1,6 +1,7 @@
 package com.staccato.memory.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -80,7 +81,7 @@ class MemoryServiceTest extends ServiceSliceTest {
         );
     }
 
-    @DisplayName("추억 정보를 기반으로, 추억을 생성하고 작성자를 저장한다.")
+    @DisplayName("이미 존재하는 추억 이름으로 추억을 생성할 수 없다.")
     @Test
     void cannotCreateMemoryByDuplicatedTitle() {
         // given
@@ -88,7 +89,7 @@ class MemoryServiceTest extends ServiceSliceTest {
         Member member = memberRepository.save(MemberFixture.create());
         memoryService.createMemory(memoryRequest, member);
 
-        // when then
+        // when & then
         assertThatThrownBy(() -> memoryService.createMemory(memoryRequest, member))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("같은 이름을 가진 추억이 있어요. 다른 이름으로 설정해주세요.");
@@ -185,7 +186,7 @@ class MemoryServiceTest extends ServiceSliceTest {
     void updateMemory(MemoryRequest updatedMemory, String expected) {
         // given
         Member member = memberRepository.save(MemberFixture.create());
-        MemoryIdResponse memoryResponse = memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10)), member);
+        MemoryIdResponse memoryResponse = memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10), "originTitle"), member);
 
         // when
         memoryService.updateMemory(updatedMemory, memoryResponse.memoryId(), member);
@@ -228,6 +229,35 @@ class MemoryServiceTest extends ServiceSliceTest {
         assertThatThrownBy(() -> memoryService.updateMemory(updatedMemory, memoryIdResponse.memoryId(), otherMember))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
+    }
+
+    @DisplayName("본래 해당 추억의 이름과 동일한 이름으로 추억을 수정할 수 있다.")
+    @Test
+    void updateMemoryByOriginTitle() {
+        // given
+        MemoryRequest memoryRequest = MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10));
+        Member member = memberRepository.save(MemberFixture.create());
+        MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
+
+        // when then
+        assertThatNoException().isThrownBy(() -> memoryService.updateMemory(memoryRequest, memoryIdResponse.memoryId(), member));
+    }
+
+    @DisplayName("이미 존재하는 이름으로 추억을 수정할 수 없다.")
+    @Test
+    void cannotUpdateMemoryByDuplicatedTitle() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create());
+        MemoryRequest memoryRequest1 = MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10), "existingTitle");
+        memoryService.createMemory(memoryRequest1, member);
+        MemoryRequest memoryRequest2 = MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10), "otherTitle");
+        MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest2, member);
+
+        // when then
+        assertThatThrownBy(() -> memoryService.updateMemory(memoryRequest1, memoryIdResponse.memoryId(), member))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("같은 이름을 가진 추억이 있어요. 다른 이름으로 설정해주세요.");
+        ;
     }
 
     @DisplayName("추억 식별값을 통해 추억을 삭제한다.")

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -80,14 +80,28 @@ class MemoryServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("추억 정보를 기반으로, 추억을 생성하고 작성자를 저장한다.")
+    @Test
+    void cannotCreateMemoryByDuplicatedTitle() {
+        // given
+        MemoryRequest memoryRequest = MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10));
+        Member member = memberRepository.save(MemberFixture.create());
+        memoryService.createMemory(memoryRequest, member);
+
+        // when then
+        assertThatThrownBy(() -> memoryService.createMemory(memoryRequest, member))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessage("같은 이름을 가진 추억이 있어요. 다른 이름으로 설정해주세요.");
+    }
+
     @DisplayName("조건에 따라 추억 목록을 조회한다.")
     @MethodSource("yearProvider")
     @ParameterizedTest
     void readAllMemories(Integer year, int expectedSize) {
         // given
         Member member = memberRepository.save(MemberFixture.create());
-        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2023, 7, 1), LocalDate.of(2024, 7, 10)), member);
-        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10)), member);
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2023, 7, 1), LocalDate.of(2024, 7, 10), "title1"), member);
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10), "title2"), member);
 
         // when
         MemoryResponses memoryResponses = memoryService.readAllMemories(member, year);

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -239,7 +239,7 @@ class MemoryServiceTest extends ServiceSliceTest {
         Member member = memberRepository.save(MemberFixture.create());
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
 
-        // when then
+        // when & then
         assertThatNoException().isThrownBy(() -> memoryService.updateMemory(memoryRequest, memoryIdResponse.memoryId(), member));
     }
 
@@ -253,7 +253,7 @@ class MemoryServiceTest extends ServiceSliceTest {
         MemoryRequest memoryRequest2 = MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10), "otherTitle");
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest2, member);
 
-        // when then
+        // when & then
         assertThatThrownBy(() -> memoryService.updateMemory(memoryRequest1, memoryIdResponse.memoryId(), member))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("같은 이름을 가진 추억이 있어요. 다른 이름으로 설정해주세요.");

--- a/backend/src/test/java/com/staccato/moment/service/MomentServiceTest.java
+++ b/backend/src/test/java/com/staccato/moment/service/MomentServiceTest.java
@@ -19,6 +19,8 @@ import com.staccato.comment.domain.Comment;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
+import com.staccato.fixture.Member.MemberFixture;
+import com.staccato.fixture.memory.MemoryFixture;
 import com.staccato.fixture.moment.CommentFixture;
 import com.staccato.fixture.moment.MomentFixture;
 import com.staccato.member.domain.Member;
@@ -269,22 +271,6 @@ class MomentServiceTest extends ServiceSliceTest {
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
     }
 
-    private Member saveMember() {
-        return memberRepository.save(Member.builder().nickname("staccato").build());
-    }
-
-    private Memory saveMemory(Member member) {
-        Memory memory = Memory.builder().title("Sample Memory").startAt(LocalDate.now())
-                .endAt(LocalDate.now().plusDays(1)).build();
-        memory.addMemoryMember(member);
-        return memoryRepository.save(memory);
-    }
-
-    private Moment saveMomentWithImages(Memory memory) {
-        Moment moment = MomentFixture.createWithImages(memory, LocalDateTime.now(), new MomentImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
-        return momentRepository.save(moment);
-    }
-
     @DisplayName("순간의 기분을 선택할 수 있다.")
     @Test
     void updateMomentFeelingById() {
@@ -302,5 +288,20 @@ class MomentServiceTest extends ServiceSliceTest {
                 () -> assertThat(momentRepository.findById(moment.getId())).isNotEmpty(),
                 () -> assertThat(momentRepository.findById(moment.getId()).get().getFeeling()).isEqualTo(Feeling.HAPPY)
         );
+    }
+
+    private Member saveMember() {
+        return memberRepository.save(MemberFixture.create());
+    }
+
+    private Memory saveMemory(Member member) {
+        Memory memory = MemoryFixture.create(LocalDate.now(), LocalDate.now().plusDays(1));
+        memory.addMemoryMember(member);
+        return memoryRepository.save(memory);
+    }
+
+    private Moment saveMomentWithImages(Memory memory) {
+        Moment moment = MomentFixture.createWithImages(memory, LocalDateTime.now(), new MomentImages(List.of("https://oldExample.com.jpg", "https://existExample.com.jpg")));
+        return momentRepository.save(moment);
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #280
## 🚩 Summary
- 추억을 생성할 때 이미 존재하는 이름으로는 생성할 수 없다.
- 추억을 수정할 때 본래 해당 추억의 이름이 아닌 이미 존재하는 타 추억의 이름으로 변경할 수 없다.
- 픽스처 리팩터링

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
