### PR TITLE
refactor: 클립보드 복사 시 토스트 메시지가 뜨지 않는 문제 해결 #448

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -159,6 +159,7 @@ class MemoryUpdateViewModel
         }
 
         private fun updateSuccessStatus() {
+            _isPosting.value = true
             _isUpdateSuccess.setValue(true)
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/mypage/MyPageActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/mypage/MyPageActivity.kt
@@ -3,12 +3,14 @@ package com.on.staccato.presentation.mypage
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.viewModels
 import com.on.staccato.R
 import com.on.staccato.databinding.ActivityMypageBinding
 import com.on.staccato.presentation.base.BindingActivity
 import com.on.staccato.presentation.mypage.viewmodel.MyPageViewModel
+import com.on.staccato.presentation.util.showToast
 import com.on.staccato.presentation.webview.WebViewActivity
 import com.on.staccato.presentation.webview.WebViewActivity.Companion.EXTRA_TOOLBAR_TITLE
 import com.on.staccato.presentation.webview.WebViewActivity.Companion.EXTRA_URL
@@ -57,6 +59,13 @@ class MyPageActivity :
     private fun copyUuidCodeOnClipBoard(code: String) {
         val clipData: ClipData = ClipData.newPlainText(UUID_CODE_LABEL, code)
         clipboardManager.setPrimaryClip(clipData)
+        showCopySuccessMessageBySdkVersion()
+    }
+
+    private fun showCopySuccessMessageBySdkVersion() {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+            showToast(getString(R.string.all_clipboard_copy))
+        }
     }
 
     override fun onPrivacyPolicyClicked() {

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -25,6 +25,7 @@
     <string name="all_setting">설정</string>
     <string name="all_location_permission_denial">위치 권한을 거부 하셨습니다.</string>
     <string name="all_webview_failure">웹 브라우저를 띄울 수 없습니다.</string>
+    <string name="all_clipboard_copy">클립보드에 복사했어요!</string>
 
     // MainActivity
     <string name="main_end">버튼을 한 번 더 누르면 종료됩니다.</string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #448 

## 🚩 Summary
### 📹 시연 영상
https://github.com/user-attachments/assets/a4b16fbc-53cb-40f0-bbac-6dad18708f08


### ✅ 개선 사항
안드로이드 API 레벨 13 이상 부터는 클립보드 복사 시에 시스템에서 토스트 메시지를 띄워줍니다.
즉, API 레벨 13 미만에서는 토스트 메시지가 뜨지 않습니다.
- [x] API 레벨 13 미만일 경우 앱에서 토스트 메시지를 띄우도록 버전에 따라 분기처리를 하였습니다.

## 🛠️ Technical Concerns

## 🙂 To Reviewer

## 📋 To Do
- 바텀시트 너머로 마이페이지 버튼이 눌리는 현상 개선