### PR TITLE
fix: android ci 오류 수정 #519

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -60,9 +60,10 @@ jobs:
 
       - name: Create KeyStore File and Properties
         run: |
+          pwd
           mkdir ./app/signing
           echo "$UPLOAD_KEY_STORE_JKS" | base64 --decode > ./app/signing/upload_key_store.jks
-          echo $KEY_STORE_PROPERTIES > ./app/signing/keystore.properties
+          echo "$KEY_STORE_PROPERTIES" > ./app/signing/keystore.properties
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## ⭐️ Issue Number
- #519 

## 🚩 Summary
- android-ci.yml 파일의 앱 서명용 keystore를 생성하는 부분의 명령어를 수정하였습니다.
- `UPLOAD_KEY_STORE_JKS` 의 인코딩 파일 내용을 다시 적용하였습니다.
