### PR TITLE
chore: Thread, Hikari CP 변경

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,18 +8,24 @@ spring:
     init:
       mode: always
   datasource:
-    hikari:
-      maximum-pool-size: 10
-      minimum-idle: 10
-      idle-timeout: 600000
-      connection-timeout: 8000
-      max-lifetime: 1800000
     writer:
+      hikari:
+        maximum-pool-size: 10
+        minimum-idle: 10
+        idle-timeout: 600000
+        connection-timeout: 8000
+        max-lifetime: 1800000
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbcUrl: ${SPRING_WRITER_DATASOURCE_URL}
       username: ${SPRING_DATASOURCE_USERNAME}
       password: ${SPRING_DATASOURCE_PASSWORD}
     reader:
+      hikari:
+        maximum-pool-size: 10
+        minimum-idle: 10
+        idle-timeout: 600000
+        connection-timeout: 8000
+        max-lifetime: 1800000
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbcUrl: ${SPRING_READER_DATASOURCE_URL}
       username: ${SPRING_DATASOURCE_USERNAME}

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,6 +8,12 @@ spring:
     init:
       mode: always
   datasource:
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 10
+      idle-timeout: 600000
+      connection-timeout: 8000
+      max-lifetime: 1800000
     writer:
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbcUrl: ${SPRING_WRITER_DATASOURCE_URL}
@@ -79,5 +85,10 @@ management:
 
 server:
   tomcat:
+    accept-count: 100
+    max-connections: 2048
+    threads:
+      min-spare: 10
+      max: 30
     mbeanregistry:
       enabled: true


### PR DESCRIPTION
## ⭐️ Issue Number
- #517 

## 🚩 Summary
- MaxThread
    - 크기가 크면 크면 context Switching 비용이 많이 발생한다.
    - 스레드도 메모리를 들고 있는다!
    - 값을 줄이면서 테스트 했을 때 **30**일 때가 제일 TPS가 좋았다.
- MaxConnection
    - 1000명 기준 목표 TPS가 40인 것에 비해 Max Connection이 과도하게 크다.
    - Connection을 획득 후 대기만 하면서 리소스가 낭비된다.
    - 따라서, Max Connection 수가 더 줄었을 때 성능은 더 향상된다.
    - 대신, connection을 얻지 못해서 테스트 실패율이 증가한다.
    - 테스트 실패율과 TPS를 두고 저울질 한다면, 테스트 실패율이 더 낮은 것이 중요하다고 생각해서 **2048**을 선택했다.        
- Worker Connection
    - nginx에서 동시에 처리할 수 있는 커넥션 수
    - WorkerConnection ≥ MaxConnection으로 설정을 하는 것이 좋다고 생각했다.
    - MaxConnection의 수와 같이 **2048**개의 동시 처리 커넥션 수를 가져가기로 했다.
- Min Spare
    - 항상 있는 최소한의 스레드 수
    - 너무 낮게 설정하면 커넥션이 즉시 사용 가능한 상태가 아니어서 추가 요청 시 지연이 발생할 수 있고, 너무 높게 설정하면 불필요한 커넥션 유지로 자원 낭비가 발생할 수 있다
    - 10개나 20개나 메모리 부하에 큰 영향을 미칠까? 성능에 큰 영향을 미칠까?
    - 큰 영향을 끼치지 않는다고 판단하여 **수정하지 않기로(10)** 결정했다.
- accept-count
    - max-connections 이상의 요청이 들어 왔을 때 사용하는 요청 대기열 큐의 사이즈
    - 만약 max-connections 이상의 연결 시도라서 요청 대기열 큐에 저장되는데, 요청 대기열 큐의 사이즈인 accept-count 보다도 연결 시도가 많아지면 연결을 거부한다.
    - Max Connection도 충분히 작은 값으로 설정했기 때문에 Connection 실패를 줄이는 의도에서 **수정하지 않기로(100)** 결정했다.
- Hikari.maxConnection, minimum-idle
    - maximum-pool-size 과 minimum-idle을 동일하게가져가는 것이 권장사항이며,
    minimum-idle을 pool size보다 작게 가져갈 시 Connection을 생성하고 삭제하는 비용이 발생하므로, 동일하게 가져갔다.
    - maximum-pool-size을 기존 10보다 더 적게(5개) 혹은 더 많게(15개) 구성하였을 때 TPS와 성공응답 비율의 차이가 크지 않았다고 판단하여 Default 값 10으로 유지하였다.
    - https://github.com/brettwooldridge/HikariCP/wiki/About-Pool-Sizing
- Hikari.connectionTimeOut
    - 클라이언트 측 timeout: 10초
    - 클라이언트 측보다 짧게 가져가야 한다고 생각했다.
        - 우리가 10초보다 길면, 클라이언트측은 응답을 못하고, 원인을 알 수 없다.
        - 서버에서는 처리를 완료했는데, 10초 이내에 응답을 돌려주지 못하는 문제가 있을 수 있다.
    - 추가로 서비스 특성 상 처리 순서가 중요하지 않고, 오히려 빠른 실패로 사용자의 재시도를 유도하는 것이 사용자 경험 측면에서 더 좋다고 생각했다.
    - 따라서, ConnectionTimeout을 **8초**로 결정했다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
