### PR TITLE
fix: 추억 수정 시 사진 등록 중이라면 저장 버튼을 비활성화 #447

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -106,6 +106,7 @@ class MemoryUpdateViewModel
 
         fun setThumbnailUrl(imageResponse: ImageResponse?) {
             _thumbnailUrl.value = imageResponse?.imageUrl
+            _isPhotoPosting.value = false
         }
 
         fun updateMemory() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memoryupdate/viewmodel/MemoryUpdateViewModel.kt
@@ -61,7 +61,7 @@ class MemoryUpdateViewModel
         val isPosting: LiveData<Boolean> get() = _isPosting
 
         private val _isPhotoPosting = MutableLiveData<Boolean>(false)
-        val isPhotoPosting: LiveData<Boolean> get() = _isPosting
+        val isPhotoPosting: LiveData<Boolean> get() = _isPhotoPosting
 
         val isPeriodActive = MutableLiveData<Boolean>()
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #447 

<br>

## 🎥 시연영상
https://github.com/user-attachments/assets/c732e408-d0f0-4fbc-9181-9fa9e764da3d

<br>

## 🚩 Summary
- 추억 수정 시 사진 등록 중에 저장 버튼이 활성화되어 있는 문제 해결  

- 관련 QA 내용
  <img width="1128" alt="image" src="https://github.com/user-attachments/assets/90a4938e-f23e-4268-bc10-145d0caf9e76">