### PR TITLE
fix: embedded 인스턴스화  관련 NPE 버그 해결

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -1,7 +1,7 @@
 name: Backend CI/CD dev
 
 on:
-  pull_request:
+  push:
     branches: [ "develop-be", "develop" ]
 
 jobs:

--- a/backend/src/main/java/com/staccato/memory/controller/docs/MemoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/memory/controller/docs/MemoryControllerDocs.java
@@ -28,7 +28,7 @@ public interface MemoryControllerDocs {
             @ApiResponse(description = """
                     <발생 가능한 케이스>
                                         
-                    (1) 필수 값(추억 제목, 기간)이 누락되었을 때
+                    (1) 필수 값(추억 제목)이 누락되었을 때
                                         
                     (2) 날짜 형식(yyyy-MM-dd)이 잘못되었을 때
                                         
@@ -36,7 +36,7 @@ public interface MemoryControllerDocs {
                                         
                     (4) 내용이 공백 포함 500자를 초과했을 때
                                         
-                    (5) 기간 설정이 잘못되었을 때
+                    (5) 기간 설정이 잘못되었을 때 (시작 날짜와 끝날짜 중 하나만 설정할 수 없음)
                     
                     (6) 이미 존재하는 추억 이름일 때
                     """,
@@ -81,7 +81,7 @@ public interface MemoryControllerDocs {
             @ApiResponse(description = """
                     <발생 가능한 케이스>
                                         
-                    (1) 필수 값(추억 제목, 기간)이 누락되었을 때
+                    (1) 필수 값(추억 제목)이 누락되었을 때
                                         
                     (2) 날짜 형식(yyyy-MM-dd)이 잘못되었을 때
                                         

--- a/backend/src/main/java/com/staccato/memory/domain/Term.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Term.java
@@ -46,7 +46,7 @@ public class Term {
     }
 
     public boolean doesNotContain(LocalDateTime date) {
-        if(isExist(startAt, endAt)) {
+        if (isExist(startAt, endAt)) {
             ChronoLocalDate targetDate = ChronoLocalDate.from(date);
             return (startAt.isAfter(targetDate) || endAt.isBefore(targetDate));
         }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -18,6 +18,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        create_empty_composites.enabled: true
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -17,6 +17,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        create_empty_composites.enabled: true
     hibernate:
       ddl-auto: create
     defer-datasource-initialization: true

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -18,6 +18,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        create_empty_composites.enabled: true
     hibernate:
       ddl-auto: validate
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/backend/src/main/resources/application-stage.yml
+++ b/backend/src/main/resources/application-stage.yml
@@ -18,6 +18,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        create_empty_composites.enabled: true
     hibernate:
       ddl-auto: update
     database-platform: org.hibernate.dialect.MySQL8Dialect


### PR DESCRIPTION
## ⭐️ Issue Number
- #371

## 🚩 Summary
- 하이버네이트는 Entity 로딩 과정에서 Embedded Type의 모든 Field값이 null이면 인스턴스화하지 않는다.
- 이로 인해, 추억 기간 미설정 시, 조회하면 NPE가 발생 (ex: `memory.getTerm().getStart()`) 
- create_empty_composites.enabled = true로 `@Embedded` 객체의 모든 필드가 null이어도 해당 객체 자체가 null이 되는 것을 방지

참고: https://hibernate.atlassian.net/browse/HHH-7610
## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
- 컨트롤러 테스트 작성
