### PR TITLE
feat: 기본 추억 제공 구현 #508

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -48,8 +48,9 @@ public class AuthService {
     }
 
     private void createBasicMemory(Member member) {
-        Memory memory = memoryRepository.save(Memory.basic());
+        Memory memory = Memory.basic();
         memory.addMemoryMember(member);
+        memoryRepository.save(memory);
     }
 
     public Member extractFromToken(String token) {

--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -12,6 +12,8 @@ import com.staccato.exception.UnauthorizedException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 import com.staccato.member.repository.MemberRepository;
+import com.staccato.memory.domain.Memory;
+import com.staccato.memory.repository.MemoryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,12 +24,14 @@ import lombok.extern.slf4j.Slf4j;
 @Transactional(readOnly = true)
 public class AuthService {
     private final MemberRepository memberRepository;
+    private final MemoryRepository memoryRepository;
     private final TokenProvider tokenProvider;
 
     @Transactional
     public LoginResponse login(LoginRequest loginRequest) {
         Member member = createMember(loginRequest);
         String token = tokenProvider.create(member);
+        createBasicMemory(member);
         return new LoginResponse(token);
     }
 
@@ -41,6 +45,11 @@ public class AuthService {
         if (memberRepository.existsByNickname(nickname)) {
             throw new StaccatoException("이미 존재하는 닉네임입니다. 다시 설정해주세요.");
         }
+    }
+
+    private void createBasicMemory(Member member) {
+        Memory memory = memoryRepository.save(Memory.basic());
+        memory.addMemoryMember(member);
     }
 
     public Member extractFromToken(String token) {

--- a/backend/src/main/java/com/staccato/memory/domain/Memory.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Memory.java
@@ -26,6 +26,9 @@ import lombok.NonNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memory extends BaseEntity {
+    private static final String DEFAULT_TITLE = "기본 추억";
+    private static final String DEFAULT_DESCRIPTION = "스타카토를 담을 수 있는 추억입니다.";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -47,6 +50,13 @@ public class Memory extends BaseEntity {
         this.title = title.trim();
         this.description = description;
         this.term = new Term(startAt, endAt);
+    }
+
+    public static Memory basic() {
+        return Memory.builder()
+                .title(DEFAULT_TITLE)
+                .description(DEFAULT_DESCRIPTION)
+                .build();
     }
 
     public void addMemoryMember(Member member) {

--- a/backend/src/main/java/com/staccato/memory/domain/Memory.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Memory.java
@@ -27,7 +27,7 @@ import lombok.NonNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memory extends BaseEntity {
     private static final String DEFAULT_TITLE = "기본 추억";
-    private static final String DEFAULT_DESCRIPTION = "스타카토를 담을 수 있는 추억입니다.";
+    private static final String DEFAULT_DESCRIPTION = "스타카토를 추억에 담아보세요.";
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import com.staccato.fixture.Member.MemberFixture;
 import com.staccato.fixture.auth.LoginRequestFixture;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
+import com.staccato.memory.repository.MemoryMemberRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,6 +25,8 @@ class AuthServiceTest extends ServiceSliceTest {
     private AuthService authService;
     @Autowired
     private MemberRepository memberRepository;
+    @Autowired
+    private MemoryMemberRepository memoryMemberRepository;
     @Autowired
     private TokenProvider tokenProvider;
 
@@ -40,6 +43,23 @@ class AuthServiceTest extends ServiceSliceTest {
         assertAll(
                 () -> assertThat(memberRepository.findAll()).hasSize(1),
                 () -> assertThat(loginResponse.token()).isNotNull()
+        );
+    }
+
+    @DisplayName("입력받은 닉네임으로 멤버를 저장할 때 기본 추억을 생성한다.")
+    @Test
+    void loginThenCreateBasicMemory() {
+        // given
+        LoginRequest loginRequest = LoginRequestFixture.create();
+
+        // when
+        LoginResponse loginResponse = authService.login(loginRequest);
+
+        // then
+        assertAll(
+                () -> assertThat(memberRepository.findAll()).hasSize(1),
+                () -> assertThat(loginResponse.token()).isNotNull(),
+                () -> assertThat(memoryMemberRepository.findAll()).hasSize(1)
         );
     }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #508 

## 🚩 Summary
- `Memory` 도메인에 기본 추억을 제공하는 정적 팩터리 메서드 `basic()`을 만들었습니다.
- 기본 추억은 `기본 추억`이라는 제목과 `스타카토를 추억에 담아보세요`라는 설명을 가집니다.
- `AuthService`에서는 `login()`이 호출되었을 때 회원 정보를 생성하고, 해당 회원 정보에 대해 기본 추억을 생성합니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
