### PR TITLE
feat: 개발용 이스터에그 로직 제거 #424

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -1,14 +1,9 @@
 package com.staccato.auth.service;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.core.env.Environment;
-import org.springframework.core.env.Profiles;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.staccato.auth.service.dto.request.LoginRequest;
 import com.staccato.auth.service.dto.response.LoginResponse;
-import com.staccato.config.auth.AdminProperties;
 import com.staccato.config.auth.TokenProvider;
 import com.staccato.config.log.LogForm;
 import com.staccato.config.log.annotation.Trace;
@@ -17,7 +12,6 @@ import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -26,25 +20,15 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-@EnableConfigurationProperties(AdminProperties.class)
 public class AuthService {
     private final MemberRepository memberRepository;
     private final TokenProvider tokenProvider;
-    private final AdminProperties adminProperties;
-    private final Environment environment;
 
     @Transactional
     public LoginResponse login(LoginRequest loginRequest) {
-        if (isNotProdProfile() && adminProperties.key().equals(loginRequest.nickname())) {
-            return new LoginResponse(adminProperties.token());
-        }
         Member member = createMember(loginRequest);
         String token = tokenProvider.create(member);
         return new LoginResponse(token);
-    }
-
-    private boolean isNotProdProfile() {
-        return !environment.acceptsProfiles(Profiles.of("prod"));
     }
 
     private Member createMember(LoginRequest loginRequest) {

--- a/backend/src/main/java/com/staccato/config/auth/AdminProperties.java
+++ b/backend/src/main/java/com/staccato/config/auth/AdminProperties.java
@@ -1,8 +1,0 @@
-package com.staccato.config.auth;
-
-import org.springframework.boot.context.properties.ConfigurationProperties;
-
-@ConfigurationProperties(prefix = "security.admin")
-public record AdminProperties(String key, String token) {
-}
-


### PR DESCRIPTION
## ⭐️ Issue Number
- #424

## 🚩 Summary
- 이전 기록을 불러올 수 있는 방법이 생겼기 때문에, 더이상 개발용 계정 접속을 위한 로직이 필요 없어졌다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
