### PR TITLE
fix: 현주소 로딩 버그 수정, 사진 드래그 시 투명하게 조절 #444

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/CurrentLocationHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/CurrentLocationHandler.kt
@@ -1,5 +1,5 @@
 package com.on.staccato.presentation.momentcreation
 
 interface CurrentLocationHandler {
-    fun onSearchClicked()
+    fun onCurrentLocationClicked()
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -99,7 +99,18 @@ class MomentCreationActivity :
 
     override fun onResume() {
         super.onResume()
-        checkLocationSetting()
+        if (viewModel.isPlaceSearchClicked.value != true) {
+            checkLocationSetting()
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        if (autocompleteFragment.isVisible) {
+            viewModel.setIsPlaceSearchClicked(true)
+        } else {
+            viewModel.setIsPlaceSearchClicked(false)
+        }
     }
 
     override fun onNewPlaceSelected(
@@ -122,7 +133,7 @@ class MomentCreationActivity :
         viewModel.clearPlace()
     }
 
-    override fun onSearchClicked() {
+    override fun onCurrentLocationClicked() {
         checkLocationSetting(isCurrentLocationCallClicked = true)
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/MomentCreationActivity.kt
@@ -106,11 +106,8 @@ class MomentCreationActivity :
 
     override fun onPause() {
         super.onPause()
-        if (autocompleteFragment.isVisible) {
-            viewModel.setIsPlaceSearchClicked(true)
-        } else {
-            viewModel.setIsPlaceSearchClicked(false)
-        }
+        val hasPlaceSearchClicked = autocompleteFragment.isVisible
+        viewModel.setIsPlaceSearchClicked(hasPlaceSearchClicked)
     }
 
     override fun onNewPlaceSelected(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachViewHolder.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/adapter/PhotoAttachViewHolder.kt
@@ -27,5 +27,13 @@ sealed class PhotoAttachViewHolder(binding: ViewDataBinding) :
             binding.attachedPhoto = item
             binding.selectedPhotoHandler = attachedPhotoHandler
         }
+
+        fun startMoving() {
+            binding.ivAttachedPhoto.alpha = 0.6F
+        }
+
+        fun stopMoving() {
+            binding.ivAttachedPhoto.alpha = 1F
+        }
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/viewmodel/MomentCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/momentcreation/viewmodel/MomentCreationViewModel.kt
@@ -84,6 +84,9 @@ class MomentCreationViewModel
 
         private val photoJobs = mutableMapOf<String, Job>()
 
+        private val _isPlaceSearchClicked = MutableLiveData(false)
+        val isPlaceSearchClicked: LiveData<Boolean> get() = _isPlaceSearchClicked
+
         override fun onAddClicked() {
             if ((currentPhotos.value?.size ?: 0) == MAX_PHOTO_NUMBER) {
                 _errorMessage.postValue(MAX_PHOTO_NUMBER_MESSAGE)
@@ -152,6 +155,10 @@ class MomentCreationViewModel
                         }
                     }
             }
+        }
+
+        fun setIsPlaceSearchClicked(value: Boolean) {
+            _isPlaceSearchClicked.value = value
         }
 
         private fun initSelectedMemoryAndVisitedAt(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitcreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitcreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -43,8 +43,23 @@ class AttachedPhotoItemTouchHelperCallback(
     ) {
         super.onSelectedChanged(viewHolder, actionState)
         when (actionState) {
-            ItemTouchHelper.ACTION_STATE_IDLE -> moveListener.onStopDrag()
+            ItemTouchHelper.ACTION_STATE_DRAG -> {
+                if (viewHolder != null) {
+                    (viewHolder as PhotoAttachViewHolder.AttachedPhotoViewHolder).startMoving()
+                }
+            }
+
+            ItemTouchHelper.ACTION_STATE_IDLE -> {
+                moveListener.onStopDrag()
+            }
         }
+    }
+
+    override fun clearView(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+    ) {
+        (viewHolder as PhotoAttachViewHolder.AttachedPhotoViewHolder).stopMoving()
     }
 
     override fun onSwiped(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/visitupdate/VisitUpdateActivity.kt
@@ -105,7 +105,7 @@ class VisitUpdateActivity :
         viewModel.clearPlace()
     }
 
-    override fun onSearchClicked() {
+    override fun onCurrentLocationClicked() {
         checkLocationSetting()
     }
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -170,7 +170,6 @@
                     app:layout_constraintStart_toStartOf="@id/tv_visit_creation_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/autocomplete_fragment" />
 
-
                 <TextView
                     android:id="@+id/tv_place_address"
                     android:layout_width="0dp"
@@ -202,7 +201,7 @@
                         android:id="@+id/btn_current_location"
                         style="@style/CurrentLocationStyle"
                         android:layout_marginTop="10dp"
-                        android:onClick="@{()->currentLocationHandler.onSearchClicked()}"
+                        android:onClick="@{()->currentLocationHandler.onCurrentLocationClicked()}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -39,9 +39,10 @@
             app:title="@string/visit_creation_toolbar_title" />
 
         <androidx.core.widget.NestedScrollView
+            android:overScrollMode="never"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toBotto정mOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar_visit_creation">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_creation.xml
@@ -42,7 +42,7 @@
             android:overScrollMode="never"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            app:layout_constraintBottom_toBotto정mOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar_visit_creation">
 
             <androidx.constraintlayout.widget.ConstraintLayout

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
@@ -41,6 +41,7 @@
         <androidx.core.widget.NestedScrollView
             android:layout_width="match_parent"
             android:layout_height="0dp"
+            android:overScrollMode="never"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toBottomOf="@id/toolbar_visit_update">
 

--- a/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_visit_update.xml
@@ -170,7 +170,6 @@
                     app:layout_constraintStart_toStartOf="@id/tv_visit_update_place_name_title"
                     app:layout_constraintTop_toBottomOf="@id/autocomplete_fragment" />
 
-
                 <TextView
                     android:id="@+id/tv_place_address"
                     android:layout_width="0dp"
@@ -202,7 +201,7 @@
                         android:id="@+id/btn_current_location"
                         style="@style/CurrentLocationStyle"
                         android:layout_marginTop="10dp"
-                        android:onClick="@{()->currentLocationHandler.onSearchClicked()}"
+                        android:onClick="@{()->currentLocationHandler.onCurrentLocationClicked()}"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
## ⭐️ Issue Number
- #444 

## 🚩 Summary
- [x] 스타카토 생성 시 현주소 로딩 버그 수정
- [x] 사진 드래그 시 투명하게 조절
- [x] 스타카토 수정 및 생성 화면 overScroll never 설정

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
