### PR TITLE
fix: 스타카토 생성, 삭제 후 지도 화면의 마커가 갱신되지 않는 오류 해결 #326

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/main/SharedViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/main/SharedViewModel.kt
@@ -9,7 +9,14 @@ class SharedViewModel : ViewModel() {
     val isTimelineUpdated: SingleLiveData<Boolean>
         get() = _isTimelineUpdated
 
+    private val _isStaccatosUpdated = MutableSingleLiveData(false)
+    val isStaccatosUpdated: SingleLiveData<Boolean> get() = _isStaccatosUpdated
+
     fun setTimelineHasUpdated() {
         _isTimelineUpdated.setValue(true)
+    }
+
+    fun setStaccatosHasUpdated() {
+        _isStaccatosUpdated.setValue(true)
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
@@ -13,6 +13,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.findNavController
@@ -30,6 +31,7 @@ import com.woowacourse.staccato.data.StaccatoClient.momentApiService
 import com.woowacourse.staccato.data.moment.MomentDefaultRepository
 import com.woowacourse.staccato.data.moment.MomentRemoteDataSource
 import com.woowacourse.staccato.domain.model.MomentLocation
+import com.woowacourse.staccato.presentation.main.SharedViewModel
 import com.woowacourse.staccato.presentation.maps.model.MarkerUiModel
 import com.woowacourse.staccato.presentation.moment.MomentFragment.Companion.MOMENT_ID_KEY
 
@@ -41,6 +43,7 @@ class MapsFragment : Fragment() {
             ),
         )
     }
+    private val sharedViewModel: SharedViewModel by activityViewModels<SharedViewModel>()
 
     private val mapReadyCallback =
         OnMapReadyCallback { googleMap ->
@@ -74,6 +77,7 @@ class MapsFragment : Fragment() {
         val mapFragment = childFragmentManager.findFragmentById(R.id.map) as SupportMapFragment?
         mapFragment?.getMapAsync(mapReadyCallback)
         observeStaccatoId()
+        observeDeletedStaccato()
     }
 
     override fun onResume() {
@@ -131,6 +135,7 @@ class MapsFragment : Fragment() {
 
     private fun observeMomentLocations(googleMap: GoogleMap) {
         viewModel.momentLocations.observe(viewLifecycleOwner) { momentLocations ->
+            googleMap.clear()
             addMarkers(momentLocations, googleMap)
         }
     }
@@ -180,6 +185,14 @@ class MapsFragment : Fragment() {
         val bundle =
             bundleOf(MOMENT_ID_KEY to staccatoId)
         findNavController().navigate(R.id.momentFragment, bundle, navOptions)
+    }
+
+    private fun observeDeletedStaccato() {
+        sharedViewModel.isStaccatosUpdated.observe(viewLifecycleOwner) { isDeleted ->
+            if (isDeleted) {
+                viewModel.loadStaccatos()
+            }
+        }
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
@@ -76,6 +76,11 @@ class MapsFragment : Fragment() {
         observeStaccatoId()
     }
 
+    override fun onResume() {
+        super.onResume()
+        viewModel.loadMoments()
+    }
+
     private fun checkLocationPermissions(googleMap: GoogleMap) {
         val isAccessFineLocationGranted =
             ContextCompat.checkSelfPermission(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsFragment.kt
@@ -78,7 +78,7 @@ class MapsFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.loadMoments()
+        viewModel.loadStaccatos()
     }
 
     private fun checkLocationPermissions(googleMap: GoogleMap) {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
@@ -40,7 +40,7 @@ class MapsViewModel(
         _staccatoId.value = markers.first { it.markerId == markerId }.staccatoId
     }
 
-    fun loadMoments() {
+    fun loadStaccatos() {
         viewModelScope.launch {
             val result = momentRepository.getMoments()
             result.onSuccess(::setMomentLocations)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
@@ -31,10 +31,6 @@ class MapsViewModel(
     private val _staccatoId = MutableLiveData<Long>()
     val staccatoId: LiveData<Long> get() = _staccatoId
 
-    init {
-        loadMoments()
-    }
-
     fun setMarkers(markers: List<MarkerUiModel>) {
         _markers.value = markers
     }
@@ -44,7 +40,7 @@ class MapsViewModel(
         _staccatoId.value = markers.first { it.markerId == markerId }.staccatoId
     }
 
-    private fun loadMoments() {
+    fun loadMoments() {
         viewModelScope.launch {
             val result = momentRepository.getMoments()
             result.onSuccess(::setMomentLocations)

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/maps/MapsViewModel.kt
@@ -14,7 +14,6 @@ import com.woowacourse.staccato.presentation.common.MutableSingleLiveData
 import com.woowacourse.staccato.presentation.common.SingleLiveData
 import com.woowacourse.staccato.presentation.maps.model.MarkerUiModel
 import kotlinx.coroutines.launch
-import java.lang.IllegalArgumentException
 
 class MapsViewModel(
     private val momentRepository: MomentRepository,

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memory/MemoryFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memory/MemoryFragment.kt
@@ -75,8 +75,6 @@ class MemoryFragment :
             val bundle =
                 bundleOf(
                     MOMENT_ID_KEY to visitId,
-//                    MEMORY_ID_KEY to memoryId,
-//                    MEMORY_TITLE_KEY to it.title,
                 )
             findNavController().navigate(R.id.action_memoryFragment_to_momentFragment, bundle)
         }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/moment/MomentFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/moment/MomentFragment.kt
@@ -3,6 +3,7 @@ package com.woowacourse.staccato.presentation.moment
 import android.os.Bundle
 import android.view.View
 import androidx.core.os.bundleOf
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.google.android.material.tabs.TabLayoutMediator
@@ -11,6 +12,7 @@ import com.woowacourse.staccato.databinding.FragmentMomentBinding
 import com.woowacourse.staccato.presentation.base.BindingFragment
 import com.woowacourse.staccato.presentation.common.DeleteDialogFragment
 import com.woowacourse.staccato.presentation.main.MainActivity
+import com.woowacourse.staccato.presentation.main.SharedViewModel
 import com.woowacourse.staccato.presentation.moment.comments.MomentCommentsFragment
 import com.woowacourse.staccato.presentation.moment.detail.ViewpagePhotoAdapter
 import com.woowacourse.staccato.presentation.moment.feeling.MomentFeelingSelectionFragment
@@ -25,6 +27,7 @@ class MomentFragment :
     private val momentViewModel: MomentViewModel by viewModels { MomentViewModelFactory() }
     private var momentId by Delegates.notNull<Long>()
     private lateinit var pagePhotoAdapter: ViewpagePhotoAdapter
+    private val sharedViewModel: SharedViewModel by activityViewModels<SharedViewModel>()
     private val deleteDialog =
         DeleteDialogFragment {
             momentViewModel.deleteMoment(momentId)
@@ -94,7 +97,10 @@ class MomentFragment :
             }
         }
         momentViewModel.isDeleted.observe(viewLifecycleOwner) { isDeleted ->
-            if (isDeleted) findNavController().popBackStack()
+            if (isDeleted) {
+                sharedViewModel.setStaccatosHasUpdated()
+                findNavController().popBackStack()
+            }
         }
     }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #326 

<br>

## 🚩 Summary

- 스타카토 생성, 삭제 후 지도 화면의 마커가 갱신되지 않는 오류 해결
- 지도 로드 시 현위치로 카메라 이동

<br>

## 🛠️ Technical Concerns
(추후 작성)

<br>

## 🙂 To Reveiwer

<br>

## 📋 To Do
