### PR TITLE
feat: application-dev에서 env를 참조하도록 수정

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -44,17 +44,17 @@ security:
 cloud:
   aws:
     s3:
-      bucket: techcourse-project-2024
-      endpoint: https://techcourse-project-2024.s3.ap-northeast-2.amazonaws.com
+      bucket: ${AWS_S3_BUCKET}
+      endpoint: ${AWS_S3_ENDPOINT}
     cloudfront:
-      endpoint: https://d25aribbn0gp8k.cloudfront.net
+      endpoint: ${AWS_CLOUDFRONT_ENDPOINT}
     region:
-      static: ap-northeast-2
+      static: ${AWS_REGION_STATIC}
     stack:
       auto: false
 image:
   folder:
-    name: image/
+    name: ${AWS_S3_FOLDER}
 
 management:
   server:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -40,17 +40,17 @@ security:
 cloud:
   aws:
     s3:
-      bucket: techcourse-project-2024
-      endpoint: https://techcourse-project-2024.s3.ap-northeast-2.amazonaws.com
+      bucket: example
+      endpoint: example
     cloudfront:
-      endpoint: https://d25aribbn0gp8k.cloudfront.net
+      endpoint: example
     region:
-      static: ap-northeast-2
+      static: example
     stack:
       auto: false
 image:
   folder:
-    name: image/
+    name: example
 
 management:
   server:


### PR DESCRIPTION
## ⭐️ Issue Number
- #498 

## 🚩 Summary
원래는 `application-dev.yml`에서 아래와 같이 이미지가 저장되는 세부 폴더를 지정해주고 있었다.
```yaml
image:
  folder:
    name: image/
```

test 서버는 이미지가 저장되는 폴더를 따로 `image-test/`로 정의해주고자, 이미지 저장 경로를 `.env`에서 관리하는 것으로 변경했다.

```yaml
image:
  folder:
    name: ${AWS_S3_FOLDER}
```

그리고 test 서버의 env 파일과 dev 서버의 env 파일을 변경해주었다. (현재 변경 완료)
```yaml
# test 서버
AWS_S3_FOLDER=image-test/
```

```yaml
# dev 서버
AWS_S3_FOLDER=image/
```

이제 dev 코드의 ci/cd가 돌면, 변경된 env를 참조하면서 dev 서버에서 실행되어 s3로 보내지는 이미지들은 전부 `image/` 폴더에 저장된다. 그리고 test 서버에서 새로운 dev 태그 이미지를 pull해서 그 이미지를 기반으로 컨테이너를 생성하면, test 서버에서 실행되어 s3로 보내지는 이미지들은 전부 `image-test/` 폴더에 저장된다.

1. dev 서버와 test 서버의 env 파일에 `image.folder.name` 값을 추가한다. (완료)
2. dev ci/cd가 돌아간다. dev 서버의 성공을 확인한다.
3. test 서버로 들어가서 dev 태그 이미지를 docker hub로부터 pull해온다.
4. pull 해온 이미지를 바탕으로 docker container를 띄운다.

---

* dev 서버의 env에 이미 `AWS_S3_BUCKET`, `AWS_S3_ENDPOINT` 등등이 저장되어 있었으나, env를 바라보지 않았었다가 바라보게 바꾸면서 해당 변수의 실제 값들을 매핑해주지 않았었다. 이번에 바꾸는 김에, 나머지 부분도 한 번에 바꾸었다.

* local의 사용하지 않는 값들도 같이 숨겼다. 나중에 실제 s3를 테스트하는 코드가 추가되면 로컬에서 해당 값들을 관리하도록 한다.

