### PR TITLE
build: 안드로이드 CI/CD 재설정 #445

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -70,22 +70,22 @@ jobs:
       - name: Build Release AAB
         run: ./gradlew bundleRelease
 
-      - name: Upload Release APK
+      - name: Upload Release APK in artifact
         uses: actions/upload-artifact@v3
         with:
           name: app-release.apk
           path: android/Staccato_AN/app/build/outputs/apk/release/app-release.apk
 
-      - name: Upload Release AAB
+      - name: Upload Release AAB in artifact
         uses: actions/upload-artifact@v3
         with:
           name: app-release.aab
           path: android/Staccato_AN/app/build/outputs/bundle/release/app-release.aab
 
-#      - name: Upload On Google Play
-#        uses: r0adkll/upload-google-play@v1
-#        with:
-#          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
-#          packageName: com.on.staccato
-#          releaseFiles: android/Staccato_AN/app/build/outputs/bundle/release/app-release.aab
-#          track: internal
+      - name: Deploy AAB On Google Play Console
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          packageName: com.on.staccato
+          releaseFiles: android/Staccato_AN/app/build/outputs/bundle/release/app-release.aab
+          track: product

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -85,7 +85,8 @@ jobs:
       - name: Deploy AAB On Google Play Console
         uses: r0adkll/upload-google-play@v1
         with:
-          serviceAccountJsonPlainText: ${{ secrets.SERVICE_ACCOUNT_JSON }}
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY_JSON }}
           packageName: com.on.staccato
           releaseFiles: android/Staccato_AN/app/build/outputs/bundle/release/app-release.aab
           track: product
+          whatsNewDirectory: android/Staccato_AN/deploy/whatsnew/

--- a/.github/workflows/android-ci-cd-dev.yml
+++ b/.github/workflows/android-ci-cd-dev.yml
@@ -69,14 +69,14 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug
+      - name: Build Release APK
+        run: ./gradlew assembleRelease
 
-      - name: Upload Debug APK
+      - name: Upload Release APK
         uses: actions/upload-artifact@v3
         with:
-          name: app-debug.apk
-          path: android/Staccato_AN/app/build/outputs/apk/debug/app-debug.apk
+          name: app-release.apk
+          path: android/Staccato_AN/app/build/outputs/apk/release/app-release.apk
 
       - name: Upload Artifact to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
@@ -84,4 +84,4 @@ jobs:
           appId: ${{secrets.FIREBASE_APP_ID}}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: staccato_tester
-          file: android/Staccato_AN/app/build/outputs/apk/debug/app-debug.apk
+          file: android/Staccato_AN/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android-ci-cd-dev.yml
+++ b/.github/workflows/android-ci-cd-dev.yml
@@ -1,9 +1,9 @@
-name: Android CI/CD for generating demo APK
+name: Android CI/CD for release(generating demo APK)
 
 on:
   push:
     paths: 'android/**'
-    branches: [ "develop" ]
+    branches: [ "release-an" ]
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,7 +3,7 @@ name: Android CI for develop
 on:
   pull_request:
     paths: 'android/**'
-    branches: [ "develop" ]
+    branches: [ "develop", "release-an", "main" ]
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,7 +3,7 @@ name: Android CI for develop-an
 on:
   pull_request:
     paths: 'android/**'
-    branches: [ "develop-an" ]
+    branches: [ "develop" ]
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,4 +1,4 @@
-name: Android CI for develop-an
+name: Android CI for develop
 
 on:
   pull_request:


### PR DESCRIPTION
## ⭐️ Issue Number
- #445 

## 🚩 Summary

### android-ci.yml 파일 수정
브랜치 전략이 변경됨에 따라, **CI** 가 적용될 브랜치를 업데이트 하였습니다.
- [x] `pull-request` 타겟 브랜치 변경 : `develop-an` ➡️ `develop`, `release-an`, `main`

### `android-ci-cd-demo-apk.yml` 파일 수정
데모(테스트)용 앱을 추출하기 위해 사용 중이던 **CI/CD**를 수정하였습니다. 
- yml 파일 명 변경 : 개발 단계에서 사용되는 CI/CD 파일이므로, 파일 이름을 명시적으로 변경하였습니다.
  - [x] `android-ci-cd-demo-apk.yml` ➡️ `android-ci-cd-dev.yml`
- 타겟 브랜치 변경 : 개발 브랜치인 `develop` 에서 배포 준비 브랜치인 `release-an`으로 push 될 때 **CI/CD** 가 적용됩니다.
  - [x] `push` 타겟 브랜치 변경 : `develop` ➡️ `release-an`
- 앱 빌드 모드 변경 : 무거운 debug 용으로 빌드하지 않고, 용량이 더 적은 release 모드로 빌드하도록 변경하였습니다.
  - [x] 앱 추출 시 debug 모드 에서 release 모드로 변경

### Git Action Secret 수정
이전에 CD 설정을 할 때, 콘솔로 업로드하는 작업이 인증 오류로 업로드가 되지 않는 문제가 있었습니다.
기존에 가지고 있던 서비스 계정 키 Secret 변수에 문제가 있을 것이라 생각해서, 새로 생성한 서비스 계정의 키로 교체하였습니다.
  - [x] 구글 서비스 계정 키(GCP의 서비스 계정 API key) 변경

### android-cd.yml 파일 수정
CD를 재설정하는 작업을 아래와 같이 진행했습니다.
- 구글 플레이 콘솔에 업로드하는 작업 복구
  - [x] 구글 플레이 콘솔 업로드 액션 사용 : [r0adkll/upload-google-play](https://github.com/r0adkll/upload-google-play)
  - [x] 변경된 구글 서비스 계정 키 적용 : `SERVICE_ACCOUNT_JSON` ➡️ `GOOGLE_SERVICE_ACCOUNT_KEY_JSON`
  - [x] 출시 노트 옵션 적용 : `whatsNewDirectory` 옵션을 추가하여 출시노트를 함께 업로드하도록 변경하였습니다.

## 🙂 To Reviewer
- CI, CD 의 동작을 잘 모르겠다면 언제든 질문해주세요!

## 📋 To Do
- 자동 배포 잘되게 빌기