### PR TITLE
refactor: 스타카토 조회 API 응답에 추억 기간 추가 #427

### DIFF
--- a/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
+++ b/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.domain.MomentImage;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -18,8 +19,10 @@ public record MomentDetailResponse(
         @Schema(example = "2024 서울 투어")
         String memoryTitle,
         @Schema(example = "2024-06-30")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate startAt,
         @Schema(example = "2024-07-04")
+        @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
         @Schema(example = "즐거웠던 남산에서의 기억")
         String staccatoTitle,

--- a/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
+++ b/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
@@ -1,6 +1,7 @@
 package com.staccato.moment.service.dto.response;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import com.staccato.moment.domain.Moment;
@@ -16,6 +17,10 @@ public record MomentDetailResponse(
         long memoryId,
         @Schema(example = "2024 서울 투어")
         String memoryTitle,
+        @Schema(example = "2024-06-30")
+        LocalDate startAt,
+        @Schema(example = "2024-07-04")
+        LocalDate endAt,
         @Schema(example = "즐거웠던 남산에서의 기억")
         String staccatoTitle,
         @ArraySchema(arraySchema = @Schema(example = "[\"https://example.com/images/namsan_tower.jpg\", \"https://example.com/images/namsan_tower2.jpg\"]"))
@@ -38,6 +43,8 @@ public record MomentDetailResponse(
                 moment.getId(),
                 moment.getMemory().getId(),
                 moment.getMemory().getTitle(),
+                moment.getMemory().getTerm().getStartAt(),
+                moment.getMemory().getTerm().getEndAt(),
                 moment.getTitle(),
                 moment.getMomentImages().getImages().stream().map(MomentImage::getImageUrl).toList(),
                 moment.getVisitedAt(),

--- a/backend/src/test/java/com/staccato/fixture/moment/MomentDetailResponseFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/moment/MomentDetailResponseFixture.java
@@ -1,6 +1,7 @@
 package com.staccato.fixture.moment;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import com.staccato.moment.service.dto.response.MomentDetailResponse;
@@ -11,6 +12,8 @@ public class MomentDetailResponseFixture {
                 momentId,
                 1,
                 "memoryTitle",
+                LocalDate.parse("2024-06-30"),
+                LocalDate.parse("2024-07-04"),
                 "staccatoTitle",
                 List.of("https://example1.com.jpg"),
                 visitedAt,

--- a/backend/src/test/java/com/staccato/moment/controller/MomentControllerTest.java
+++ b/backend/src/test/java/com/staccato/moment/controller/MomentControllerTest.java
@@ -235,6 +235,8 @@ class MomentControllerTest {
                          "momentId": 1,
                          "memoryId": 1,
                          "memoryTitle": "memoryTitle",
+                         "startAt": "2024-06-30",
+                         "endAt": "2024-07-04",
                          "staccatoTitle": "staccatoTitle",
                          "momentImageUrls": ["https://example1.com.jpg"],
                          "visitedAt": "2021-11-08T11:58:20",


### PR DESCRIPTION
## ⭐️ Issue Number
- #427

## 🚩 Summary
- 안드로이드 요청으로 스타카토 조회 API 응답에 추억 기간을 포함하도록 수정했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
