### PR TITLE
feat: Logging 레벨 수정 및 DB 예외 로깅, AOP 적용 #351

### DIFF
--- a/backend/src/main/java/com/staccato/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/staccato/auth/controller/AuthController.java
@@ -1,18 +1,17 @@
 package com.staccato.auth.controller;
 
 import jakarta.validation.Valid;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.auth.service.AuthService;
 import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
-
+import com.staccato.config.log.annotation.Trace;
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @RestController
 @RequiredArgsConstructor
 public class AuthController implements AuthControllerDocs {

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -5,21 +5,21 @@ import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
 import com.staccato.config.auth.AdminProperties;
 import com.staccato.config.auth.TokenProvider;
 import com.staccato.config.log.LogForm;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.StaccatoException;
 import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+@Trace
 @Slf4j
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -1,10 +1,8 @@
 package com.staccato.comment.controller;
 
 import java.net.URI;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,17 +13,17 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.comment.controller.docs.CommentControllerDocs;
 import com.staccato.comment.service.CommentService;
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @RestController
 @RequestMapping("/comments")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/staccato/comment/service/CommentService.java
+++ b/backend/src/main/java/com/staccato/comment/service/CommentService.java
@@ -1,24 +1,23 @@
 package com.staccato.comment.service;
 
 import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.staccato.comment.domain.Comment;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.memory.domain.Memory;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.repository.MomentRepository;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -13,8 +13,8 @@ public class LogForm {
             "}";
 
     public static final String TRACE_LOGGING_FORM = "\n{\n" +
-            INDENT + "\"Method\": \"{}\"" + DELIMITER +
-            "\"Args\": \"{}\"\n" +
+            INDENT + "\"Invoked Class\": \"{}\"" + DELIMITER +
+            "\"Invoked Method\": \"{}\"\n" +
             "}";
 
     public static final String LOGIN_MEMBER_FORM = "\n{\n" +

--- a/backend/src/main/java/com/staccato/config/log/LogForm.java
+++ b/backend/src/main/java/com/staccato/config/log/LogForm.java
@@ -12,6 +12,11 @@ public class LogForm {
             "\"processingTimeMs\": \"{}\"\n" +
             "}";
 
+    public static final String TRACE_LOGGING_FORM = "\n{\n" +
+            INDENT + "\"Method\": \"{}\"" + DELIMITER +
+            "\"Args\": \"{}\"\n" +
+            "}";
+
     public static final String LOGIN_MEMBER_FORM = "\n{\n" +
             INDENT + "\"loginMemberId\": \"{}\"" + DELIMITER +
             "\"loginMemberNickname\": \"{}\"\n" +
@@ -29,5 +34,6 @@ public class LogForm {
     public static final String ERROR_LOGGING_FORM = "\n{\n" +
             INDENT + "\"exceptionResponse\": \"{}\"" + DELIMITER +
             "\"exceptionMessage\": \"{}\"\n" +
+            "\"exceptionStackTrace\": \"{}\"\n" +
             "}";
 }

--- a/backend/src/main/java/com/staccato/config/log/TraceAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/TraceAspect.java
@@ -1,0 +1,35 @@
+package com.staccato.config.log;
+
+import java.util.Arrays;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.Signature;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+
+import com.staccato.member.domain.Member;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Aspect
+@Component
+public class TraceAspect {
+    @Before("@annotation(com.staccato.config.log.annotation.Trace)")
+    public void doTrace(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        Signature signature = joinPoint.getSignature();
+        log.info(LogForm.TRACE_LOGGING_FORM, signature.getName(), excludeMemberArgs(args));
+    }
+
+    private static Object[] excludeMemberArgs(Object[] args) {
+        return Arrays.stream(args)
+                .filter(arg -> !(arg instanceof Member))
+                .toArray();
+    }
+}
+
+// 1. toString()을 활용해 멤버의 정보를 그대로 출력
+// 2. 위와 같은 로직을 통해 민감한 정보들은 제외하고 출력
+// 사용자에 대한 로깅은 extractFromToken 부분에서 처리하므로 사용자 추적 가능.

--- a/backend/src/main/java/com/staccato/config/log/TraceAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/TraceAspect.java
@@ -1,35 +1,21 @@
 package com.staccato.config.log;
 
-import java.util.Arrays;
-
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.Signature;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.stereotype.Component;
-
-import com.staccato.member.domain.Member;
-
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Aspect
 @Component
 public class TraceAspect {
-    @Before("@annotation(com.staccato.config.log.annotation.Trace)")
+    @Before("@within(com.staccato.config.log.annotation.Trace)")
     public void doTrace(JoinPoint joinPoint) {
-        Object[] args = joinPoint.getArgs();
         Signature signature = joinPoint.getSignature();
-        log.info(LogForm.TRACE_LOGGING_FORM, signature.getName(), excludeMemberArgs(args));
-    }
-
-    private static Object[] excludeMemberArgs(Object[] args) {
-        return Arrays.stream(args)
-                .filter(arg -> !(arg instanceof Member))
-                .toArray();
+        String className = signature.getDeclaringTypeName();
+        String methodName = signature.getName();
+        log.info(LogForm.TRACE_LOGGING_FORM, className, methodName);
     }
 }
-
-// 1. toString()을 활용해 멤버의 정보를 그대로 출력
-// 2. 위와 같은 로직을 통해 민감한 정보들은 제외하고 출력
-// 사용자에 대한 로깅은 extractFromToken 부분에서 처리하므로 사용자 추적 가능.

--- a/backend/src/main/java/com/staccato/config/log/annotation/Trace.java
+++ b/backend/src/main/java/com/staccato/config/log/annotation/Trace.java
@@ -5,7 +5,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.METHOD)
+@Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Trace {
 }

--- a/backend/src/main/java/com/staccato/config/log/annotation/Trace.java
+++ b/backend/src/main/java/com/staccato/config/log/annotation/Trace.java
@@ -1,0 +1,11 @@
+package com.staccato.config.log.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Trace {
+}

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import com.staccato.config.log.LogForm;
 
@@ -75,6 +77,24 @@ public class GlobalExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), exceptionMessage);
         log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse, e.getMessage());
         return ResponseEntity.badRequest().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    @ApiResponse(responseCode = "400")
+    public ResponseEntity<ExceptionResponse> handleMissingServletRequestPartException(MissingServletRequestPartException e) {
+        String exceptionMessage = "요청된 파트가 누락되었습니다. 올바른 데이터를 제공해주세요.";
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), exceptionMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.badRequest().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(MultipartException.class)
+    @ApiResponse(responseCode = "413")
+    public ResponseEntity<ExceptionResponse> handleMultipartException(MultipartException e) {
+        String exceptionMessage = "20MB 이하의 사진을 업로드해 주세요.";
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.PAYLOAD_TOO_LARGE.toString(), exceptionMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(exceptionResponse);
     }
 
     @ExceptionHandler(StaccatoException.class)

--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -5,9 +5,12 @@ import java.util.Optional;
 import jakarta.validation.ConstraintViolationException;
 
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.transaction.CannotCreateTransactionException;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -103,6 +106,30 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ExceptionResponse> handleInternalServerErrorException(RuntimeException e) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), INTERNAL_SERVER_ERROR_MESSAGE);
         log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(CannotCreateTransactionException.class)
+    @ApiResponse(responseCode = "500")
+    public ResponseEntity<ExceptionResponse> handleCannotCreateTransactionException(CannotCreateTransactionException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), INTERNAL_SERVER_ERROR_MESSAGE);
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage(), e.getStackTrace());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(DataAccessException.class)
+    @ApiResponse(responseCode = "500")
+    public ResponseEntity<ExceptionResponse> handleDataAccessException(DataAccessException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), INTERNAL_SERVER_ERROR_MESSAGE);
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage(), e.getStackTrace());
+        return ResponseEntity.internalServerError().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(TransactionSystemException.class)
+    @ApiResponse(responseCode = "500")
+    public ResponseEntity<ExceptionResponse> handleTransactionSystemException(TransactionSystemException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.INTERNAL_SERVER_ERROR.toString(), INTERNAL_SERVER_ERROR_MESSAGE);
+        log.error(LogForm.ERROR_LOGGING_FORM, exceptionResponse, e.getMessage(), e.getStackTrace());
         return ResponseEntity.internalServerError().body(exceptionResponse);
     }
 }

--- a/backend/src/main/java/com/staccato/image/controller/ImageController.java
+++ b/backend/src/main/java/com/staccato/image/controller/ImageController.java
@@ -8,15 +8,15 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
 import com.staccato.config.auth.LoginMember;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.image.controller.docs.ImageControllerDocs;
 import com.staccato.image.service.ImageService;
 import com.staccato.image.service.dto.ImageUrlResponse;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @RestController
 @RequestMapping("/images")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/staccato/image/service/ImageService.java
+++ b/backend/src/main/java/com/staccato/image/service/ImageService.java
@@ -2,18 +2,17 @@ package com.staccato.image.service;
 
 import java.io.IOException;
 import java.util.UUID;
-
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
-
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.StaccatoException;
 import com.staccato.image.domain.ImageExtension;
 import com.staccato.image.infrastructure.S3ObjectClient;
 import com.staccato.image.service.dto.ImageUrlResponse;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @Service
 @RequiredArgsConstructor
 public class ImageService {

--- a/backend/src/main/java/com/staccato/memory/controller/MemoryController.java
+++ b/backend/src/main/java/com/staccato/memory/controller/MemoryController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.staccato.config.auth.LoginMember;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
 import com.staccato.memory.controller.docs.MemoryControllerDocs;
 import com.staccato.memory.service.MemoryService;
@@ -37,6 +38,7 @@ import lombok.RequiredArgsConstructor;
 public class MemoryController implements MemoryControllerDocs {
     private final MemoryService memoryService;
 
+    @Trace
     @PostMapping
     public ResponseEntity<MemoryIdResponse> createMemory(
             @Valid @RequestBody MemoryRequest memoryRequest,

--- a/backend/src/main/java/com/staccato/memory/controller/MemoryController.java
+++ b/backend/src/main/java/com/staccato/memory/controller/MemoryController.java
@@ -2,10 +2,8 @@ package com.staccato.memory.controller;
 
 import java.net.URI;
 import java.time.LocalDate;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -17,7 +15,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -26,11 +23,11 @@ import com.staccato.memory.service.MemoryService;
 import com.staccato.memory.service.dto.request.MemoryRequest;
 import com.staccato.memory.service.dto.response.MemoryDetailResponse;
 import com.staccato.memory.service.dto.response.MemoryIdResponse;
-import com.staccato.memory.service.dto.response.MemoryResponses;
 import com.staccato.memory.service.dto.response.MemoryNameResponses;
-
+import com.staccato.memory.service.dto.response.MemoryResponses;
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @Validated
 @RestController
 @RequestMapping("/memories")
@@ -38,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 public class MemoryController implements MemoryControllerDocs {
     private final MemoryService memoryService;
 
-    @Trace
     @PostMapping
     public ResponseEntity<MemoryIdResponse> createMemory(
             @Valid @RequestBody MemoryRequest memoryRequest,

--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -2,10 +2,9 @@ package com.staccato.memory.service;
 
 import java.time.LocalDate;
 import java.util.List;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
@@ -21,9 +20,9 @@ import com.staccato.memory.service.dto.response.MemoryResponses;
 import com.staccato.memory.service.dto.response.MomentResponse;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.repository.MomentRepository;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)

--- a/backend/src/main/java/com/staccato/moment/controller/MomentController.java
+++ b/backend/src/main/java/com/staccato/moment/controller/MomentController.java
@@ -1,11 +1,8 @@
 package com.staccato.moment.controller;
 
-import java.lang.annotation.Target;
 import java.net.URI;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,7 +13,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -28,9 +24,9 @@ import com.staccato.moment.service.dto.request.MomentUpdateRequest;
 import com.staccato.moment.service.dto.response.MomentDetailResponse;
 import com.staccato.moment.service.dto.response.MomentIdResponse;
 import com.staccato.moment.service.dto.response.MomentLocationResponses;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @RestController
 @RequestMapping("/moments")
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/staccato/moment/controller/MomentController.java
+++ b/backend/src/main/java/com/staccato/moment/controller/MomentController.java
@@ -1,5 +1,6 @@
 package com.staccato.moment.controller;
 
+import java.lang.annotation.Target;
 import java.net.URI;
 
 import jakarta.validation.Valid;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.staccato.config.auth.LoginMember;
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
 import com.staccato.moment.controller.docs.MomentControllerDocs;
 import com.staccato.moment.service.MomentService;

--- a/backend/src/main/java/com/staccato/moment/service/MomentService.java
+++ b/backend/src/main/java/com/staccato/moment/service/MomentService.java
@@ -2,7 +2,7 @@ package com.staccato.moment.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
@@ -18,9 +18,9 @@ import com.staccato.moment.service.dto.response.MomentDetailResponse;
 import com.staccato.moment.service.dto.response.MomentIdResponse;
 import com.staccato.moment.service.dto.response.MomentLocationResponse;
 import com.staccato.moment.service.dto.response.MomentLocationResponses;
-
 import lombok.RequiredArgsConstructor;
 
+@Trace
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor


### PR DESCRIPTION
## ⭐️ Issue Number
- #351 

## 🚩 Summary
- 예상가능한, 의도한 에러(`StaccatoException`) → `INFO`
- 예상하지 못한 에러면서 **비정상적인 사용자 행동**이나 **잘못된 입력**으로 인해 발생한 예외의 경우(`HttpMessageNotReadableException`, `ForbiddenException`, `etc`) → `WARN`
   <img width="1327" alt="logWarn" src="https://github.com/user-attachments/assets/2be293f0-fd11-426a-9b65-16e79acc4ebf">
- `RunTimeException` → `ERROR`
- `DB SQL` 관련 `Exception` 중 특정 에러는 `ERROR`, 다른 특정 에러는 `WARN`이 될 것 같다.
    - 우선 크리티컬한(`ERROR`) 것들만 `GlobalExeptionHandelr`에 등록
    - `CannotCreateTransactionException`
      - **DB 커넥션 실패**
    - `DataAccessException`
      - **SQL 구문 오류**
    - `TransactionSystemException`
      - **트랜잭션 실패**

## 🛠️ Technical Concerns

### `AOP` 구성이유 (카고의 의견 반영)
- Index를 걸때 생성하는 부분에서는 더 손해이지만, 조회하는 부분에서 큰 이점이 있어 적용하는데, 만약 A 컬럼을 이용하는데 조회보다 생성하는 부분이 많다면? A컬럼에는 index를 걸지 않는 쪽이 이득이다. 이것을 확인할려면 각 메서드마다 logging을 남겨야 확인 가능할 수 있다.

- `AOP`를 적용하면서 아래와 같은 `log`를 남기게끔 구성하였는데,
``` 
[2024-09-09 19:52:46:52696] [http-nio-8080-exec-3] [request_id=4b5eed9f-3be8-417a-87e4-b0ff36201442] INFO  [com.staccato.config.log.TraceAspect.doTrace.-26] - 
{
    "Method": "createMemory",
    "Args": "[MemoryRequest[memoryThumbnailUrl=null, memoryTitle=2023 여름 휴가, description=친구들과 함께한 여름 휴가 여행, startAt=2023-07-01, endAt=2023-07-10]]"
}
```
  - 인자에서 `Member`관련 정보를 남기면서, 추후에 추가될 민감한 정보들도 있을 것이라 생각되어 우선 `Member`관련 로깅은 제외하도록 구성 (+ `extractToken()`에서 사용자 로깅을 남기는 것과 중복된 부분도 있어서 `Member` 로깅제외)
  ``` java
  private static Object[] excludeMemberArgs(Object[] args) {
    return Arrays.stream(args)
            .filter(arg -> !(arg instanceof Member))
            .toArray();
  }
  ```


## 🙂 To Reviewer
- 우선적으로 `MemoryController`에만 `AOP`를 적용한 상태입니다.
- `AOP`의 적용 부분에서 납득가지 않는 부분이나, 이해가 가지 않는 사항에 대해서는 편하게 같이 의견공유하여 조율하면 좋겠습니다.

## 📋 To Do
- 모든 `Service` 메서드에 `Logging AOP` 적용