### PR TITLE
refactor: 추억 기간 설정 기능 개선 #432

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
@@ -2,6 +2,7 @@ package com.on.staccato.presentation
 
 import android.graphics.drawable.Drawable
 import android.net.Uri
+import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout
@@ -174,17 +175,19 @@ fun ImageView.setRoundedCornerImageByUriWithGlide(
 }
 
 @BindingAdapter(
-    value = ["memoryTitle", "startDate", "endDate", "isPhotoPosting"],
+    value = ["memoryTitle", "startDate", "endDate", "isPeriodSettingOn", "isPhotoPosting"],
 )
 fun Button.setMemorySaveButtonActive(
     title: String?,
     startDate: LocalDate?,
     endDate: LocalDate?,
+    isPeriodSettingOn: Boolean,
     isPhotoPosting: Boolean?,
 ) {
-    val areBothNullOrNotNull = (startDate == null) == (endDate == null)
+    val doesPeriodNotExist = (startDate == null) || (endDate == null)
+    val needPeriodButNotExist = isPeriodSettingOn && doesPeriodNotExist
     isEnabled =
-        if (title.isNullOrBlank() || isPhotoPosting == true || !areBothNullOrNotNull) {
+        if (title.isNullOrBlank() || isPhotoPosting == true || needPeriodButNotExist) {
             setTextColor(resources.getColor(R.color.gray4, null))
             false
         } else {
@@ -194,18 +197,20 @@ fun Button.setMemorySaveButtonActive(
 }
 
 @BindingAdapter(
-    value = ["memoryTitle", "startDate", "endDate", "photoUri", "photoUrl"],
+    value = ["memoryTitle", "startDate", "endDate", "isPeriodSettingOn", "photoUri", "photoUrl"],
 )
 fun Button.setMemorySaveButtonActive(
     title: String?,
     startDate: LocalDate?,
     endDate: LocalDate?,
+    isPeriodSettingOn: Boolean,
     photoUri: Uri?,
     photoUrl: String?,
 ) {
-    val areBothNullOrNotNull = (startDate == null) == (endDate == null)
+    val doesPeriodNotExist = (startDate == null) || (endDate == null)
+    val needPeriodButNotExist = isPeriodSettingOn && doesPeriodNotExist
     isEnabled =
-        if (title.isNullOrBlank() || (photoUri != null && photoUrl == null) || !areBothNullOrNotNull) {
+        if (title.isNullOrBlank() || (photoUri != null && photoUrl == null) || needPeriodButNotExist) {
             setTextColor(resources.getColor(R.color.gray4, null))
             false
         } else {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
@@ -2,7 +2,6 @@ package com.on.staccato.presentation
 
 import android.graphics.drawable.Drawable
 import android.net.Uri
-import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.FrameLayout

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/BindingAdapters.kt
@@ -9,6 +9,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.ProgressBar
+import android.widget.ScrollView
 import android.widget.TextView
 import androidx.core.view.isGone
 import androidx.core.view.isInvisible
@@ -569,4 +570,11 @@ fun Button.setRecoveryEnabled(recoveryCode: String?) {
             setTextColor(resources.getColor(R.color.white, null))
             true
         }
+}
+
+@BindingAdapter("scrollToBottom")
+fun ScrollView.scrollToBottom(isPeriodSettingOn: Boolean) {
+    if (isPeriodSettingOn) {
+        post { fullScroll(ScrollView.FOCUS_DOWN) }
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/MemoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/MemoryCreationActivity.kt
@@ -73,7 +73,7 @@ class MemoryCreationActivity :
             .setTheme(R.style.DatePickerStyle)
             .setSelection(
                 Pair(
-                    MaterialDatePicker.thisMonthInUtcMilliseconds(),
+                    MaterialDatePicker.todayInUtcMilliseconds(),
                     MaterialDatePicker.todayInUtcMilliseconds(),
                 ),
             ).build()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -35,10 +35,10 @@ class MemoryCreationViewModel
         val title = ObservableField<String>()
         val description = ObservableField<String>()
 
-        private val _startDate = MediatorLiveData<LocalDate?>(null)
+        private val _startDate = MutableLiveData<LocalDate?>(null)
         val startDate: LiveData<LocalDate?> get() = _startDate
 
-        private val _endDate = MediatorLiveData<LocalDate?>(null)
+        private val _endDate = MutableLiveData<LocalDate?>(null)
         val endDate: LiveData<LocalDate?> get() = _endDate
 
         private val _createdMemoryId = MutableLiveData<Long>()
@@ -59,26 +59,7 @@ class MemoryCreationViewModel
         private val _isPhotoPosting = MutableLiveData<Boolean>(false)
         val isPhotoPosting: LiveData<Boolean> get() = _isPhotoPosting
 
-        val isPeriodSet = MutableLiveData<Boolean>(false)
-
-        init {
-            setPeriodMediator()
-        }
-
-        private fun setPeriodMediator() {
-            setDateMediator(_startDate)
-            setDateMediator(_endDate)
-        }
-
-        private fun setDateMediator(date: MediatorLiveData<LocalDate?>) {
-            with(date) {
-                addSource(isPeriodSet) { isSet ->
-                    if (!isSet) {
-                        value = null
-                    }
-                }
-            }
-        }
+        val isPeriodSettingOn = MutableLiveData<Boolean>(false)
 
         fun createThumbnailUrl(
             context: Context,
@@ -130,12 +111,12 @@ class MemoryCreationViewModel
             _createdMemoryId.value = memoryCreationResponse.memoryId
         }
 
-        private fun makeNewMemory(): NewMemory =
+        private fun makeNewMemory() =
             NewMemory(
                 memoryThumbnailUrl = thumbnailUrl.value,
                 memoryTitle = title.get() ?: throw IllegalArgumentException(),
-                startAt = startDate.value,
-                endAt = endDate.value,
+                startAt = if (isPeriodSettingOn.value == true) { startDate.value } else { null },
+                endAt = if (isPeriodSettingOn.value == true) { endDate.value } else { null },
                 description = description.get(),
             )
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -115,10 +115,18 @@ class MemoryCreationViewModel
             NewMemory(
                 memoryThumbnailUrl = thumbnailUrl.value,
                 memoryTitle = title.get() ?: throw IllegalArgumentException(),
-                startAt = if (isPeriodSettingOn.value == true) { startDate.value } else { null },
-                endAt = if (isPeriodSettingOn.value == true) { endDate.value } else { null },
+                startAt = getDateByPeriodSetting(startDate),
+                endAt = getDateByPeriodSetting(endDate),
                 description = description.get(),
             )
+
+        private fun getDateByPeriodSetting(date: LiveData<LocalDate?>): LocalDate? {
+            return if (isPeriodSettingOn.value == true) {
+                date.value
+            } else {
+                null
+            }
+        }
 
         private fun handleServerError(
             status: Status,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memorycreation/viewmodel/MemoryCreationViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.net.Uri
 import androidx.databinding.ObservableField
 import androidx.lifecycle.LiveData
-import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -46,10 +45,10 @@ class MemoryUpdateViewModel
         val title = ObservableField<String>()
         val description = ObservableField<String>()
 
-        private val _startDate = MediatorLiveData<LocalDate?>(null)
+        private val _startDate = MutableLiveData<LocalDate?>(null)
         val startDate: LiveData<LocalDate?> get() = _startDate
 
-        private val _endDate = MediatorLiveData<LocalDate?>(null)
+        private val _endDate = MutableLiveData<LocalDate?>(null)
         val endDate: LiveData<LocalDate?> get() = _endDate
 
         private val _isUpdateSuccess = MutableSingleLiveData<Boolean>(false)
@@ -64,17 +63,9 @@ class MemoryUpdateViewModel
         private val _isPhotoPosting = MutableLiveData<Boolean>(false)
         val isPhotoPosting: LiveData<Boolean> get() = _isPosting
 
-        val isPeriodSet = MutableLiveData<Boolean>()
-
-        private val lastStartDate = MediatorLiveData<LocalDate?>(null)
-        private val lastEndDate = MediatorLiveData<LocalDate?>(null)
+        val isPeriodSettingOn = MutableLiveData<Boolean>()
 
         private var memoryId: Long = 0L
-
-        init {
-            setDateMediator(_startDate, lastStartDate)
-            setDateMediator(_endDate, lastEndDate)
-        }
 
         fun fetchMemory(memoryId: Long) {
             fetchMemoryId(memoryId)
@@ -136,61 +127,25 @@ class MemoryUpdateViewModel
             _endDate.value = convertLongToLocalDate(endAt)
         }
 
-        private fun setDateMediator(
-            date: MediatorLiveData<LocalDate?>,
-            lastDate: MediatorLiveData<LocalDate?>,
-        ) {
-            with(date) {
-                addSource(isPeriodSet) { isSet ->
-                    value =
-                        if (isSet) {
-                            lastDate.value
-                        } else {
-                            null
-                        }
-                }
-            }
-            updateLastDateMediator(lastDate, date)
-        }
-
-        private fun updateLastDateMediator(
-            lastDate: MediatorLiveData<LocalDate?>,
-            date: MediatorLiveData<LocalDate?>,
-        ) {
-            with(lastDate) {
-                addSource(date) { updatedDate ->
-                    if (updatedDate != null) {
-                        value = updatedDate
-                    }
-                }
-            }
-        }
-
         private fun initializeMemory(memory: Memory) {
             _thumbnailUrl.value = memory.memoryThumbnailUrl
             title.set(memory.memoryTitle)
             description.set(memory.description)
             _startDate.value = memory.startAt
             _endDate.value = memory.endAt
-            initializeLastDates(memory)
             checkMemoryHasPeriod(memory)
         }
 
-        private fun initializeLastDates(memory: Memory) {
-            lastStartDate.value = memory.startAt
-            lastEndDate.value = memory.endAt
-        }
-
         private fun checkMemoryHasPeriod(memory: Memory) {
-            isPeriodSet.value = memory.startAt != null && memory.endAt != null
+            isPeriodSettingOn.value = memory.startAt != null && memory.endAt != null
         }
 
         private fun makeNewMemory() =
             NewMemory(
                 memoryThumbnailUrl = thumbnailUrl.value,
                 memoryTitle = title.get() ?: throw IllegalArgumentException(),
-                startAt = startDate.value,
-                endAt = endDate.value,
+                startAt = if (isPeriodSettingOn.value == true) { startDate.value } else { null },
+                endAt = if (isPeriodSettingOn.value == true) { endDate.value } else { null },
                 description = description.get(),
             )
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -144,10 +144,18 @@ class MemoryUpdateViewModel
             NewMemory(
                 memoryThumbnailUrl = thumbnailUrl.value,
                 memoryTitle = title.get() ?: throw IllegalArgumentException(),
-                startAt = if (isPeriodSettingOn.value == true) { startDate.value } else { null },
-                endAt = if (isPeriodSettingOn.value == true) { endDate.value } else { null },
+                startAt = getDateByPeriodSetting(startDate),
+                endAt = getDateByPeriodSetting(endDate),
                 description = description.get(),
             )
+
+        private fun getDateByPeriodSetting(date: LiveData<LocalDate?>): LocalDate? {
+            return if (isPeriodSettingOn.value == true) {
+                date.value
+            } else {
+                null
+            }
+        }
 
         private fun updateSuccessStatus() {
             _isUpdateSuccess.setValue(true)

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
@@ -229,6 +229,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_creation_period_selection"
                     bind:endDate="@{viewModel.endDate}"
+                    bind:isPeriodSettingOn="@{viewModel.isPeriodSettingOn}"
                     bind:isPhotoPosting="@{viewModel.isPhotoPosting}"
                     bind:memoryTitle="@{viewModel.title}"
                     bind:startDate="@{viewModel.startDate}" />

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
@@ -175,7 +175,7 @@
                     android:layout_height="20dp"
                     android:layout_marginEnd="24dp"
                     android:background="@android:color/transparent"
-                    android:checked="@={viewModel.isPeriodSet}"
+                    android:checked="@={viewModel.isPeriodSettingOn}"
                     android:thumb="@drawable/shape_switch_thumb_oval"
                     app:layout_constraintBottom_toBottomOf="@id/tv_memory_creation_period_title"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -215,7 +215,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_creation_period_description"
                     bind:endDate="@{viewModel.endDate}"
-                    bind:periodSelectionVisibility="@{viewModel.isPeriodSet}"
+                    bind:periodSelectionVisibility="@{viewModel.isPeriodSettingOn}"
                     bind:startDate="@{viewModel.startDate}" />
 
                 <androidx.appcompat.widget.AppCompatButton

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_creation.xml
@@ -39,7 +39,8 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_memory_creation">
+            app:layout_constraintTop_toBottomOf="@id/toolbar_memory_creation"
+            bind:scrollToBottom="@{viewModel.isPeriodSettingOn}">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
@@ -176,7 +176,7 @@
                     android:layout_height="20dp"
                     android:layout_marginEnd="24dp"
                     android:background="@android:color/transparent"
-                    android:checked="@={viewModel.isPeriodSet}"
+                    android:checked="@={viewModel.isPeriodSettingOn}"
                     android:thumb="@drawable/shape_switch_thumb_oval"
                     app:layout_constraintBottom_toBottomOf="@id/tv_memory_update_period_title"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -217,7 +217,7 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_update_period_description"
                     bind:endDate="@{viewModel.endDate}"
-                    bind:periodSelectionVisibility="@{viewModel.isPeriodSet}"
+                    bind:periodSelectionVisibility="@{viewModel.isPeriodSettingOn}"
                     bind:startDate="@{viewModel.startDate}" />
 
                 <androidx.appcompat.widget.AppCompatButton

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
@@ -232,6 +232,7 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_memory_update_period_selection"
                     bind:endDate="@{viewModel.endDate}"
                     bind:memoryTitle="@{viewModel.title}"
+                    bind:isPeriodSettingOn="@{viewModel.isPeriodSettingOn}"
                     bind:photoUri="@{viewModel.thumbnailUri}"
                     bind:photoUrl="@{viewModel.thumbnailUrl}"
                     bind:startDate="@{viewModel.startDate}" />

--- a/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_memory_update.xml
@@ -39,7 +39,8 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/toolbar_memory_update">
+            app:layout_constraintTop_toBottomOf="@id/toolbar_memory_update"
+            bind:scrollToBottom="@{viewModel.isPeriodSettingOn}">
 
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
## ⭐️ Issue Number
- #432 

## 🚩 Summary
- [ ] 기간 설정을 활성화하였을 때, 기간을 설정해야만 저장 버튼을 활성화시킨다.
  - [ ] `BindingAdatper`의 추억 저장 버튼 활성화 로직 수정
- [ ] 추억 생성 화면에서도 최근에 선택했던 날짜를 기억하도록 변경
- [ ] 추억 생성 시 기간 설정 스위치를 켰을 때, 기본값으로 오늘 범위의 날짜가 설정
- [ ] 스위치 On 시 스크롤 위치를 맨 밑으로 변경
- [ ] 리팩터링
  - [ ] `lastStartDate`, `lastEndDate` 제거하기
  - [ ] `isPeriodSet` 변수명 수정

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
- 추억 수정 화면의 날짜 선택 시, 최근에 선택했던 날짜가 자동으로 선택되어 있도록 수정