### PR TITLE
feat: 추억 생성/수정 시 기간을 nullable하게 변경 #350

### DIFF
--- a/backend/src/main/java/com/staccato/memory/domain/Term.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Term.java
@@ -30,7 +30,7 @@ public class Term {
 
     private void validateTermDates(LocalDate startAt, LocalDate endAt) {
         if (isOnlyOneDatePresent(startAt, endAt)) {
-            throw new StaccatoException("추억 시작 날짜와 끝 날짜를 모두 입력해주세요.");
+            throw new StaccatoException("추억의 시작 날짜와 끝 날짜는 함께 입력되거나, 함께 비워져 있어야 합니다.");
         }
         if (isInvalidTerm(startAt, endAt)) {
             throw new StaccatoException("끝 날짜가 시작 날짜보다 앞설 수 없어요.");

--- a/backend/src/test/java/com/staccato/memory/controller/MemoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/memory/controller/MemoryControllerTest.java
@@ -63,7 +63,8 @@ class MemoryControllerTest {
         return Stream.of(
                 new MemoryRequest("https://example.com/memorys/geumohrm.jpg", "2023 여름 휴가", "친구들과 함께한 여름 휴가 추억", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),
                 new MemoryRequest(null, "2023 여름 휴가", "친구들과 함께한 여름 휴가 추억", LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),
-                new MemoryRequest("https://example.com/memorys/geumohrm.jpg", "2023 여름 휴가", null, LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10))
+                new MemoryRequest("https://example.com/memorys/geumohrm.jpg", "2023 여름 휴가", null, LocalDate.of(2023, 7, 1), LocalDate.of(2023, 7, 10)),
+                new MemoryRequest("https://example.com/memorys/geumohrm.jpg", "2023 여름 휴가", null, null, null)
         );
     }
 

--- a/backend/src/test/java/com/staccato/memory/domain/TermTest.java
+++ b/backend/src/test/java/com/staccato/memory/domain/TermTest.java
@@ -56,7 +56,7 @@ class TermTest {
     void cannotCreateTermByNoStartAt() {
         assertThatThrownBy(() -> new Term(null, LocalDate.now()))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessage("추억 시작 날짜와 끝 날짜를 모두 입력해주세요.");
+                .hasMessage("추억의 시작 날짜와 끝 날짜는 함께 입력되거나, 함께 비워져 있어야 합니다.");
     }
 
     @DisplayName("시작 날짜는 있는데, 끝 날짜가 누락되면 예외를 발생한다.")
@@ -64,6 +64,6 @@ class TermTest {
     void cannotCreateTermByNoEndAt() {
         assertThatThrownBy(() -> new Term(LocalDate.now(), null))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessage("추억 시작 날짜와 끝 날짜를 모두 입력해주세요.");
+                .hasMessage("추억의 시작 날짜와 끝 날짜는 함께 입력되거나, 함께 비워져 있어야 합니다.");
     }
 }

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -223,6 +223,22 @@ class MemoryServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("기간이 존재하는 추억에 대해 기간이 존재하지 않도록 변경할 수 있다.")
+    @Test
+    void updateMemoryWithNullableTerm() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create());
+        MemoryIdResponse memoryResponse = memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 10)), member);
+
+        // when
+        MemoryRequest memoryUpdateRequest = MemoryRequestFixture.create(null, null);
+        memoryService.updateMemory(memoryUpdateRequest, memoryResponse.memoryId(), member);
+        Memory foundedMemory = memoryRepository.findById(memoryResponse.memoryId()).get();
+
+        // then
+        assertThat(foundedMemory.getTerm()).isEqualTo(null);
+    }
+
     @DisplayName("존재하지 않는 추억을 수정하려 할 경우 예외가 발생한다.")
     @Test
     void failUpdateMemory() {

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -82,6 +82,25 @@ class MemoryServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("추억의 기간이 null이더라도 추억을 생성할 수 있다.")
+    @Test
+    void createMemoryWithoutTerm() {
+        // given
+        MemoryRequest memoryRequest = MemoryRequestFixture.create(null, null);
+        Member member = memberRepository.save(MemberFixture.create());
+
+        // when
+        MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
+        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemoryCreatedAtDesc(member.getId())
+                .get(0);
+
+        // then
+        assertAll(
+                () -> assertThat(memoryMember.getMember().getId()).isEqualTo(member.getId()),
+                () -> assertThat(memoryMember.getMemory().getId()).isEqualTo(memoryIdResponse.memoryId())
+        );
+    }
+
     @DisplayName("이미 존재하는 추억 이름으로 추억을 생성할 수 없다.")
     @Test
     void cannotCreateMemoryByDuplicatedTitle() {


### PR DESCRIPTION
## ⭐️ Issue Number
- #350 

## 🚩 Summary
- 아래 세 가지 기능이 가능하도록 수정하려 했으나, 리니가 미리 이에 대비하여 로직을 짜두었네요(리니 짱👍). 따라서 프로덕션 코드에는 변경사항이 없습니다. 
  - memory request DTO에 기간과 관련된 필드를 nullable하게 만듭니다. 
  - Term 객체 생성 시 startAt과 endAt이 null이더라도 생성이 가능하도록 만듭니다. 단, 둘 중 하나만 null인 경우는 허용하지 않습니다.
  - memory가 가진 Term의 startAt, endAt이 null이라면 어떤 날짜의 스타카토든 포함할 수 있도록 만듭니다.
- 따라서 테스트 코드를 몇 개 추가한 것이 끝입니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer
추억 생성 시 시작 날짜와 끝 날짜 중 하나만 입력해서 요청이 오면, 현재 서버 단에서는 `추억 시작 날짜와 끝 날짜를 모두 입력해주세요.`라는 예외 메시지를 던집니다. 그런데 이제 시작 날짜와 끝 날짜를 모두 입력하지 않은 경우도 가능하게 되었습니다. 따라서 `시작 날짜와 끝 날짜 모두 입력하거나 모두 입력하지 않아야 합니다.`라는 의미의 예외를 던지는 것이 좋을 것 같아요. 근데 좋은 예외메시지가 잘 떠오르질 않네요. 혹시나 좋은 메시지가 떠오르면 추천해주세요! (잘 안 떠오르면 일단 넘어가도 될 것 같습니다)

## 📋 To Do
- 현재는 사용자가 시작 날짜와 끝 날짜를 모두 선택하지 않고선 추억 생성 버튼이 비활성화 되는 것으로 알고 있습니다. 시작 날짜와 끝 날짜 중 하나만 선택했을 때에는 추억 생성 버튼이 여전히 비활성화되고, 둘 다 선택하거나 둘 다 선택하지 않았을 때에만 활성화 되도록 변경되어야겠네요.
- DB 서버에서 memory의 start_at, end_at 컬럼이 nullable하도록 alter를 쳐줘야 합니다.