### PR TITLE
build: Android CD 수정

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -78,13 +78,13 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: app-release.apk
-          path: app/build/outputs/apk/release/app-release.apk
+          path: android/Staccato_AN/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload Release AAB
         uses: actions/upload-artifact@v3
         with:
           name: app-release.aab
-          path: ./app/build/outputs/bundle/release/app-release.aab
+          path: android/Staccato_AN/app/build/outputs/bundle/release/app-release.aab
 
       - name: Upload On Google Play
         uses: r0adkll/upload-google-play@v1

--- a/.github/workflows/android-ci-cd-demo-apk.yml
+++ b/.github/workflows/android-ci-cd-demo-apk.yml
@@ -75,7 +75,8 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: debug-apk
-          path: app/build/outputs/apk/debug/app-debug.apk
+          path: android/Staccato_AN/app/build/outputs/apk/debug/app-debug.apk
+          if-no-files-found: error
 
       - name: Upload Artifact to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1


### PR DESCRIPTION
## ⭐️ Issue Number
- #315 

## 🚩 Summary

- [x] upload-artifact step에서 빌드 파일의 upload 경로 수정
  - upload-artifact 는 defaults 설정의 working-directory 경로가 적용되지 않음
