### PR TITLE
fix: 중복 닉네임 입력 시 유저 정보 불러오도록 수정 #344

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -2,7 +2,7 @@ name: Backend CI/CD dev
 
 on:
   pull_request:
-    branches: [ "develop-be" ]
+    branches: [ "develop-be", "develop" ]
 
 jobs:
   ci:

--- a/.github/workflows/backend-ci-cd-stage.yml
+++ b/.github/workflows/backend-ci-cd-stage.yml
@@ -2,7 +2,7 @@ name: Backend CI/CD stage
 
 on:
   push:
-    branches: [ "develop-be" ]
+    branches: [ "develop-be", "develop" ]
 
 jobs:
   ci:

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -47,7 +47,10 @@ public class AuthService {
 
     private Member createMember(LoginRequest loginRequest) {
         Member member = loginRequest.toMember();
-        validateNickname(member.getNickname());
+        //validateNickname(member.getNickname());
+        if(memberRepository.existsByNickname(member.getNickname())){
+            return memberRepository.findByNickname(member.getNickname());
+        }
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -1,14 +1,12 @@
 package com.staccato.member.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-    Optional<Member> findByIdAndIsDeletedIsFalse(long memberId);
-
     boolean existsByNickname(Nickname nickname);
+
+    Member findByNickname(Nickname nickname);
 }

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -39,6 +40,22 @@ class AuthServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 기존에 존재하던 사용자를 반환한다.")
+    @Test
+    void loginByDuplicated() {
+        // given
+        String nickname = "staccato";
+        memberRepository.save(Member.builder().nickname(nickname).build());
+        LoginRequest loginRequest = new LoginRequest(nickname);
+
+        // when
+        LoginResponse response = authService.login(loginRequest);
+
+        // then
+        assertThat(response.token()).isNotBlank();
+    }
+
+    @Disabled
     @DisplayName("입력받은 닉네임이 이미 존재하는 닉네임인 경우 예외가 발생한다.")
     @Test
     void cannotLoginByDuplicated() {


### PR DESCRIPTION
## ⭐️ Issue Number
- #344 

## 🚩 Summary
- 중복 검증 테스트 disable
- 중복 검증 로직 주석 처리
- 중복 검증 대신 기존 사용자 불러오도록 수정

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
- 소셜 로그인 마이그레이션