### PR TITLE
refactor: N+1 문제 해결 #470

### DIFF
--- a/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
+++ b/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
@@ -2,16 +2,16 @@ package com.staccato.memory.repository;
 
 import java.time.LocalDate;
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
 import com.staccato.member.domain.Member;
 import com.staccato.memory.domain.MemoryMember;
 
 public interface MemoryMemberRepository extends JpaRepository<MemoryMember, Long> {
-    List<MemoryMember> findAllByMemberIdOrderByMemory(long memberId);
+
+    @Query("SELECT mm FROM MemoryMember mm JOIN FETCH mm.memory WHERE mm.member.id = :memberId")
+    List<MemoryMember> findAllByMemberId(long memberId);
 
     @Query("""
             SELECT mm FROM MemoryMember mm WHERE mm.member.id = :memberId

--- a/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
+++ b/backend/src/main/java/com/staccato/memory/repository/MemoryMemberRepository.java
@@ -14,7 +14,7 @@ public interface MemoryMemberRepository extends JpaRepository<MemoryMember, Long
     List<MemoryMember> findAllByMemberId(long memberId);
 
     @Query("""
-            SELECT mm FROM MemoryMember mm WHERE mm.member.id = :memberId
+            SELECT mm FROM MemoryMember mm JOIN FETCH mm.memory WHERE mm.member.id = :memberId
             AND ((mm.memory.term.startAt is null AND mm.memory.term.endAt is null)
             or (:date BETWEEN mm.memory.term.startAt AND mm.memory.term.endAt))
             """)

--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -44,7 +44,7 @@ public class MemoryService {
     }
 
     public MemoryResponses readAllMemories(Member member) {
-        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId());
+        List<MemoryMember> memoryMembers = memoryMemberRepository.findAllByMemberId(member.getId());
         sortByCreatedAtDescending(memoryMembers);
 
         return MemoryResponses.from(

--- a/backend/src/main/java/com/staccato/moment/repository/MomentRepository.java
+++ b/backend/src/main/java/com/staccato/moment/repository/MomentRepository.java
@@ -2,11 +2,15 @@ package com.staccato.moment.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import com.staccato.member.domain.Member;
 import com.staccato.moment.domain.Moment;
 
 public interface MomentRepository extends JpaRepository<Moment, Long> {
-    List<Moment> findAllByMemoryIdOrderByVisitedAt(long memoryId);
+
+    @Query("SELECT m FROM Moment m LEFT JOIN FETCH m.momentImages.images WHERE m.memory.id = :memoryId ORDER BY m.visitedAt")
+    List<Moment> findAllByMemoryIdOrderByVisitedAt(@Param("memoryId") long memoryId);
 
     void deleteAllByMemoryId(long memoryId);
 

--- a/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
@@ -2,6 +2,7 @@ package com.staccato.memory.repository;
 
 import java.time.LocalDate;
 import java.util.List;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,6 +24,23 @@ class MemoryMemberRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private MemoryRepository memoryRepository;
+
+    @DisplayName("사용자의 모든 추억 목록을 조회한다.")
+    @Test
+    void findAllByMemberId() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create());
+        Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 30), LocalDate.of(2023, 12, 30)));
+        Memory memory2 = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2023, 12, 31)));
+        memoryMemberRepository.save(new MemoryMember(member, memory));
+        memoryMemberRepository.save(new MemoryMember(member, memory2));
+
+        // when
+        List<MemoryMember> result = memoryMemberRepository.findAllByMemberId(member.getId());
+
+        // then
+        assertThat(result).hasSize(2);
+    }
 
     @DisplayName("사용자 식별자와 날짜로 추억 목록을 조회한다.")
     @Test

--- a/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/repository/MemoryMemberRepositoryTest.java
@@ -2,7 +2,6 @@ package com.staccato.memory.repository;
 
 import java.time.LocalDate;
 import java.util.List;
-import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -76,7 +76,7 @@ class MemoryServiceTest extends ServiceSliceTest {
 
         // when
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
-        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId())
+        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberId(member.getId())
                 .get(0);
 
         // then
@@ -95,7 +95,7 @@ class MemoryServiceTest extends ServiceSliceTest {
 
         // when
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(memoryRequest, member);
-        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberIdOrderByMemory(member.getId())
+        MemoryMember memoryMember = memoryMemberRepository.findAllByMemberId(member.getId())
                 .get(0);
 
         // then

--- a/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
@@ -17,6 +17,7 @@ import com.staccato.memory.domain.MemoryMember;
 import com.staccato.memory.repository.MemoryMemberRepository;
 import com.staccato.memory.repository.MemoryRepository;
 import com.staccato.moment.domain.Moment;
+import com.staccato.moment.domain.MomentImages;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -60,6 +61,28 @@ class MomentRepositoryTest {
                 () -> assertThat(memberResult).containsExactlyInAnyOrder(moment, moment1, moment2),
                 () -> assertThat(anotherMemberResult.size()).isEqualTo(1),
                 () -> assertThat(anotherMemberResult).containsExactlyInAnyOrder(anotherMoment)
+        );
+    }
+
+    @DisplayName("사용자의 특정 추억에 해당하는 모든 스타카토를 조회한다.")
+    @Test
+    void findAllByMemoryIdOrderByVisitedAt() {
+        // given
+        Member member = memberRepository.save(MemberFixture.create());
+        Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
+        memoryMemberRepository.save(new MemoryMember(member, memory));
+
+        Moment moment1 = momentRepository.save(MomentFixture.createWithImages(memory, LocalDateTime.of(2023, 12, 31, 22, 20), new MomentImages(List.of("image1", "image2"))));
+        Moment moment2 = momentRepository.save(MomentFixture.createWithImages(memory, LocalDateTime.of(2024, 1, 1, 22, 20), new MomentImages(List.of("image1", "image2"))));
+        Moment moment3 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2024, 1, 10, 23, 21)));
+
+        // when
+        List<Moment> moments = momentRepository.findAllByMemoryIdOrderByVisitedAt(memory.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(moments.size()).isEqualTo(3),
+                () -> assertThat(moments).containsExactlyInAnyOrder(moment1, moment2, moment3)
         );
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #470

## 🚩 Summary
### N+1 발생 지점
- 추억 조회
- 추억 삭제
    - 조회가 이루어지는 이유는 deleteAll()로 판명
    - 이는 N+1 문제보다는 BulkDelete를 적용하지 않은 상태에서 발생하는 문제로 판명
    - #406 
- 추억 목록 조회
- 특정 날짜를 포함하는 사용자의 모든 추억 목록 조회

## 🛠️ Technical Concerns


## 🙂 To Reviewer
- 자세한 사항은 노션 확인 바랍니다.

## 📋 To Do
