### PR TITLE
fix: 특정 스타카토 조회시 위도,경도도 함께 반환 #390

### DIFF
--- a/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
+++ b/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
@@ -1,5 +1,6 @@
 package com.staccato.moment.service.dto.response;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -30,6 +31,10 @@ public record MomentDetailResponse(
         String placeName,
         @Schema(example = "서울 용산구 남산공원길 105")
         String address,
+        @Schema(example = "51.51978412729915")
+        BigDecimal latitude,
+        @Schema(example = "-0.12712788587027796")
+        BigDecimal longitude,
         List<CommentResponse> comments
 ) {
     public MomentDetailResponse(Moment moment) {
@@ -43,6 +48,8 @@ public record MomentDetailResponse(
                 moment.getFeeling().getValue(),
                 moment.getSpot().getPlaceName(),
                 moment.getSpot().getAddress(),
+                moment.getSpot().getLatitude(),
+                moment.getSpot().getLongitude(),
                 moment.getComments().stream().map(CommentResponse::new).toList()
         );
     }

--- a/backend/src/test/java/com/staccato/fixture/moment/MomentDetailResponseFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/moment/MomentDetailResponseFixture.java
@@ -1,5 +1,6 @@
 package com.staccato.fixture.moment;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -17,6 +18,8 @@ public class MomentDetailResponseFixture {
                 "happy",
                 "placeName",
                 "address",
+                new BigDecimal("37.77490000000000"),
+                new BigDecimal("-122.41940000000000"),
                 List.of());
     }
 }

--- a/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
@@ -9,8 +9,8 @@ import com.staccato.moment.domain.Moment;
 import com.staccato.moment.domain.MomentImages;
 
 public class MomentFixture {
-    private static final BigDecimal latitude = new BigDecimal("37.7749");
-    private static final BigDecimal longitude = new BigDecimal("-122.4194");
+    private static final BigDecimal latitude = new BigDecimal("37.77490000000000");
+    private static final BigDecimal longitude = new BigDecimal("-122.41940000000000");
 
     public static Moment create(Memory memory) {
         return Moment.builder()


### PR DESCRIPTION
## ⭐️ Issue Number
- #390 

## 🚩 Summary
- 구글맵API를 붙였기 때문에, 스타카토 수정시 위치를 변경할 수 있게 되었습니다.
- 스타카토 수정 페이지에 들어갈 때, 기존 데이터를 미리 채워야하기 때문에 스타카토 조회가 일어납니다. (MomentDetailResponse)
- 현재 스타카토 조회시(MomentDetailResponse) 위도 경도를 보내주고 있지 않습니다.
- 스타카토 수정 요청을 보내려면 위도 경도값도 다시 보내줘야 하는데, 조회시 위도경도가 없으므로 위치를 바꾸지 않았을 때 문제가 생깁니다.
- 따라서 MomentDetailResponse에 위도경도 필드를 추가했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer
- 매우 간단한 수정입니다~

## 📋 To Do
