### PR TITLE
fix: 스타카토 삭제 시 마커가 갱신되지 않는 오류 해결 #533

### DIFF
--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         applicationId = "com.on.staccato"
         minSdk = 26
         targetSdk = 34
-        versionCode = 5
+        versionCode = 6
         versionName = "1.2.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -80,6 +80,7 @@ class MainActivity :
         observeCurrentLocation()
         observeStaccatoLocations()
         observeStaccatoId()
+        observeDeletedStaccato()
         setupBottomSheetController()
         setupBackPressedHandler()
         setUpBottomSheetBehaviorAction()
@@ -271,6 +272,14 @@ class MainActivity :
                 BOTTOM_SHEET_STATE_REQUEST_KEY,
                 bundleOf(BOTTOM_SHEET_NEW_STATE to STATE_EXPANDED),
             )
+        }
+    }
+
+    private fun observeDeletedStaccato() {
+        sharedViewModel.isStaccatosUpdated.observe(this) { isDeleted ->
+            if (isDeleted) {
+                mapsViewModel.loadStaccatos()
+            }
         }
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
@@ -11,7 +11,9 @@ class SharedViewModel : ViewModel() {
     val isTimelineUpdated: SingleLiveData<Boolean>
         get() = _isTimelineUpdated
 
-    private val isStaccatosUpdated = MutableSingleLiveData(false)
+    private val _isStaccatosUpdated = MutableSingleLiveData(false)
+    val isStaccatosUpdated: SingleLiveData<Boolean>
+        get() = _isStaccatosUpdated
 
     private val _isPermissionCancelClicked = MutableLiveData(false)
     val isPermissionCancelClicked: LiveData<Boolean> get() = _isPermissionCancelClicked
@@ -24,7 +26,7 @@ class SharedViewModel : ViewModel() {
     }
 
     fun setStaccatosHasUpdated() {
-        isStaccatosUpdated.setValue(true)
+        _isStaccatosUpdated.setValue(true)
     }
 
     fun updateIsPermissionCancelClicked() {


### PR DESCRIPTION
## ⭐️ Issue Number
- #533 

## 🚩 Summary
- 스타카토 삭제 시 마커가 갱신되지 않는 오류 해결

## 🙂 To Reviewer
스타카토 삭제 후 마커가 제대로 갱신되는 지 확인해주세요!
