### PR TITLE
feat: 스타카토 생성 및 수정 화면 위치 권한 플로우 변경 #416

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
@@ -1,0 +1,137 @@
+package com.on.staccato.presentation.common
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.view.View
+import androidx.activity.result.ActivityResultCaller
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentManager
+import com.google.android.gms.common.api.ResolvableApiException
+import com.google.android.gms.location.Granularity
+import com.google.android.gms.location.LocationRequest
+import com.google.android.gms.location.LocationServices
+import com.google.android.gms.location.LocationSettingsRequest
+import com.google.android.gms.location.LocationSettingsResponse
+import com.google.android.gms.location.Priority
+import com.google.android.gms.location.SettingsClient
+import com.google.android.gms.tasks.Task
+import com.on.staccato.R
+import com.on.staccato.presentation.common.location.LocationDialogFragment
+import com.on.staccato.presentation.util.showSnackBar
+
+class LocationPermissionManager(
+    private val context: Context,
+    private val activity: Activity,
+) {
+    val locationPermissions: Array<String> =
+        arrayOf(
+            Manifest.permission.ACCESS_FINE_LOCATION,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+        )
+    private val locationDialog = LocationDialogFragment()
+
+    fun requestPermissionLauncher(
+        activityResultCaller: ActivityResultCaller,
+        view: View,
+        actionWhenHavePermission: () -> Unit,
+    ) = activityResultCaller.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+        permissions.forEach { (_, isGranted) ->
+            if (isGranted) {
+                view.showSnackBar(context.resources.getString(R.string.maps_location_permission_granted_message))
+                checkLocationSetting(actionWhenHavePermission)
+            } else {
+                view.showSnackBar(context.resources.getString(R.string.all_location_permission_denial))
+            }
+        }
+    }
+
+    fun checkLocationSetting(actionWhenHavePermission: () -> Unit) {
+        val locationRequest: LocationRequest = buildLocationRequest()
+
+        val builder =
+            LocationSettingsRequest
+                .Builder()
+                .addLocationRequest(locationRequest)
+
+        val settingsClient: SettingsClient = LocationServices.getSettingsClient(activity)
+        val locationSettingsResponse: Task<LocationSettingsResponse> =
+            settingsClient.checkLocationSettings(builder.build())
+
+        succeedLocationSettings(locationSettingsResponse, actionWhenHavePermission)
+        failLocationSettings(locationSettingsResponse, activity)
+    }
+
+    fun checkSelfLocationPermission(): Boolean {
+        val isGrantedCoarseLocation =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+
+        val isGrantedFineLocation =
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+
+        return isGrantedCoarseLocation && isGrantedFineLocation
+    }
+
+    fun shouldShowRequestLocationPermissionsRationale(): Boolean {
+        val shouldRequestCoarseLocation =
+            ActivityCompat.shouldShowRequestPermissionRationale(
+                activity,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            )
+
+        val shouldRequestFineLocation =
+            ActivityCompat.shouldShowRequestPermissionRationale(
+                activity,
+                Manifest.permission.ACCESS_FINE_LOCATION,
+            )
+
+        return shouldRequestCoarseLocation && shouldRequestFineLocation
+    }
+
+    fun showLocationRequestRationaleDialog(fragmentManager: FragmentManager) {
+        if (!locationDialog.isAdded) {
+            locationDialog.show(fragmentManager, LocationDialogFragment.TAG)
+        }
+    }
+
+    private fun buildLocationRequest(): LocationRequest =
+        LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, INTERVAL_MILLIS).apply {
+            setGranularity(Granularity.GRANULARITY_PERMISSION_LEVEL)
+            setWaitForAccurateLocation(true)
+        }.build()
+
+    private fun succeedLocationSettings(
+        locationSettingsResponse: Task<LocationSettingsResponse>,
+        actionWhenHavePermission: () -> Unit,
+    ) {
+        locationSettingsResponse.addOnSuccessListener { actionWhenHavePermission() }
+    }
+
+    private fun failLocationSettings(
+        locationSettingsResponse: Task<LocationSettingsResponse>,
+        activity: Activity,
+    ) {
+        locationSettingsResponse.addOnFailureListener { exception ->
+            if (exception is ResolvableApiException) {
+                exception.startResolutionForResult(
+                    activity,
+                    REQUEST_CODE_LOCATION,
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val INTERVAL_MILLIS = 10000L
+        private const val REQUEST_CODE_LOCATION = 100
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
@@ -28,11 +28,6 @@ class LocationPermissionManager(
     private val context: Context,
     private val activity: Activity,
 ) {
-    val locationPermissions: Array<String> =
-        arrayOf(
-            Manifest.permission.ACCESS_FINE_LOCATION,
-            Manifest.permission.ACCESS_COARSE_LOCATION,
-        )
     private val locationDialog = LocationDialogFragment()
 
     fun requestPermissionLauncher(
@@ -129,6 +124,11 @@ class LocationPermissionManager(
     }
 
     companion object {
+        val locationPermissions: Array<String> =
+            arrayOf(
+                Manifest.permission.ACCESS_FINE_LOCATION,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            )
         private const val INTERVAL_MILLIS = 10000L
         private const val REQUEST_CODE_LOCATION = 100
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/LocationPermissionManager.kt
@@ -5,8 +5,8 @@ import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.view.View
-import androidx.activity.result.ActivityResultCaller
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentManager
@@ -22,19 +22,17 @@ import com.google.android.gms.tasks.Task
 import com.on.staccato.R
 import com.on.staccato.presentation.common.location.LocationDialogFragment
 import com.on.staccato.presentation.util.showSnackBar
-import java.lang.Exception
 
 class LocationPermissionManager(
     private val context: Context,
-    private val activity: Activity,
+    private val activity: AppCompatActivity,
 ) {
     private val locationDialog = LocationDialogFragment()
 
     fun requestPermissionLauncher(
-        activityResultCaller: ActivityResultCaller,
         view: View,
         actionWhenHavePermission: () -> Unit,
-    ) = activityResultCaller.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
+    ) = activity.registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
         permissions.forEach { (_, isGranted) ->
             if (isGranted) {
                 view.showSnackBar(context.resources.getString(R.string.maps_location_permission_granted_message))

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/location/LocationDialogFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/location/LocationDialogFragment.kt
@@ -48,7 +48,7 @@ class LocationDialogFragment : DialogFragment(), LocationDialogHandler {
     }
 
     override fun onCancelClicked() {
-        sharedViewModel.updateIsLocationDenial()
+        sharedViewModel.updateIsPermissionCancelClicked()
         dismiss()
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/location/LocationDialogFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/location/LocationDialogFragment.kt
@@ -53,6 +53,7 @@ class LocationDialogFragment : DialogFragment(), LocationDialogHandler {
     }
 
     override fun onSettingClicked() {
+        sharedViewModel.updateIsSettingClicked(isSettingClicked = true)
         navigateToSetting()
         dismiss()
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -95,6 +95,11 @@ class MainActivity :
         onMarkerClicked(map)
     }
 
+    override fun onStop() {
+        super.onStop()
+        sharedViewModel.updateIsSettingClicked(false)
+    }
+
     override fun onStaccatoCreationClicked() {
         MomentCreationActivity.startWithResultLauncher(
             0L,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -343,6 +343,7 @@ class MainActivity :
 
     private fun setUpBottomSheetBehaviorAction() {
         behavior.apply {
+            changeSkipCollapsed()
             addBottomSheetCallback(
                 object : BottomSheetBehavior.BottomSheetCallback() {
                     override fun onStateChanged(
@@ -356,11 +357,17 @@ class MainActivity :
                                 binding.constraintMainBottomSheet.setBackgroundResource(
                                     R.drawable.shape_bottom_sheet_square,
                                 )
+                                changeSkipCollapsed(skipCollapsed = false)
                             }
 
                             STATE_HALF_EXPANDED -> {
                                 mapsViewModel.setIsHalf(isHalf = true)
                                 currentFocus?.let { clearFocusAndHideKeyboard(it) }
+                                changeSkipCollapsed()
+                            }
+
+                            STATE_COLLAPSED -> {
+                                mapsViewModel.setIsHalf(isHalf = false)
                             }
 
                             else -> {
@@ -368,20 +375,31 @@ class MainActivity :
                                 binding.constraintMainBottomSheet.setBackgroundResource(
                                     R.drawable.shape_bottom_sheet_20dp,
                                 )
-                                mapsViewModel.setIsHalf(isHalf = false)
                                 currentFocus?.let { clearFocusAndHideKeyboard(it) }
                             }
                         }
                     }
 
                     override fun onSlide(
-                        p0: View,
-                        p1: Float,
+                        view: View,
+                        slideOffset: Float,
                     ) {
+                        if (slideOffset < 0.05) {
+                            changeSkipCollapsed(isHideable = false)
+                            state = STATE_COLLAPSED
+                        }
                     }
                 },
             )
         }
+    }
+
+    private fun BottomSheetBehavior<ConstraintLayout>.changeSkipCollapsed(
+        isHideable: Boolean = true,
+        skipCollapsed: Boolean = true,
+    ) {
+        this.isHideable = isHideable
+        this.skipCollapsed = skipCollapsed
     }
 
     private fun setUpBottomSheetStateListener() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -112,7 +112,6 @@ class MainActivity :
     private fun setupPermissionRequestLauncher() {
         permissionRequestLauncher =
             locationPermissionManager.requestPermissionLauncher(
-                activityResultCaller = this,
                 view = binding.root,
                 actionWhenHavePermission = ::enableMyLocation,
             )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -34,6 +34,7 @@ import com.on.staccato.databinding.ActivityMainBinding
 import com.on.staccato.domain.model.MomentLocation
 import com.on.staccato.presentation.base.BindingActivity
 import com.on.staccato.presentation.common.LocationPermissionManager
+import com.on.staccato.presentation.common.LocationPermissionManager.Companion.locationPermissions
 import com.on.staccato.presentation.main.model.MarkerUiModel
 import com.on.staccato.presentation.main.viewmodel.MapsViewModel
 import com.on.staccato.presentation.main.viewmodel.SharedViewModel
@@ -61,7 +62,6 @@ class MainActivity :
     private val sharedViewModel: SharedViewModel by viewModels()
     private val mapsViewModel: MapsViewModel by viewModels()
     private val locationPermissionManager = LocationPermissionManager(context = this, activity = this)
-    private val locationPermissions = locationPermissionManager.locationPermissions
 
     val memoryCreationLauncher: ActivityResultLauncher<Intent> = handleMemoryResult()
     val memoryUpdateLauncher: ActivityResultLauncher<Intent> = handleMemoryResult()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -1,12 +1,8 @@
 package com.on.staccato.presentation.main
 
-import android.Manifest.permission.ACCESS_COARSE_LOCATION
-import android.Manifest.permission.ACCESS_FINE_LOCATION
 import android.content.Intent
-import android.content.pm.PackageManager
 import android.location.Location
 import android.os.Bundle
-import android.util.Log
 import android.view.View
 import android.view.inputmethod.InputMethodManager
 import androidx.activity.addCallback
@@ -14,21 +10,13 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.app.ActivityCompat
-import androidx.core.content.ContextCompat
 import androidx.core.os.bundleOf
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
-import com.google.android.gms.common.api.ResolvableApiException
 import com.google.android.gms.location.FusedLocationProviderClient
-import com.google.android.gms.location.Granularity
-import com.google.android.gms.location.LocationRequest
 import com.google.android.gms.location.LocationServices
-import com.google.android.gms.location.LocationSettingsRequest
-import com.google.android.gms.location.LocationSettingsResponse
 import com.google.android.gms.location.Priority.PRIORITY_HIGH_ACCURACY
-import com.google.android.gms.location.SettingsClient
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -41,12 +29,11 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_COLLAPSED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_EXPANDED
 import com.google.android.material.bottomsheet.BottomSheetBehavior.STATE_HALF_EXPANDED
-import com.google.android.material.snackbar.Snackbar
 import com.on.staccato.R
 import com.on.staccato.databinding.ActivityMainBinding
 import com.on.staccato.domain.model.MomentLocation
 import com.on.staccato.presentation.base.BindingActivity
-import com.on.staccato.presentation.common.location.LocationDialogFragment
+import com.on.staccato.presentation.common.LocationPermissionManager
 import com.on.staccato.presentation.main.model.MarkerUiModel
 import com.on.staccato.presentation.main.viewmodel.MapsViewModel
 import com.on.staccato.presentation.main.viewmodel.SharedViewModel
@@ -68,18 +55,13 @@ class MainActivity :
     private lateinit var behavior: BottomSheetBehavior<ConstraintLayout>
     private lateinit var navHostFragment: NavHostFragment
     private lateinit var navController: NavController
+    private lateinit var permissionRequestLauncher: ActivityResultLauncher<Array<String>>
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
 
-    private val locationPermissions: Array<String> =
-        arrayOf(
-            ACCESS_FINE_LOCATION,
-            ACCESS_COARSE_LOCATION,
-        )
     private val sharedViewModel: SharedViewModel by viewModels()
     private val mapsViewModel: MapsViewModel by viewModels()
-    private val locationDialog = LocationDialogFragment()
-
-    private val requestPermissionLauncher = initRequestPermissionsLauncher()
+    private val locationPermissionManager = LocationPermissionManager(context = this, activity = this)
+    private val locationPermissions = locationPermissionManager.locationPermissions
 
     val memoryCreationLauncher: ActivityResultLauncher<Intent> = handleMemoryResult()
     val memoryUpdateLauncher: ActivityResultLauncher<Intent> = handleMemoryResult()
@@ -88,6 +70,7 @@ class MainActivity :
 
     override fun initStartView(savedInstanceState: Bundle?) {
         binding.handler = this
+        setupPermissionRequestLauncher()
         setupGoogleMap()
         setupFusedLocationProviderClient()
         observeCurrentLocation()
@@ -112,12 +95,6 @@ class MainActivity :
         onMarkerClicked(map)
     }
 
-    private fun moveDefaultLocation() {
-        val defaultLocation =
-            LatLng(SEOUL_STATION_LATITUDE, SEOUL_STATION_LONGITUDE)
-        googleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(defaultLocation, DEFAULT_ZOOM))
-    }
-
     override fun onStaccatoCreationClicked() {
         MomentCreationActivity.startWithResultLauncher(
             0L,
@@ -127,21 +104,14 @@ class MainActivity :
         )
     }
 
-    private fun initRequestPermissionsLauncher() =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
-            permissions.forEach { (_, isGranted) ->
-                if (isGranted) {
-                    makeSnackBar(
-                        getString(R.string.maps_location_permission_granted_message),
-                    ).show()
-                    checkLocationSetting()
-                } else {
-                    makeSnackBar(
-                        getString(R.string.all_location_permission_denial),
-                    ).show()
-                }
-            }
-        }
+    private fun setupPermissionRequestLauncher() {
+        permissionRequestLauncher =
+            locationPermissionManager.requestPermissionLauncher(
+                activityResultCaller = this,
+                view = binding.root,
+                actionWhenHavePermission = ::enableMyLocation,
+            )
+    }
 
     private fun setupGoogleMap() {
         val map: SupportMapFragment? =
@@ -150,47 +120,21 @@ class MainActivity :
     }
 
     private fun checkLocationSetting() {
-        val locationRequest: LocationRequest = buildLocationRequest()
-
-        val builder =
-            LocationSettingsRequest
-                .Builder()
-                .addLocationRequest(locationRequest)
-
-        val settingsClient: SettingsClient = LocationServices.getSettingsClient(this)
-        val locationSettingsResponse: Task<LocationSettingsResponse> =
-            settingsClient.checkLocationSettings(builder.build())
-
-        succeedLocationSettings(locationSettingsResponse)
-        failLocationSettings(locationSettingsResponse)
+        locationPermissionManager.checkLocationSetting(actionWhenHavePermission = ::enableMyLocation)
     }
 
-    private fun succeedLocationSettings(locationSettingsResponse: Task<LocationSettingsResponse>) {
-        locationSettingsResponse.addOnSuccessListener {
-            enableMyLocation()
-        }
+    private fun moveDefaultLocation() {
+        val defaultLocation =
+            LatLng(SEOUL_STATION_LATITUDE, SEOUL_STATION_LONGITUDE)
+        googleMap.animateCamera(CameraUpdateFactory.newLatLngZoom(defaultLocation, DEFAULT_ZOOM))
     }
-
-    private fun failLocationSettings(locationSettingsResponse: Task<LocationSettingsResponse>) {
-        locationSettingsResponse.addOnFailureListener { exception ->
-            if (exception is ResolvableApiException) {
-                exception.startResolutionForResult(
-                    this,
-                    REQUEST_CODE_LOCATION,
-                )
-            }
-        }
-    }
-
-    private fun buildLocationRequest(): LocationRequest =
-        LocationRequest.Builder(PRIORITY_HIGH_ACCURACY, INTERVAL_MILLIS).apply {
-            setGranularity(Granularity.GRANULARITY_PERMISSION_LEVEL)
-            setWaitForAccurateLocation(true)
-        }.build()
 
     private fun enableMyLocation() {
+        val checkSelfLocationPermission = locationPermissionManager.checkSelfLocationPermission()
+        val shouldShowRequestLocationPermissionsRationale = locationPermissionManager.shouldShowRequestLocationPermissionsRationale()
+
         when {
-            checkSelfLocationPermission() -> {
+            checkSelfLocationPermission -> {
                 googleMap.isMyLocationEnabled = true
                 val currentLocation: Task<Location> =
                     fusedLocationProviderClient.getCurrentLocation(
@@ -200,57 +144,21 @@ class MainActivity :
                 mapsViewModel.setCurrentLocation(currentLocation)
             }
 
-            shouldShowRequestLocationPermissionsRationale() -> {
-                observeIsLocationDenial { showLocationRequestRationaleDialog() }
+            shouldShowRequestLocationPermissionsRationale -> {
+                observeIsPermissionCancelClicked {
+                    locationPermissionManager.showLocationRequestRationaleDialog(supportFragmentManager)
+                }
             }
 
             else -> {
-                observeIsLocationDenial { requestPermissionLauncher.launch(locationPermissions) }
+                observeIsPermissionCancelClicked { permissionRequestLauncher.launch(locationPermissions) }
             }
         }
     }
 
-    private fun observeIsLocationDenial(action: () -> Unit) {
-        sharedViewModel.isLocationDenial.observe(this) { isCancel ->
-            if (!isCancel) action()
-        }
-    }
-
-    private fun checkSelfLocationPermission(): Boolean {
-        val isGrantedCoarseLocation =
-            ContextCompat.checkSelfPermission(
-                this,
-                ACCESS_COARSE_LOCATION,
-            ) == PackageManager.PERMISSION_GRANTED
-
-        val isGrantedFineLocation =
-            ContextCompat.checkSelfPermission(
-                this,
-                ACCESS_FINE_LOCATION,
-            ) == PackageManager.PERMISSION_GRANTED
-
-        return isGrantedCoarseLocation && isGrantedFineLocation
-    }
-
-    private fun shouldShowRequestLocationPermissionsRationale(): Boolean {
-        val shouldRequestCoarseLocation =
-            ActivityCompat.shouldShowRequestPermissionRationale(
-                this,
-                ACCESS_COARSE_LOCATION,
-            )
-
-        val shouldRequestFineLocation =
-            ActivityCompat.shouldShowRequestPermissionRationale(
-                this,
-                ACCESS_FINE_LOCATION,
-            )
-
-        return shouldRequestCoarseLocation && shouldRequestFineLocation
-    }
-
-    private fun showLocationRequestRationaleDialog() {
-        if (!locationDialog.isAdded) {
-            locationDialog.show(supportFragmentManager, LocationDialogFragment.TAG)
+    private fun observeIsPermissionCancelClicked(requestLocationPermissions: () -> Unit) {
+        sharedViewModel.isPermissionCancelClicked.observe(this) { isCancel ->
+            if (!isCancel) requestLocationPermissions()
         }
     }
 
@@ -345,8 +253,6 @@ class MainActivity :
 
         navController.navigate(R.id.momentFragment, bundle, navOptions)
     }
-
-    private fun makeSnackBar(message: String) = Snackbar.make(binding.root, message, Snackbar.LENGTH_SHORT)
 
     private fun setupBackPressedHandler() {
         var backPressedTime = 0L
@@ -480,7 +386,6 @@ class MainActivity :
         ) { _, bundle ->
             val newState = bundle.getInt(BOTTOM_SHEET_NEW_STATE)
             behavior.state = newState
-            Log.d("hye", "$newState")
         }
     }
 
@@ -497,8 +402,6 @@ class MainActivity :
     }
 
     companion object {
-        private const val INTERVAL_MILLIS = 10000L
-        private const val REQUEST_CODE_LOCATION = 100
         private const val DEFAULT_MAP_PADDING = 0
         private const val DEFAULT_ZOOM = 15f
         private const val SEOUL_STATION_LATITUDE = 37.554677038139815

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -135,11 +135,11 @@ class MainActivity :
     }
 
     private fun enableMyLocation() {
-        val checkSelfLocationPermission = locationPermissionManager.checkSelfLocationPermission()
+        val isLocationPermissionGranted = locationPermissionManager.checkSelfLocationPermission()
         val shouldShowRequestLocationPermissionsRationale = locationPermissionManager.shouldShowRequestLocationPermissionsRationale()
 
         when {
-            checkSelfLocationPermission -> {
+            isLocationPermissionGranted -> {
                 googleMap.isMyLocationEnabled = true
                 val currentLocation: Task<Location> =
                     fusedLocationProviderClient.getCurrentLocation(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
@@ -17,6 +17,9 @@ class SharedViewModel : ViewModel() {
     private val _isPermissionCancelClicked = MutableLiveData(false)
     val isPermissionCancelClicked: LiveData<Boolean> get() = _isPermissionCancelClicked
 
+    private val _isSettingClicked = MutableLiveData(false)
+    val isSettingClicked: LiveData<Boolean> get() = _isSettingClicked
+
     fun setTimelineHasUpdated() {
         _isTimelineUpdated.setValue(true)
     }
@@ -27,5 +30,9 @@ class SharedViewModel : ViewModel() {
 
     fun updateIsPermissionCancelClicked() {
         _isPermissionCancelClicked.value = true
+    }
+
+    fun updateIsSettingClicked(isSettingClicked: Boolean) {
+        _isSettingClicked.value = isSettingClicked
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
@@ -14,8 +14,8 @@ class SharedViewModel : ViewModel() {
     private val _isStaccatosUpdated = MutableSingleLiveData(false)
     val isStaccatosUpdated: SingleLiveData<Boolean> get() = _isStaccatosUpdated
 
-    private val _isLocationDenial = MutableLiveData(false)
-    val isLocationDenial: LiveData<Boolean> get() = _isLocationDenial
+    private val _isPermissionCancelClicked = MutableLiveData(false)
+    val isPermissionCancelClicked: LiveData<Boolean> get() = _isPermissionCancelClicked
 
     fun setTimelineHasUpdated() {
         _isTimelineUpdated.setValue(true)
@@ -25,7 +25,7 @@ class SharedViewModel : ViewModel() {
         _isStaccatosUpdated.setValue(true)
     }
 
-    fun updateIsLocationDenial() {
-        _isLocationDenial.value = true
+    fun updateIsPermissionCancelClicked() {
+        _isPermissionCancelClicked.value = true
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -79,7 +79,6 @@ class MomentCreationActivity :
         viewModel.fetchMemoryCandidates(memoryId)
         setupPermissionRequestLauncher()
         setupFusedLocationProviderClient()
-        fetchCurrentLocationAddress()
         initBinding()
         initAdapter()
         initItemTouchHelper()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -159,12 +159,12 @@ class MomentCreationActivity :
     }
 
     private fun fetchCurrentLocationAddress(isCurrentLocationCallClicked: Boolean = false) {
-        val checkSelfLocationPermission = locationPermissionManager.checkSelfLocationPermission()
+        val isLocationPermissionGranted = locationPermissionManager.checkSelfLocationPermission()
         val shouldShowRequestLocationPermissionsRationale =
             locationPermissionManager.shouldShowRequestLocationPermissionsRationale()
 
         when {
-            checkSelfLocationPermission -> {
+            isLocationPermissionGranted -> {
                 val currentLocation: Task<Location> =
                     fusedLocationProviderClient.getCurrentLocation(
                         Priority.PRIORITY_HIGH_ACCURACY,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -71,6 +71,25 @@ class MomentCreationActivity :
 
     private val sharedViewModel: SharedViewModel by viewModels()
 
+    override fun initStartView(savedInstanceState: Bundle?) {
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
+        viewModel.fetchMemoryCandidates(memoryId)
+        setupPermissionRequestLauncher()
+        fetchCurrentLocationAddress()
+        initBinding()
+        initAdapter()
+        initItemTouchHelper()
+        initToolbar()
+        initMemorySelectionFragment()
+        observeViewModelData()
+        initGooglePlaceSearch()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        checkLocationSetting()
+    }
+
     override fun onNewPlaceSelected(
         placeId: String,
         name: String,
@@ -111,25 +130,6 @@ class MomentCreationActivity :
     override fun onCreateDoneClicked() {
         window.setFlags(FLAG_NOT_TOUCHABLE, FLAG_NOT_TOUCHABLE)
         viewModel.createMoment()
-    }
-
-    override fun initStartView(savedInstanceState: Bundle?) {
-        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
-        viewModel.fetchMemoryCandidates(memoryId)
-        setupPermissionRequestLauncher()
-        fetchCurrentLocationAddress()
-        initBinding()
-        initAdapter()
-        initItemTouchHelper()
-        initToolbar()
-        initMemorySelectionFragment()
-        observeViewModelData()
-        initGooglePlaceSearch()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        checkLocationSetting()
     }
 
     private fun setupPermissionRequestLauncher() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -72,9 +72,9 @@ class MomentCreationActivity :
     private val sharedViewModel: SharedViewModel by viewModels()
 
     override fun initStartView(savedInstanceState: Bundle?) {
-        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
         viewModel.fetchMemoryCandidates(memoryId)
         setupPermissionRequestLauncher()
+        setupFusedLocationProviderClient()
         fetchCurrentLocationAddress()
         initBinding()
         initAdapter()
@@ -149,6 +149,10 @@ class MomentCreationActivity :
                 )
             },
         )
+    }
+
+    private fun setupFusedLocationProviderClient() {
+        fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this)
     }
 
     private fun fetchCurrentLocationAddress(isCurrentLocationCallClicked: Boolean = false) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -27,6 +27,7 @@ import com.on.staccato.presentation.base.BindingActivity
 import com.on.staccato.presentation.common.CustomAutocompleteSupportFragment
 import com.on.staccato.presentation.common.GooglePlaceFragmentEventHandler
 import com.on.staccato.presentation.common.LocationPermissionManager
+import com.on.staccato.presentation.common.LocationPermissionManager.Companion.locationPermissions
 import com.on.staccato.presentation.common.PhotoAttachFragment
 import com.on.staccato.presentation.main.viewmodel.SharedViewModel
 import com.on.staccato.presentation.memory.MemoryFragment.Companion.MEMORY_ID_KEY
@@ -70,7 +71,6 @@ class MomentCreationActivity :
     private val memoryTitle by lazy { intent.getStringExtra(MEMORY_TITLE_KEY) ?: "" }
 
     private val locationPermissionManager = LocationPermissionManager(context = this, activity = this)
-    private val locationPermissions = locationPermissionManager.locationPermissions
     private lateinit var permissionRequestLauncher: ActivityResultLauncher<Array<String>>
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
     private lateinit var address: String

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -138,7 +138,6 @@ class MomentCreationActivity :
     private fun setupPermissionRequestLauncher() {
         permissionRequestLauncher =
             locationPermissionManager.requestPermissionLauncher(
-                activityResultCaller = this,
                 view = binding.root,
                 actionWhenHavePermission = ::fetchCurrentLocationAddress,
             )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -48,28 +48,32 @@ class MomentCreationActivity :
     MomentCreationHandler,
     BindingActivity<ActivityVisitCreationBinding>() {
     override val layoutResourceId = R.layout.activity_visit_creation
+
     private val viewModel: MomentCreationViewModel by viewModels()
+    private val sharedViewModel: SharedViewModel by viewModels()
+
     private val memoryVisitedAtSelectionFragment by lazy {
         MemoryVisitedAtSelectionFragment()
     }
     private val photoAttachFragment by lazy {
         PhotoAttachFragment().apply { setMultipleAbleOption(true) }
     }
-    private val fragmentManager: FragmentManager = supportFragmentManager
-    private lateinit var photoAttachAdapter: PhotoAttachAdapter
-    private lateinit var itemTouchHelper: ItemTouchHelper
-    private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, 0L) }
-    private val memoryTitle by lazy { intent.getStringExtra(MEMORY_TITLE_KEY) ?: "" }
-    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
-    private lateinit var address: String
     private val autocompleteFragment by lazy {
         supportFragmentManager.findFragmentById(R.id.autocomplete_fragment) as CustomAutocompleteSupportFragment
     }
+
+    private val fragmentManager: FragmentManager = supportFragmentManager
+    private lateinit var photoAttachAdapter: PhotoAttachAdapter
+    private lateinit var itemTouchHelper: ItemTouchHelper
+
+    private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, 0L) }
+    private val memoryTitle by lazy { intent.getStringExtra(MEMORY_TITLE_KEY) ?: "" }
+
     private val locationPermissionManager = LocationPermissionManager(context = this, activity = this)
     private val locationPermissions = locationPermissionManager.locationPermissions
     private lateinit var permissionRequestLauncher: ActivityResultLauncher<Array<String>>
-
-    private val sharedViewModel: SharedViewModel by viewModels()
+    private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
+    private lateinit var address: String
 
     override fun initStartView(savedInstanceState: Bundle?) {
         viewModel.fetchMemoryCandidates(memoryId)

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -139,7 +139,6 @@ class VisitUpdateActivity :
     private fun setupPermissionRequestLauncher() {
         permissionRequestLauncher =
             locationPermissionManager.requestPermissionLauncher(
-                activityResultCaller = this,
                 view = binding.root,
                 actionWhenHavePermission = ::fetchCurrentLocationAddress,
             )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -27,6 +27,7 @@ import com.on.staccato.presentation.base.BindingActivity
 import com.on.staccato.presentation.common.CustomAutocompleteSupportFragment
 import com.on.staccato.presentation.common.GooglePlaceFragmentEventHandler
 import com.on.staccato.presentation.common.LocationPermissionManager
+import com.on.staccato.presentation.common.LocationPermissionManager.Companion.locationPermissions
 import com.on.staccato.presentation.common.PhotoAttachFragment
 import com.on.staccato.presentation.main.viewmodel.SharedViewModel
 import com.on.staccato.presentation.memory.MemoryFragment.Companion.MEMORY_ID_KEY
@@ -71,7 +72,6 @@ class VisitUpdateActivity :
     }
 
     private val locationPermissionManager = LocationPermissionManager(context = this, activity = this)
-    private val locationPermissions = locationPermissionManager.locationPermissions
     private lateinit var permissionRequestLauncher: ActivityResultLauncher<Array<String>>
     private lateinit var fusedLocationProviderClient: FusedLocationProviderClient
     private lateinit var address: String

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -156,12 +156,12 @@ class VisitUpdateActivity :
     }
 
     private fun fetchCurrentLocationAddress() {
-        val checkSelfLocationPermission = locationPermissionManager.checkSelfLocationPermission()
+        val isLocationPermissionGranted = locationPermissionManager.checkSelfLocationPermission()
         val shouldShowRequestLocationPermissionsRationale =
             locationPermissionManager.shouldShowRequestLocationPermissionsRationale()
 
         when {
-            checkSelfLocationPermission -> {
+            isLocationPermissionGranted -> {
                 val currentLocation: Task<Location> =
                     fusedLocationProviderClient.getCurrentLocation(
                         Priority.PRIORITY_HIGH_ACCURACY,


### PR DESCRIPTION
## ⭐️ Issue Number
- #416 

<br>

## 🚩 Summary

> 스타카토 생성 및 수정 화면에 위치 설정 확인 플로우를 추가하고 기존의 위치 권한을 확인하는 플로우를 수정했습니다.
> 위치 설정 및 위치 권한 설정과 관련된 중복 로직들을 `LocationPermissionManager`가 가지도록 변경했습니다.

- **스타카토 생성 화면**

  https://github.com/user-attachments/assets/296d96ec-c88a-424e-b049-fddf3c9d1075

  - 스타카토 생성 화면은 현위치를 바로 불러옵니다.
  - 따라서 화면에 진입하자마자 위치 설정과 위치 권한 설정을 확인 합니다. 
  - 위치 권한이 설정 되어있지 않다면 교육용 UI를 띄웁니다.
  - 사용자가 교육용 UI의 취소 버튼을 누르면 현 위치를 불러오지 않습니다.
  - 사용자가 현위치 불러오기 버튼을 다시 누르면 교육용 UI를 띄워 설정으로 이동하도록 유도합니다.
  - 사용자가 설정으로 이동해 위치 권한을 허용하고 돌아오면 바로 현위치를 불러옵니다.

- **스타카토 수정 화면**

  https://github.com/user-attachments/assets/4f4ecced-2263-4831-be61-e3f8392eac14

  - 스타카토 수정 화면은 현위치 불러오기 버튼을 눌렀을 때만 위치 설정과 위치 권한 설정을 확인합니다.
  - 현위치 불러오기 버튼이 눌렸을 때 위치 권한이 허용되어 있다면 현위치를 불러옵니다.
  - 현위치 불러오기 버튼아 눌렸을 때 위치 권한이 허용되어있지 않다면 교육용 UI를 띄웁니다.
  - 사용자가 설정으로 이동해 위치 권한을 허용하고 돌아오면 바로 현위치를 불러옵니다.

<br>

## 🛠️ Technical Concerns
위치 권한과 관련한 자세한 정보는 [홈 화면에서의 위치 권한 설정 PR](https://github.com/woowacourse-teams/2024-staccato/pull/399) 을 확인해주세요!

<br>

## 🙂 To Reviewer
테스트 기기가 화면녹화가 안돼서 애뮬레이터로 시연영상을 촬영해 현위치가 올바르지 않은 점 양해 부탁드립니다!

<br>

## 📋 To Do
- 스타카토 도메인명 변경