### PR TITLE
feat: 추억 생성 및 수정 이미지 로딩 중 표시 및 저장 버튼 비활성화 #332

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -7,6 +7,7 @@ import android.widget.Button
 import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.NumberPicker
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
@@ -444,4 +445,28 @@ fun ImageView.enableSendButton(commentInput: MutableLiveData<String>) {
 
 fun String?.isBlankOrEmpty(): Boolean {
     return this == null || this.trim().isEmpty()
+}
+
+@BindingAdapter(value = ["thumbnailUri", "thumbnailUrl"])
+fun ProgressBar.setThumbnailLoadingProgressBar(
+    thumbnailUri: Uri?,
+    thumbnailUrl: String?,
+) {
+    visibility = if (thumbnailUri != null && thumbnailUrl == null) {
+        View.VISIBLE
+    } else {
+        View.GONE
+    }
+}
+
+@BindingAdapter(value = ["thumbnailUri", "thumbnailUrl"])
+fun View.setThumbnail(
+    thumbnailUri: Uri?,
+    thumbnailUrl: String?,
+) {
+    visibility = if (thumbnailUri == null && thumbnailUrl == null) {
+        View.VISIBLE
+    } else {
+        View.GONE
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/BindingAdapters.kt
@@ -188,15 +188,36 @@ fun Button.setLoginButtonActive(nickName: String?) {
 }
 
 @BindingAdapter(
-    value = ["memoryTitle", "startDate", "endDate"],
+    value = ["memoryTitle", "startDate", "endDate", "isPhotoPosting"],
 )
 fun Button.setMemorySaveButtonActive(
     title: String?,
     startDate: LocalDate?,
     endDate: LocalDate?,
+    isPhotoPosting: Boolean?,
 ) {
     isEnabled =
-        if (title.isNullOrBlank() || startDate == null || endDate == null) {
+        if (title.isNullOrBlank() || startDate == null || endDate == null || isPhotoPosting == true) {
+            setTextColor(resources.getColor(R.color.gray4, null))
+            false
+        } else {
+            setTextColor(resources.getColor(R.color.white, null))
+            true
+        }
+}
+
+@BindingAdapter(
+    value = ["memoryTitle", "startDate", "endDate", "photoUri", "photoUrl"],
+)
+fun Button.setMemorySaveButtonActive(
+    title: String?,
+    startDate: LocalDate?,
+    endDate: LocalDate?,
+    photoUri: Uri?,
+    photoUrl: String?,
+) {
+    isEnabled =
+        if (title.isNullOrBlank() || startDate == null || endDate == null || (photoUri != null && photoUrl == null)) {
             setTextColor(resources.getColor(R.color.gray4, null))
             false
         } else {
@@ -452,11 +473,12 @@ fun ProgressBar.setThumbnailLoadingProgressBar(
     thumbnailUri: Uri?,
     thumbnailUrl: String?,
 ) {
-    visibility = if (thumbnailUri != null && thumbnailUrl == null) {
-        View.VISIBLE
-    } else {
-        View.GONE
-    }
+    visibility =
+        if (thumbnailUri != null && thumbnailUrl == null) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
 }
 
 @BindingAdapter(value = ["thumbnailUri", "thumbnailUrl"])
@@ -464,9 +486,10 @@ fun View.setThumbnail(
     thumbnailUri: Uri?,
     thumbnailUrl: String?,
 ) {
-    visibility = if (thumbnailUri == null && thumbnailUrl == null) {
-        View.VISIBLE
-    } else {
-        View.GONE
-    }
+    visibility =
+        if (thumbnailUri == null && thumbnailUrl == null) {
+            View.VISIBLE
+        } else {
+            View.GONE
+        }
 }

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/MemoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/MemoryCreationActivity.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
-import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/MemoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/MemoryCreationActivity.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
@@ -73,11 +74,13 @@ class MemoryCreationActivity :
     }
 
     override fun onImageDeletionClicked() {
+        viewModel.setThumbnailUri(null)
         viewModel.setThumbnailUrl(null)
     }
 
     override fun onUrisSelected(vararg uris: Uri) {
         viewModel.createThumbnailUrl(this, uris.first())
+        viewModel.setThumbnailUri(uris.first())
         showToast(getString(R.string.all_posting_photo))
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -2,6 +2,7 @@ package com.woowacourse.staccato.presentation.memorycreation.viewmodel
 
 import android.content.Context
 import android.net.Uri
+import android.util.Log
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -41,7 +42,10 @@ class MemoryCreationViewModel(
     private val _errorMessage = MutableLiveData<String>()
     val errorMessage: LiveData<String> get() = _errorMessage
 
-    private val _thumbnailUrl = MutableLiveData<String?>()
+    private val _thumbnailUri = MutableLiveData<Uri?>(null)
+    val thumbnailUri: LiveData<Uri?> get() = _thumbnailUri
+
+    private val _thumbnailUrl = MutableLiveData<String?>(null)
     val thumbnailUrl: LiveData<String?> get() = _thumbnailUrl
 
     private val _isPosting = MutableLiveData<Boolean>(false)
@@ -51,6 +55,7 @@ class MemoryCreationViewModel(
         context: Context,
         thumbnailUri: Uri,
     ) {
+        _thumbnailUri.value = thumbnailUri
         val thumbnailFile = convertMemoryUriToFile(context, thumbnailUri, name = MEMORY_FILE_NAME)
         viewModelScope.launch {
             val result: ResponseResult<ImageResponse> =
@@ -59,6 +64,10 @@ class MemoryCreationViewModel(
                 .onServerError(::handleServerError)
                 .onException(::handelException)
         }
+    }
+
+    fun setThumbnailUri(thumbnailUri: Uri?) {
+        _thumbnailUri.value = thumbnailUri
     }
 
     fun setThumbnailUrl(imageResponse: ImageResponse?) {
@@ -120,3 +129,4 @@ class MemoryCreationViewModel(
         private const val MEMORY_CREATION_ERROR_MESSAGE = "추억 생성에 실패했습니다"
     }
 }
+

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -2,7 +2,6 @@ package com.woowacourse.staccato.presentation.memorycreation.viewmodel
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -51,11 +50,15 @@ class MemoryCreationViewModel(
     private val _isPosting = MutableLiveData<Boolean>(false)
     val isPosting: LiveData<Boolean> get() = _isPosting
 
+    private val _isPhotoPosting = MutableLiveData<Boolean>(false)
+    val isPhotoPosting: LiveData<Boolean> get() = _isPhotoPosting
+
     fun createThumbnailUrl(
         context: Context,
         thumbnailUri: Uri,
     ) {
         _thumbnailUri.value = thumbnailUri
+        _isPhotoPosting.value = true
         val thumbnailFile = convertMemoryUriToFile(context, thumbnailUri, name = MEMORY_FILE_NAME)
         viewModelScope.launch {
             val result: ResponseResult<ImageResponse> =
@@ -72,6 +75,7 @@ class MemoryCreationViewModel(
 
     fun setThumbnailUrl(imageResponse: ImageResponse?) {
         _thumbnailUrl.value = imageResponse?.imageUrl
+        _isPhotoPosting.value = false
     }
 
     fun setMemoryPeriod(

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -133,4 +133,3 @@ class MemoryCreationViewModel(
         private const val MEMORY_CREATION_ERROR_MESSAGE = "추억 생성에 실패했습니다"
     }
 }
-

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/MemoryUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/MemoryUpdateActivity.kt
@@ -28,9 +28,7 @@ import com.woowacourse.staccato.presentation.memoryupdate.viewmodel.MemoryUpdate
 import com.woowacourse.staccato.presentation.momentcreation.OnUrisSelectedListener
 import com.woowacourse.staccato.presentation.util.showToast
 
-class MemoryUpdateActivity :
-    BindingActivity<ActivityMemoryUpdateBinding>(),
-    MemoryUpdateHandler,
+class MemoryUpdateActivity : BindingActivity<ActivityMemoryUpdateBinding>(), MemoryUpdateHandler,
     OnUrisSelectedListener {
     override val layoutResourceId = R.layout.activity_memory_update
     private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, DEFAULT_MEMORY_ID) }
@@ -74,10 +72,12 @@ class MemoryUpdateActivity :
     }
 
     override fun onPhotoDeletionClicked() {
+        viewModel.setThumbnailUri(null)
         viewModel.setThumbnailUrl(null)
     }
 
     override fun onUrisSelected(vararg uris: Uri) {
+        viewModel.setThumbnailUri(uris.first())
         viewModel.createThumbnailUrl(this, uris.first())
         showToast(getString(R.string.all_posting_photo))
     }
@@ -94,9 +94,7 @@ class MemoryUpdateActivity :
     }
 
     private fun buildDateRangePicker() =
-        MaterialDatePicker.Builder.dateRangePicker()
-            .setTheme(R.style.DatePickerStyle)
-            .setSelection(
+        MaterialDatePicker.Builder.dateRangePicker().setTheme(R.style.DatePickerStyle).setSelection(
                 Pair(
                     MaterialDatePicker.thisMonthInUtcMilliseconds(),
                     MaterialDatePicker.todayInUtcMilliseconds(),

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/MemoryUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/MemoryUpdateActivity.kt
@@ -28,7 +28,9 @@ import com.woowacourse.staccato.presentation.memoryupdate.viewmodel.MemoryUpdate
 import com.woowacourse.staccato.presentation.momentcreation.OnUrisSelectedListener
 import com.woowacourse.staccato.presentation.util.showToast
 
-class MemoryUpdateActivity : BindingActivity<ActivityMemoryUpdateBinding>(), MemoryUpdateHandler,
+class MemoryUpdateActivity :
+    BindingActivity<ActivityMemoryUpdateBinding>(),
+    MemoryUpdateHandler,
     OnUrisSelectedListener {
     override val layoutResourceId = R.layout.activity_memory_update
     private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, DEFAULT_MEMORY_ID) }
@@ -95,11 +97,11 @@ class MemoryUpdateActivity : BindingActivity<ActivityMemoryUpdateBinding>(), Mem
 
     private fun buildDateRangePicker() =
         MaterialDatePicker.Builder.dateRangePicker().setTheme(R.style.DatePickerStyle).setSelection(
-                Pair(
-                    MaterialDatePicker.thisMonthInUtcMilliseconds(),
-                    MaterialDatePicker.todayInUtcMilliseconds(),
-                ),
-            ).build()
+            Pair(
+                MaterialDatePicker.thisMonthInUtcMilliseconds(),
+                MaterialDatePicker.todayInUtcMilliseconds(),
+            ),
+        ).build()
 
     private fun initBinding() {
         binding.lifecycleOwner = this

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -32,6 +32,9 @@ class MemoryUpdateViewModel(
     private val _memory = MutableLiveData<NewMemory>()
     val memory: LiveData<NewMemory> get() = _memory
 
+    private val _thumbnailUri = MutableLiveData<Uri?>(null)
+    val thumbnailUri: LiveData<Uri?> get() = _thumbnailUri
+
     private val _thumbnailUrl = MutableLiveData<String?>()
     val thumbnailUrl: LiveData<String?> get() = _thumbnailUrl
 
@@ -67,6 +70,7 @@ class MemoryUpdateViewModel(
         context: Context,
         thumbnailUri: Uri,
     ) {
+        _thumbnailUri.value = thumbnailUri
         val thumbnailFile = convertMemoryUriToFile(context, thumbnailUri, name = MEMORY_FILE_NAME)
         viewModelScope.launch {
             val result: ResponseResult<ImageResponse> =
@@ -75,6 +79,10 @@ class MemoryUpdateViewModel(
                 .onServerError(::handleServerError)
                 .onException(::handelException)
         }
+    }
+
+    fun setThumbnailUri(thumbnailUri: Uri?) {
+        _thumbnailUri.value = thumbnailUri
     }
 
     fun setThumbnailUrl(imageResponse: ImageResponse?) {

--- a/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/woowacourse/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -35,7 +35,7 @@ class MemoryUpdateViewModel(
     private val _thumbnailUri = MutableLiveData<Uri?>(null)
     val thumbnailUri: LiveData<Uri?> get() = _thumbnailUri
 
-    private val _thumbnailUrl = MutableLiveData<String?>()
+    private val _thumbnailUrl = MutableLiveData<String?>(null)
     val thumbnailUrl: LiveData<String?> get() = _thumbnailUrl
 
     val title = ObservableField<String>()
@@ -56,6 +56,9 @@ class MemoryUpdateViewModel(
     private val _isPosting = MutableLiveData<Boolean>()
     val isPosting: LiveData<Boolean> get() = _isPosting
 
+    private val _isPhotoPosting = MutableLiveData<Boolean>(false)
+    val isPhotoPosting: LiveData<Boolean> get() = _isPosting
+
     fun fetchMemory() {
         viewModelScope.launch {
             val result = memoryRepository.getMemory(memoryId)
@@ -70,7 +73,9 @@ class MemoryUpdateViewModel(
         context: Context,
         thumbnailUri: Uri,
     ) {
+        _thumbnailUrl.value = null
         _thumbnailUri.value = thumbnailUri
+        _isPhotoPosting.value = true
         val thumbnailFile = convertMemoryUriToFile(context, thumbnailUri, name = MEMORY_FILE_NAME)
         viewModelScope.launch {
             val result: ResponseResult<ImageResponse> =
@@ -83,14 +88,16 @@ class MemoryUpdateViewModel(
 
     fun setThumbnailUri(thumbnailUri: Uri?) {
         _thumbnailUri.value = thumbnailUri
+        _thumbnailUrl.value = null
     }
 
     fun setThumbnailUrl(imageResponse: ImageResponse?) {
         _thumbnailUrl.value = imageResponse?.imageUrl
+//        _isPhotoPosting.value = false
     }
 
     fun updateMemory() {
-        _isPosting.value = true
+//        _isPhotoPosting.value = true
         viewModelScope.launch {
             val newMemory: NewMemory = makeNewMemory()
             val result: ResponseResult<Unit> = memoryRepository.updateMemory(memoryId, newMemory)

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
@@ -206,7 +206,8 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_creation_period_description"
                     bind:endDate="@{viewModel.endDate}"
                     bind:memoryTitle="@{viewModel.title}"
-                    bind:startDate="@{viewModel.startDate}" />
+                    bind:startDate="@{viewModel.startDate}"
+                    bind:isPhotoPosting="@{viewModel.isPhotoPosting}"/>
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
@@ -54,8 +54,9 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
+                    bind:coilImageUri="@{viewModel.thumbnailUri}"
+                    bind:coilImageUrl="@{viewModel.thumbnailUrl}"
                     bind:coilPlaceHolder="@{@drawable/shape_all_gray1_8dp}"
-                    bind:coilRoundedCornerImageUrl="@{viewModel.thumbnailUrl}"
                     bind:coilRoundingRadius="@{12f}" />
 
                 <ImageButton
@@ -76,11 +77,27 @@
                     layout="@layout/layout_photo_attach"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:visibility="@{viewModel.thumbnailUrl == null ? View.VISIBLE : View.GONE }"
+                    bind:thumbnailUri="@{viewModel.thumbnailUri}"
+                    bind:thumbnailUrl="@{viewModel.thumbnailUrl}"
                     app:layout_constraintBottom_toBottomOf="@id/iv_memory_creation_photo_attach"
                     app:layout_constraintEnd_toEndOf="@id/iv_memory_creation_photo_attach"
                     app:layout_constraintStart_toStartOf="@id/iv_memory_creation_photo_attach"
                     app:layout_constraintTop_toTopOf="@id/iv_memory_creation_photo_attach" />
+
+                <ProgressBar
+                    android:id="@+id/progress_bar_memory_creation_attached_photo"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:background="@color/white_80"
+                    android:padding="100dp"
+                    android:progress="30"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_memory_creation_photo_attach"
+                    app:layout_constraintEnd_toEndOf="@id/iv_memory_creation_photo_attach"
+                    app:layout_constraintStart_toStartOf="@id/iv_memory_creation_photo_attach"
+                    app:layout_constraintTop_toTopOf="@id/iv_memory_creation_photo_attach"
+                    bind:thumbnailUri="@{viewModel.thumbnailUri}"
+                    bind:thumbnailUrl="@{viewModel.thumbnailUrl}"
+                    tools:visibility="visible" />
 
                 <TextView
                     android:id="@+id/tv_memory_creation_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
@@ -54,8 +54,9 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
+                    bind:coilImageUri="@{viewModel.thumbnailUri}"
+                    bind:coilImageUrl="@{viewModel.thumbnailUrl}"
                     bind:coilPlaceHolder="@{@drawable/shape_all_gray1_8dp}"
-                    bind:coilRoundedCornerImageUrl="@{viewModel.thumbnailUrl}"
                     bind:coilRoundingRadius="@{12}" />
 
                 <ImageButton
@@ -76,11 +77,27 @@
                     layout="@layout/layout_photo_attach"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:visibility="@{viewModel.thumbnailUrl == null ? View.VISIBLE : View.GONE }"
                     app:layout_constraintBottom_toBottomOf="@id/iv_memory_update_photo_attach"
                     app:layout_constraintEnd_toEndOf="@id/iv_memory_update_photo_attach"
                     app:layout_constraintStart_toStartOf="@id/iv_memory_update_photo_attach"
                     app:layout_constraintTop_toTopOf="@id/iv_memory_update_photo_attach"
+                    bind:thumbnailUri="@{viewModel.thumbnailUri}"
+                    bind:thumbnailUrl="@{viewModel.thumbnailUrl}"
+                    tools:visibility="visible" />
+
+                <ProgressBar
+                    android:id="@+id/progress_bar_memory_creation_attached_photo"
+                    android:layout_width="0dp"
+                    android:layout_height="0dp"
+                    android:background="@color/white_80"
+                    android:padding="100dp"
+                    android:progress="30"
+                    app:layout_constraintBottom_toBottomOf="@id/iv_memory_update_photo_attach"
+                    app:layout_constraintEnd_toEndOf="@id/iv_memory_update_photo_attach"
+                    app:layout_constraintStart_toStartOf="@id/iv_memory_update_photo_attach"
+                    app:layout_constraintTop_toTopOf="@id/iv_memory_update_photo_attach"
+                    bind:thumbnailUri="@{viewModel.thumbnailUri}"
+                    bind:thumbnailUrl="@{viewModel.thumbnailUrl}"
                     tools:visibility="visible" />
 
                 <TextView

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
@@ -197,7 +197,7 @@
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_memory_update_save"
-                    style="@style/ButtonStyle.Save.Active"
+                    style="@style/ButtonStyle.Save"
                     android:layout_marginHorizontal="16dp"
                     android:layout_marginVertical="24dp"
                     android:onClick="@{() -> handler.onSaveClicked()}"
@@ -207,7 +207,9 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_update_period_description"
                     bind:endDate="@{viewModel.endDate}"
                     bind:memoryTitle="@{viewModel.title}"
-                    bind:startDate="@{viewModel.startDate}" />
+                    bind:startDate="@{viewModel.startDate}"
+                    bind:photoUri="@{viewModel.thumbnailUri}"
+                    bind:photoUrl="@{viewModel.thumbnailUrl}" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #332 

<br>

## 🚩 Summary

- 추억 생성 이미지 로딩 중 표시 및 저장 버튼 비활성화
- 추억 수정 이미지 로딩 중 표시 및 저장 버튼 비활성화
