### PR TITLE
fix: 운영 서버 docker 포트 포워딩 복구

### DIFF
--- a/.github/workflows/backend-ci-cd-prod.yml
+++ b/.github/workflows/backend-ci-cd-prod.yml
@@ -72,6 +72,6 @@ jobs:
         run: |
           sudo docker run --env-file /home/ubuntu/staccato/.env \
           -v /home/ubuntu/staccato/logs:/logs \
-          -p 80:8080 \
+          -p 8080:8080 \
           -d --name staccato-backend-app staccato/staccato:prod
           sudo docker image prune -af


### PR DESCRIPTION
## ⭐️ Issue Number
- #437

## 🚩 Summary
- 이슈(#437)에서 nginx를 제거하려 했습니다.
- 후에 무중단 배포에서 nginx를 활용할 수도 있어서 우선 그대로 두기로 결정했습니다.
- 이에 따라 변경했던 docker 포트 포워딩 CICD Workflow를 복구했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
