### PR TITLE
fix & feat: 스타카토 생성 시 현주소 로딩 버그 수정 & 사진 길게 눌러 순서 변경 기능 #441

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -99,7 +99,10 @@ class MomentCreationActivity :
 
     override fun onResume() {
         super.onResume()
-        checkLocationSetting()
+        if (viewModel.isPlaceSearchClicked.getValue() == true) {
+            viewModel.setIsPlaceSearchClicked(false)
+            checkLocationSetting()
+        }
     }
 
     override fun onNewPlaceSelected(
@@ -123,6 +126,7 @@ class MomentCreationActivity :
     }
 
     override fun onSearchClicked() {
+        viewModel.setIsPlaceSearchClicked(true)
         checkLocationSetting(isCurrentLocationCallClicked = true)
     }
 
@@ -312,10 +316,14 @@ class MomentCreationActivity :
             window.clearFlags(FLAG_NOT_TOUCHABLE)
             finish()
         }
-        viewModel.errorMessage.observe(this) {
-            window.clearFlags(FLAG_NOT_TOUCHABLE)
-            showToast(it)
+        viewModel.errorMessage.observe(this) { message ->
+            handleError(message)
         }
+    }
+
+    private fun handleError(errorMessage: String) {
+        window.clearFlags(FLAG_NOT_TOUCHABLE)
+        showToast(errorMessage)
     }
 
     private fun fetchAddress(location: Location) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachAdapter.kt
@@ -44,7 +44,6 @@ class PhotoAttachAdapter(
                 PhotoAttachViewHolder.AttachedPhotoViewHolder(
                     binding,
                     attachedPhotoHandler,
-                    dragListener,
                 )
             }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachViewHolder.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachViewHolder.kt
@@ -1,13 +1,11 @@
 package com.on.staccato.presentation.momentcreation.adapter
 
-import android.view.MotionEvent
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
 import com.on.staccato.databinding.ItemAddPhotoBinding
 import com.on.staccato.databinding.ItemAttachedPhotoBinding
 import com.on.staccato.presentation.common.AttachedPhotoHandler
 import com.on.staccato.presentation.momentcreation.model.AttachedPhotoUiModel
-import com.on.staccato.presentation.visitcreation.adapter.ItemDragListener
 
 sealed class PhotoAttachViewHolder(binding: ViewDataBinding) :
     RecyclerView.ViewHolder(binding.root) {
@@ -24,15 +22,8 @@ sealed class PhotoAttachViewHolder(binding: ViewDataBinding) :
     class AttachedPhotoViewHolder(
         private val binding: ItemAttachedPhotoBinding,
         private val attachedPhotoHandler: AttachedPhotoHandler,
-        private val dragListener: ItemDragListener,
     ) : PhotoAttachViewHolder(binding) {
         fun bind(item: AttachedPhotoUiModel) {
-            binding.ivAttachedPhoto.setOnTouchListener { _, event ->
-                if (event.action == MotionEvent.ACTION_DOWN) {
-                    dragListener.onStartDrag(this)
-                }
-                false
-            }
             binding.attachedPhoto = item
             binding.selectedPhotoHandler = attachedPhotoHandler
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/viewmodel/MomentCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/viewmodel/MomentCreationViewModel.kt
@@ -82,6 +82,9 @@ class MomentCreationViewModel
         private val _isAddPhotoClicked = MutableSingleLiveData(false)
         val isAddPhotoClicked: SingleLiveData<Boolean> get() = _isAddPhotoClicked
 
+        private val _isPlaceSearchClicked = MutableLiveData(true)
+        val isPlaceSearchClicked: LiveData<Boolean> get() = _isPlaceSearchClicked
+
         private val photoJobs = mutableMapOf<String, Job>()
 
         override fun onAddClicked() {
@@ -152,6 +155,10 @@ class MomentCreationViewModel
                         }
                     }
             }
+        }
+
+        fun setIsPlaceSearchClicked(value: Boolean) {
+            _isPlaceSearchClicked.postValue(value)
         }
 
         private fun initSelectedMemoryAndVisitedAt(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitcreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitcreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -8,7 +8,7 @@ class AttachedPhotoItemTouchHelperCallback(
     private val moveListener: ItemMoveListener,
 ) : ItemTouchHelper.Callback() {
     override fun isLongPressDragEnabled(): Boolean {
-        return false
+        return true
     }
 
     override fun getMovementFlags(

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
     <string name="moment_comment_has_been_deleted">코멘트를 삭제했어요!</string>
 
     // activity_visit_creation / activity_visit_update
-    <string name="visit_creation_photo_drag_hint">*드래그로 순서를 바꿔보세요</string>
+    <string name="visit_creation_photo_drag_hint">*꾹 눌러 사진 순서를 바꿔 보세요</string>
     <string name="visit_creation_staccato_title">스타카토 제목</string>
     <string name="visit_creation_staccato_name_hint">어떤 순간이었나요? 제목을 입력해 주세요</string>
     <string name="visit_creation_place">장소</string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #441

## 🚩 Summary
- [x] 사진 길게 눌러 순서 변경 기능
- [x] 스타카토 생성 시 현주소 로딩 버그 수정

## 🛠️ Technical Concerns

### 1. 사진 길게 눌러 순서 변경 기능
AttachedPhotoViewHolder에서 onStartDrag 메서드를 구현하고 있어
AttachedPhotoItemTouchHelperCallback의 아래 메서드가 동작하고 있지 않았습니다.
```kotlin
    override fun isLongPressDragEnabled(): Boolean {
        return true
    }
```
따라서 해당 구현을 삭제해 주었습니다.

### 2. 스타카토 생성 시 현주소 로딩 버그 수정
구글 장소 검색창 클릭 시 `AutocompleteSupportFragment`로 focus가 이동합니다.
따라서 `StaccatoCreationActivity로` 돌아왔을 때 onResume이 호출되며 다시 현위치를 불러오는 버그가 발생했습니다.
MomentCreationViewModel에 isPlaceSearchClicked 변수를 추가해 해결했습니다.

## 😊 Todo
interface `ItemDragListener`에서 `fun onStartDrag(viewHolder: RecyclerView.ViewHolder)` 제거하기