### PR TITLE
feat: 나의 추억들 정렬 기능 구현 #503

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
@@ -104,7 +104,7 @@ class TimelineFragment :
 
     private fun setUpCreationMenu(popup: PopupMenu) {
         popup.setOnMenuItemClickListener { menuItem ->
-            val sortType: SortType = SortType.entries.first { it.menuId == menuItem.itemId }
+            val sortType: SortType = SortType.from(menuItem.itemId)
             timelineViewModel.sortTimeline(sortType)
             false
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
@@ -16,6 +16,7 @@ import com.on.staccato.presentation.main.viewmodel.SharedViewModel
 import com.on.staccato.presentation.memory.MemoryFragment.Companion.MEMORY_ID_KEY
 import com.on.staccato.presentation.memorycreation.MemoryCreationActivity
 import com.on.staccato.presentation.timeline.adapter.TimelineAdapter
+import com.on.staccato.presentation.timeline.model.SortType
 import com.on.staccato.presentation.timeline.viewmodel.TimelineViewModel
 import com.on.staccato.presentation.util.showToast
 import dagger.hilt.android.AndroidEntryPoint
@@ -103,13 +104,8 @@ class TimelineFragment :
 
     private fun setUpCreationMenu(popup: PopupMenu) {
         popup.setOnMenuItemClickListener { menuItem ->
-            when (menuItem.itemId) {
-                R.id.creation_order -> timelineViewModel.loadTimeline()
-                R.id.latest_order -> timelineViewModel.sortByLatest()
-                R.id.oldest_order -> timelineViewModel.sortByOldest()
-                R.id.with_period_order -> timelineViewModel.filterWithPeriod()
-                R.id.without_period_order -> timelineViewModel.filterWithoutPeriod()
-            }
+            val sortType: SortType = SortType.entries.first { it.menuId == menuItem.itemId }
+            timelineViewModel.sortTimeline(sortType)
             false
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
@@ -107,6 +107,8 @@ class TimelineFragment :
                 R.id.creation_order -> timelineViewModel.loadTimeline()
                 R.id.latest_order -> timelineViewModel.sortByLatest()
                 R.id.oldest_order -> timelineViewModel.sortByOldest()
+                R.id.with_period_order -> timelineViewModel.filterWithPeriod()
+                R.id.without_period_order -> timelineViewModel.filterWithoutPeriod()
             }
             false
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
@@ -77,7 +77,9 @@ class TimelineFragment :
 
     private fun setUpObserving() {
         timelineViewModel.timeline.observe(viewLifecycleOwner) { timeline ->
-            adapter.updateTimeline(timeline)
+            adapter.updateTimeline(timeline) {
+                binding.rvTimeline.scrollToPosition(0)
+            }
         }
 
         timelineViewModel.errorMessage.observe(viewLifecycleOwner) { message ->

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/TimelineFragment.kt
@@ -1,7 +1,9 @@
 package com.on.staccato.presentation.timeline
 
 import android.os.Bundle
+import android.view.Gravity
 import android.view.View
+import android.widget.PopupMenu
 import androidx.core.os.bundleOf
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -49,7 +51,10 @@ class TimelineFragment :
     }
 
     override fun onSortClicked() {
-        showToast(getString(R.string.all_default_not_supported))
+        val sortButton = binding.btnTimelineSortMemories
+        val popup = sortButton.inflateCreationMenu()
+        setUpCreationMenu(popup)
+        popup.show()
     }
 
     private fun setupBinding() {
@@ -80,6 +85,30 @@ class TimelineFragment :
             if (isUpdated) {
                 timelineViewModel.loadTimeline()
             }
+        }
+    }
+
+    private fun View.inflateCreationMenu(): PopupMenu {
+        val popup =
+            PopupMenu(
+                this.context,
+                this,
+                Gravity.END,
+                0,
+                R.style.Theme_Staccato_AN_PopupMenu,
+            )
+        popup.menuInflater.inflate(R.menu.menu_sort, popup.menu)
+        return popup
+    }
+
+    private fun setUpCreationMenu(popup: PopupMenu) {
+        popup.setOnMenuItemClickListener { menuItem ->
+            when (menuItem.itemId) {
+                R.id.creation_order -> timelineViewModel.loadTimeline()
+                R.id.latest_order -> timelineViewModel.sortByLatest()
+                R.id.oldest_order -> timelineViewModel.sortByOldest()
+            }
+            false
         }
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/adapter/TimelineAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/adapter/TimelineAdapter.kt
@@ -30,8 +30,11 @@ class TimelineAdapter(private val eventHandler: TimelineHandler) :
         holder.bind(currentList[position])
     }
 
-    fun updateTimeline(newTimeline: List<TimelineUiModel>) {
-        submitList(newTimeline)
+    fun updateTimeline(
+        newTimeline: List<TimelineUiModel>,
+        commitCallback: Runnable?,
+    ) {
+        submitList(newTimeline, commitCallback)
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/model/SortType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/model/SortType.kt
@@ -1,0 +1,14 @@
+package com.on.staccato.presentation.timeline.model
+
+import androidx.annotation.MenuRes
+import com.on.staccato.R
+
+enum class SortType(
+    @MenuRes val menuId: Int,
+) {
+    CREATION(R.id.creation_order),
+    LATEST(R.id.latest_order),
+    OLDEST(R.id.oldest_order),
+    WITH_PERIOD(R.id.with_period_order),
+    WITHOUT_PERIOD(R.id.without_period_order),
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/model/SortType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/model/SortType.kt
@@ -11,4 +11,9 @@ enum class SortType(
     OLDEST(R.id.oldest_order),
     WITH_PERIOD(R.id.with_period_order),
     WITHOUT_PERIOD(R.id.without_period_order),
+    ;
+
+    companion object {
+        fun from(menuId: Int): SortType = entries.first { it.menuId == menuId }
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -43,7 +43,7 @@ class TimelineViewModel
         val exceptionMessage: SingleLiveData<String>
             get() = _exceptionMessage
 
-        private var originalTimeline = mutableListOf<TimelineUiModel>()
+        private var originalTimeline = listOf<TimelineUiModel>()
 
         private val coroutineExceptionHandler =
             CoroutineExceptionHandler { context, throwable ->
@@ -79,8 +79,7 @@ class TimelineViewModel
 
         private fun setTimelineUiModels(timeline: Timeline) {
             _timeline.value = timeline.toTimelineUiModel()
-            originalTimeline.clear()
-            originalTimeline.addAll(_timeline.value ?: emptyList())
+            originalTimeline = _timeline.value ?: emptyList()
             _isTimelineLoading.value = false
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -74,8 +74,8 @@ class TimelineViewModel
         }
 
         private fun setTimelineUiModels(timeline: Timeline) {
-            _timeline.value = timeline.toTimelineUiModel()
-            originalTimeline.addAll(_timeline.value ?: emptyList())
+            originalTimeline.addAll(timeline.toTimelineUiModel())
+            sortByCreation()
             _isTimelineLoading.value = false
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -89,12 +89,12 @@ class TimelineViewModel
         }
 
         private fun sortByOldest() {
-            val memoriesSortedByOldest = originalTimeline.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
+            val memoriesSortedByOldest = originalTimeline.sortedWith(compareBy(nullsLast()) { it.startAt })
             _timeline.value = memoriesSortedByOldest
         }
 
         private fun filterWithPeriod() {
-            _timeline.value = originalTimeline.filter { it.startAt != null }
+            _timeline.value = originalTimeline.filter { it.startAt != null }.sortedByDescending { it.startAt }
         }
 
         private fun filterWithoutPeriod() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -38,6 +38,8 @@ class TimelineViewModel
         val isTimelineLoading: LiveData<Boolean>
             get() = _isTimelineLoading
 
+        private var originalTimeline = mutableListOf<TimelineUiModel>()
+
         private val coroutineExceptionHandler =
             CoroutineExceptionHandler { context, throwable ->
                 Log.e(
@@ -61,16 +63,26 @@ class TimelineViewModel
         }
 
         fun sortByLatest() {
-            _timeline.value = _timeline.value?.sortedByDescending { it.startAt }
+            _timeline.value = originalTimeline.sortedByDescending { it.startAt }
         }
 
         fun sortByOldest() {
-            val memoriesSortedByOldest = _timeline.value?.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
+            val memoriesSortedByOldest = originalTimeline.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
             _timeline.value = memoriesSortedByOldest
+        }
+
+        fun filterWithPeriod() {
+            _timeline.value = originalTimeline.filter { it.startAt != null }
+        }
+
+        fun filterWithoutPeriod() {
+            _timeline.value = originalTimeline.filter { it.startAt == null }
         }
 
         private fun setTimelineUiModels(timeline: Timeline) {
             _timeline.value = timeline.toTimelineUiModel()
+            if (originalTimeline.isNotEmpty()) originalTimeline.clear()
+            originalTimeline.addAll(_timeline.value ?: emptyList())
             _isTimelineLoading.value = false
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -14,6 +14,7 @@ import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData
 import com.on.staccato.presentation.common.SingleLiveData
 import com.on.staccato.presentation.mapper.toTimelineUiModel
+import com.on.staccato.presentation.timeline.model.SortType
 import com.on.staccato.presentation.timeline.model.TimelineUiModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
@@ -62,28 +63,41 @@ class TimelineViewModel
             }
         }
 
-        fun sortByLatest() {
-            _timeline.value = originalTimeline.sortedByDescending { it.startAt }
-        }
-
-        fun sortByOldest() {
-            val memoriesSortedByOldest = originalTimeline.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
-            _timeline.value = memoriesSortedByOldest
-        }
-
-        fun filterWithPeriod() {
-            _timeline.value = originalTimeline.filter { it.startAt != null }
-        }
-
-        fun filterWithoutPeriod() {
-            _timeline.value = originalTimeline.filter { it.startAt == null }
+        fun sortTimeline(type: SortType) {
+            when (type) {
+                SortType.CREATION -> sortByCreation()
+                SortType.LATEST -> sortByLatest()
+                SortType.OLDEST -> sortByOldest()
+                SortType.WITH_PERIOD -> filterWithPeriod()
+                SortType.WITHOUT_PERIOD -> filterWithoutPeriod()
+            }
         }
 
         private fun setTimelineUiModels(timeline: Timeline) {
             _timeline.value = timeline.toTimelineUiModel()
-            if (originalTimeline.isNotEmpty()) originalTimeline.clear()
             originalTimeline.addAll(_timeline.value ?: emptyList())
             _isTimelineLoading.value = false
+        }
+
+        private fun sortByCreation() {
+            _timeline.value = originalTimeline
+        }
+
+        private fun sortByLatest() {
+            _timeline.value = originalTimeline.sortedByDescending { it.startAt }
+        }
+
+        private fun sortByOldest() {
+            val memoriesSortedByOldest = originalTimeline.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
+            _timeline.value = memoriesSortedByOldest
+        }
+
+        private fun filterWithPeriod() {
+            _timeline.value = originalTimeline.filter { it.startAt != null }
+        }
+
+        private fun filterWithoutPeriod() {
+            _timeline.value = originalTimeline.filter { it.startAt == null }
         }
 
         private fun handleServerError(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -74,6 +74,7 @@ class TimelineViewModel
         }
 
         private fun setTimelineUiModels(timeline: Timeline) {
+            originalTimeline.clear()
             originalTimeline.addAll(timeline.toTimelineUiModel())
             sortByCreation()
             _isTimelineLoading.value = false

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -60,6 +60,15 @@ class TimelineViewModel
             }
         }
 
+        fun sortByLatest() {
+            _timeline.value = _timeline.value?.sortedByDescending { it.startAt }
+        }
+
+        fun sortByOldest() {
+            val memoriesSortedByOldest = _timeline.value?.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
+            _timeline.value = memoriesSortedByOldest
+        }
+
         private fun setTimelineUiModels(timeline: Timeline) {
             _timeline.value = timeline.toTimelineUiModel()
             _isTimelineLoading.value = false

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -74,9 +74,9 @@ class TimelineViewModel
         }
 
         private fun setTimelineUiModels(timeline: Timeline) {
+            _timeline.value = timeline.toTimelineUiModel()
             originalTimeline.clear()
-            originalTimeline.addAll(timeline.toTimelineUiModel())
-            sortByCreation()
+            originalTimeline.addAll(_timeline.value ?: emptyList())
             _isTimelineLoading.value = false
         }
 

--- a/android/Staccato_AN/app/src/main/res/menu/menu_sort.xml
+++ b/android/Staccato_AN/app/src/main/res/menu/menu_sort.xml
@@ -9,4 +9,10 @@
     <item
         android:id="@+id/oldest_order"
         android:title="@string/sort_oldest_order" />
+    <item
+        android:id="@+id/with_period_order"
+        android:title="@string/sort_memories_with_period_order" />
+    <item
+        android:id="@+id/without_period_order"
+        android:title="@string/sort_memories_without_period_order" />
 </menu>

--- a/android/Staccato_AN/app/src/main/res/menu/menu_sort.xml
+++ b/android/Staccato_AN/app/src/main/res/menu/menu_sort.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/creation_order"
+        android:title="@string/sort_creation_order" />
+    <item
+        android:id="@+id/latest_order"
+        android:title="@string/sort_latest_order" />
+    <item
+        android:id="@+id/oldest_order"
+        android:title="@string/sort_oldest_order" />
+</menu>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -182,5 +182,7 @@
     // fragment_location_dialog
     <string name="location_dialog_title">위치 권한 설정</string>
     <string name="location_dialog_permission_rationale">위치 권한을 활성화하면 아래 기능들을 사용할 수 있어요. \n ▪️현 위치를 조회할 수 있어요 \n ▪️현 위치를 기반으로 빠르게 스타카토를\n &#160;생성할 수 있어요 \n\n더 나은 서비스 경험을 원하신다면 위치 권한을 허용해 주세요!</string>
+    <string name="sort_memories_with_period_order">기간 있는 추억</string>
+    <string name="sort_memories_without_period_order">기간 없는 추억</string>
 
 </resources>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -47,6 +47,11 @@
     <string name="timeline_memory_creation_btn_description">추억 만들기로 이동</string>
     <string name="timeline_sort_memories_btn_description">나의 추억들 정렬</string>
 
+    // menu_sort
+    <string name="sort_creation_order">생성 순</string>
+    <string name="sort_latest_order">최신 순</string>
+    <string name="sort_oldest_order">과거 순</string>
+
     // item_timeline
     <string name="timeline_memory_icon_description">추억 아이콘</string>
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #503

<br>

## 🎥 시연영상
https://github.com/user-attachments/assets/962470c5-ec04-4d94-a7b5-6a741e4eb546

<br>

## 🚩 Summary
- [x] 생성 순 정렬
- [x] 최신 순 정렬
- [x] 과거 순 정렬
- [x] 기간 있는 추억
- [x] 기간 없는 추억
<br>

## 🛠️ Technical Concerns
**정렬 타입 enum class**
- `enum class`를 활용해 사용자가 선택한 정렬 메뉴에 해당하는 동작을 `view model`이 결정할 수 있도록 구현했습니다.

```kotlin
enum class SortType(
    @MenuRes val menuId: Int,
) {
    CREATION(R.id.creation_order),
    LATEST(R.id.latest_order),
    OLDEST(R.id.oldest_order),
    WITH_PERIOD(R.id.with_period_order),
    WITHOUT_PERIOD(R.id.without_period_order),
    ...
    ;

    companion object {
        fun from(menuId: Int): SortType = entries.first { it.menuId == menuId }
    }
}
```

**최신 순 정렬**
- `sortedByDescending()`을 활용했습니다.

**과거 순 정렬**
- `sortedWith()`을 활용했습니다.
- `startAt`을 비교해 오름차순으로 정렬하고 `startAt`이 null인 추억들은 `nullsLast()`를 이용해 기간이 있는 추억들 뒤쪽에 위치하도록 구현했습니다.
  ```kotlin
  fun sortByOldest() {
      val memoriesSortedByOldest = _timeline.value?.sortedWith(compareBy(nullsLast()) { it.startAt }) ?: emptyList()
      _timeline.value = memoriesSortedByOldest
  }
  ```

**기간 있는 추억 & 기간 없는 추억**
- `filter()` 를 활용했습니다.
<br>

## 🙂 To Reviewer
- 최신, 과거 순 정렬 시 기간이 없는 추억들은 기간이 있는 추억들 뒤쪽으로 배치했습니다.