### PR TITLE
refactor: 추억 조회 시 created_at 기준 정렬을 DB단이 아닌 애플리케이션 단에서 수행 #404

### DIFF
--- a/backend/src/main/java/com/staccato/comment/domain/Comment.java
+++ b/backend/src/main/java/com/staccato/comment/domain/Comment.java
@@ -8,10 +8,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 
 import com.staccato.config.domain.BaseEntity;
@@ -26,9 +24,6 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 @Entity
-@Table(indexes = {
-        @Index(name = "idx_moment_id", columnList = "moment_id")
-})
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/staccato/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/staccato/comment/repository/CommentRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.staccato.comment.domain.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
-    List<Comment> findAllByMomentIdOrderByCreatedAtAsc(long momentId);
+    List<Comment> findAllByMomentId(long momentId);
 }

--- a/backend/src/main/java/com/staccato/comment/service/CommentService.java
+++ b/backend/src/main/java/com/staccato/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.staccato.comment.service;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -40,7 +41,8 @@ public class CommentService {
     public CommentResponses readAllCommentsByMomentId(Member member, Long momentId) {
         Moment moment = getMoment(momentId);
         validateOwner(moment.getMemory(), member);
-        List<Comment> comments = commentRepository.findAllByMomentIdOrderByCreatedAtAsc(momentId);
+        List<Comment> comments = commentRepository.findAllByMomentId(momentId);
+        sortByCreatedAtAscending(comments);
 
         return CommentResponses.from(comments);
     }
@@ -66,6 +68,10 @@ public class CommentService {
         if (memory.isNotOwnedBy(member)) {
             throw new ForbiddenException();
         }
+    }
+
+    private void sortByCreatedAtAscending(List<Comment> comments) {
+        comments.sort(Comparator.comparing(Comment::getCreatedAt));
     }
 
     private void validateCommentOwner(Comment comment, Member member) {

--- a/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
+++ b/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
@@ -17,9 +17,8 @@ public interface MemoryMemberRepository extends JpaRepository<MemoryMember, Long
             SELECT mm FROM MemoryMember mm WHERE mm.member.id = :memberId
             AND ((mm.memory.term.startAt is null AND mm.memory.term.endAt is null)
             or (:date BETWEEN mm.memory.term.startAt AND mm.memory.term.endAt))
-            ORDER BY mm.memory.createdAt DESC
             """)
-    List<MemoryMember> findAllByMemberIdAndIncludingDateOrderByCreatedAtDesc(@Param("memberId") long memberId, @Param("date") LocalDate date);
+    List<MemoryMember> findAllByMemberIdAndIncludingDate(@Param("memberId") long memberId, @Param("date") LocalDate date);
 
     boolean existsByMemberAndMemoryTitle(Member member, String title);
 }

--- a/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
+++ b/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
@@ -11,7 +11,7 @@ import com.staccato.member.domain.Member;
 import com.staccato.memory.domain.MemoryMember;
 
 public interface MemoryMemberRepository extends JpaRepository<MemoryMember, Long> {
-    List<MemoryMember> findAllByMemberIdOrderByMemoryCreatedAtDesc(long memberId);
+    List<MemoryMember> findAllByMemberIdOrderByMemory(long memberId);
 
     @Query("""
             SELECT mm FROM MemoryMember mm WHERE mm.member.id = :memberId

--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -1,6 +1,7 @@
 package com.staccato.memory.service;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -44,12 +45,18 @@ public class MemoryService {
     }
 
     public MemoryResponses readAllMemories(Member member) {
-        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberIdOrderByMemoryCreatedAtDesc(member.getId());
+        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId());
+        sortByCreatedAtDescending(memoryMembers);
+
         return MemoryResponses.from(
                 memoryMembers.stream()
                         .map(MemoryMember::getMemory)
                         .toList()
         );
+    }
+
+    private void sortByCreatedAtDescending(List<MemoryMember> memoryMembers) {
+        memoryMembers.sort((mm1, mm2) -> mm2.getCreatedAt().compareTo(mm1.getCreatedAt()));
     }
 
     public MemoryNameResponses readAllMemoriesIncludingDate(Member member, LocalDate currentDate) {
@@ -59,6 +66,10 @@ public class MemoryService {
                         .map(MemoryMember::getMemory)
                         .toList()
         );
+    }
+
+    private void sortByCreatedAtDescending(List<MemoryMember> memoryMembers) {
+        memoryMembers.sort(Comparator.comparing(MemoryMember::getCreatedAt).reversed());
     }
 
     public MemoryDetailResponse readMemoryById(long memoryId, Member member) {

--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -55,12 +55,10 @@ public class MemoryService {
         );
     }
 
-    private void sortByCreatedAtDescending(List<MemoryMember> memoryMembers) {
-        memoryMembers.sort((mm1, mm2) -> mm2.getCreatedAt().compareTo(mm1.getCreatedAt()));
-    }
-
     public MemoryNameResponses readAllMemoriesIncludingDate(Member member, LocalDate currentDate) {
-        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberIdAndIncludingDateOrderByCreatedAtDesc(member.getId(), currentDate);
+        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberIdAndIncludingDate(member.getId(), currentDate);
+        sortByCreatedAtDescending(memoryMembers);
+
         return MemoryNameResponses.from(
                 memoryMembers.stream()
                         .map(MemoryMember::getMemory)

--- a/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
@@ -35,7 +35,7 @@ class MemoryMemberRepositoryTest {
         memoryMemberRepository.save(new MemoryMember(member, memory2));
 
         // when
-        List<MemoryMember> result = memoryMemberRepository.findAllByMemberIdAndIncludingDateOrderByCreatedAtDesc(member.getId(), LocalDate.of(2023, 12, 31));
+        List<MemoryMember> result = memoryMemberRepository.findAllByMemberIdAndIncludingDate(member.getId(), LocalDate.of(2023, 12, 31));
 
         // then
         assertThat(result).hasSize(1);
@@ -52,7 +52,7 @@ class MemoryMemberRepositoryTest {
         memoryMemberRepository.save(new MemoryMember(member, memory2));
 
         // when
-        List<MemoryMember> result = memoryMemberRepository.findAllByMemberIdAndIncludingDateOrderByCreatedAtDesc(member.getId(), LocalDate.of(2023, 12, 30));
+        List<MemoryMember> result = memoryMemberRepository.findAllByMemberIdAndIncludingDate(member.getId(), LocalDate.of(2023, 12, 30));
 
         // then
         assertThat(result).hasSize(2);

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -25,6 +25,7 @@ import com.staccato.memory.service.dto.request.MemoryRequest;
 import com.staccato.memory.service.dto.response.MemoryDetailResponse;
 import com.staccato.memory.service.dto.response.MemoryIdResponse;
 import com.staccato.memory.service.dto.response.MemoryNameResponses;
+import com.staccato.memory.service.dto.response.MemoryResponses;
 import com.staccato.memory.service.dto.response.MomentResponse;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.repository.MomentRepository;
@@ -70,7 +71,7 @@ class MemoryServiceTest extends ServiceSliceTest {
 
         // when
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
-        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemoryCreatedAtDesc(member.getId())
+        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId())
                 .get(0);
 
         // then
@@ -89,7 +90,7 @@ class MemoryServiceTest extends ServiceSliceTest {
 
         // when
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
-        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemoryCreatedAtDesc(member.getId())
+        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId())
                 .get(0);
 
         // then
@@ -124,6 +125,25 @@ class MemoryServiceTest extends ServiceSliceTest {
 
         // when & then
         assertThatNoException().isThrownBy(() -> memoryService.createMemory(memoryRequest, member));
+    }
+
+    @DisplayName("사용자의 모든 추억을 조회하면 생성 시간 기준 내림차순으로 조회된다.")
+    @Test
+    void readAllMemories() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create());
+
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2023, 7, 1), LocalDate.of(2024, 7, 10), "first"), member);
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2023, 7, 1), LocalDate.of(2024, 7, 10), "second"), member);
+
+        // when
+        MemoryResponses memoryResponses = memoryService.readAllMemories(member);
+
+        // then
+        assertAll(
+                () -> assertThat(memoryResponses.memories().get(0).memoryTitle()).isEqualTo("second"),
+                () -> assertThat(memoryResponses.memories().get(1).memoryTitle()).isEqualTo("first")
+        );
     }
 
     @DisplayName("현재 날짜를 포함하는 모든 추억 목록을 조회한다.")

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -163,6 +163,25 @@ class MemoryServiceTest extends ServiceSliceTest {
         assertThat(memoryNameResponses.memories()).hasSize(expectedSize);
     }
 
+    @DisplayName("현재 날짜를 포함하는 모든 추억 목록을 생성 시간 기준 내림차순으로 조회한다.")
+    @Test
+    void readAllMemoriesOrderByCreatedAtDesc() {
+        // given
+        LocalDate currentDate = LocalDate.of(2024, 7, 1);
+        Member member = memberRepository.save(MemberFixture.create());
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 1), "title1"), member);
+        memoryService.createMemory(MemoryRequestFixture.create(LocalDate.of(2024, 7, 1), LocalDate.of(2024, 7, 2), "title2"), member);
+
+        // when
+        MemoryNameResponses memoryNameResponses = memoryService.readAllMemoriesIncludingDate(member, currentDate);
+
+        // then
+        assertAll(
+                () -> assertThat(memoryNameResponses.memories().get(0).memoryTitle()).isEqualTo("title2"),
+                () -> assertThat(memoryNameResponses.memories().get(1).memoryTitle()).isEqualTo("title1")
+        );
+    }
+
     @DisplayName("특정 추억을 조회한다.")
     @Test
     void readMemoryById() {


### PR DESCRIPTION
## ⭐️ Issue Number
- #404 

## 🚩 Summary
- 추억 조회 시 created_at 기준 정렬을 하는데, 이를 DB단이 아닌 애플리케이션 단에서 수행하도록 변경했습니다.
- 특정 스타카토에 댓글의 갯수는 일반적으로 매우 적을 것이라 예상됩니다. 댓글의 전체 갯수는 다른 테이블에 비해 가장 많은 편이라 DB의 용량을 꽤나 큰 비율로 차지할텐데, 아주 작은 양의 정렬을 위해 (moment_id, created_at)에 대한 복합인덱스를 거는 것은 DB용량 측면에서 손해라고 생각합니다. 따라서 복합인덱스를 거는 대신 애플리케이션 단에서 정렬했습니다. 
  -  예상과 다르게 특정 스타카토에 평균적으로 많은 양의 댓글이 달린다면 복합인덱스를 고려해도 좋겠습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
