### PR TITLE
feat: 기본 추억 제목 변경 #530

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/AuthService.java
+++ b/backend/src/main/java/com/staccato/auth/service/AuthService.java
@@ -48,7 +48,7 @@ public class AuthService {
     }
 
     private void createBasicMemory(Member member) {
-        Memory memory = Memory.basic();
+        Memory memory = Memory.basic(member.getNickname());
         memory.addMemoryMember(member);
         memoryRepository.save(memory);
     }

--- a/backend/src/main/java/com/staccato/memory/domain/Memory.java
+++ b/backend/src/main/java/com/staccato/memory/domain/Memory.java
@@ -15,6 +15,7 @@ import jakarta.persistence.OneToMany;
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
+import com.staccato.member.domain.Nickname;
 import com.staccato.moment.domain.Moment;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -26,7 +27,7 @@ import lombok.NonNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Memory extends BaseEntity {
-    private static final String DEFAULT_TITLE = "기본 추억";
+    private static final String DEFAULT_SUBTITLE = "의 추억";
     private static final String DEFAULT_DESCRIPTION = "스타카토를 추억에 담아보세요.";
 
     @Id
@@ -52,9 +53,9 @@ public class Memory extends BaseEntity {
         this.term = new Term(startAt, endAt);
     }
 
-    public static Memory basic() {
+    public static Memory basic(Nickname memberNickname) {
         return Memory.builder()
-                .title(DEFAULT_TITLE)
+                .title(memberNickname.getNickname() + DEFAULT_SUBTITLE)
                 .description(DEFAULT_DESCRIPTION)
                 .build();
     }

--- a/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
@@ -6,8 +6,11 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import com.staccato.exception.StaccatoException;
+import com.staccato.fixture.Member.MemberFixture;
 import com.staccato.fixture.memory.MemoryFixture;
 import com.staccato.fixture.moment.MomentFixture;
+import com.staccato.member.domain.Member;
+import com.staccato.member.domain.Nickname;
 import com.staccato.moment.domain.Moment;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +28,19 @@ class MemoryTest {
 
         // then
         assertThat(memory.getTitle()).isEqualTo(expectedTitle);
+    }
+
+    @DisplayName("기본 추억은 멤버 이름으로 만들어진다.")
+    @Test
+    void createBasicMemoryWithMemberNickname() {
+        // given
+        String nickname = "staccato";
+
+        // when
+        Memory memory = Memory.basic(new Nickname(nickname));
+
+        // then
+        assertThat(memory.getTitle()).isEqualTo("staccato의 추억");
     }
 
     @DisplayName("추억을 수정 시 기존 스타카토 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")

--- a/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
+++ b/backend/src/test/java/com/staccato/memory/domain/MemoryTest.java
@@ -40,7 +40,7 @@ class MemoryTest {
         Memory memory = Memory.basic(new Nickname(nickname));
 
         // then
-        assertThat(memory.getTitle()).isEqualTo("staccato의 추억");
+        assertThat(memory.getTitle()).isEqualTo(nickname + "의 추억");
     }
 
     @DisplayName("추억을 수정 시 기존 스타카토 기록 날짜를 포함하지 않는 경우 수정에 실패한다.")


### PR DESCRIPTION
## ⭐️ Issue Number
- #530 

## 🚩 Summary
- 기본 추억의 제목을 '기본 추억'에서 멤버 이름을 사용해서 '{멤버 이름}의 추억'으로 바꾸었습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
