### PR TITLE
feat & fix: 사진 코루틴 취소 버그 수정 / ACTION_PICK_IMAGES 적용 #536

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
@@ -46,7 +46,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private lateinit var cameraLauncher: ActivityResultLauncher<Uri>
     private var multipleAbleOption: Boolean = false
     private var currentImageUri: Uri? = null
-    private var attachableImageCount: Int = -1
+    private var attachableImageCount: Int = INVALID_ATTACHABLE_IMAGE_COUNT
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -312,6 +312,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         private const val FILENAME_DATE_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
         private const val MIN_COUNT_FOR_PICK_IMAGES_MAX = 2
         private const val MIN_EXTENSION_VERSION = 2
+        private const val INVALID_ATTACHABLE_IMAGE_COUNT = -1
         private val CAMERA_REQUIRED_PERMISSIONS =
             mutableListOf(
                 Manifest.permission.CAMERA,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
@@ -21,7 +21,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresExtension
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -46,7 +46,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private lateinit var cameraLauncher: ActivityResultLauncher<Uri>
     private var multipleAbleOption: Boolean = false
     private var currentImageUri: Uri? = null
-    private var availableImageCount: Int? = null
+    private var attachableImageCount: Int = -1
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -99,7 +99,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     }
 
     fun setCurrentImageCount(count: Int) {
-        availableImageCount = count
+        attachableImageCount = count
     }
 
     private fun initUrisSelectedListener(context: Context) {
@@ -178,7 +178,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private fun launchGallery() {
         val intent =
             Intent(Intent.ACTION_PICK)
-                .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, IMAGE_TYPE)
                 .putExtra(Intent.EXTRA_ALLOW_MULTIPLE, multipleAbleOption)
         galleryLauncher.launch(intent)
     }
@@ -206,10 +206,10 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     }
 
     private fun handleGalleryPermissionNotGranted() {
-        if (VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (isPhotoPickerAvailable()) {
             val intent =
                 Intent(MediaStore.ACTION_PICK_IMAGES)
-                    .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                    .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, IMAGE_TYPE)
                     .setImageCountLimit()
             galleryLauncher.launch(intent)
         } else {
@@ -217,14 +217,16 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         }
     }
 
-    @RequiresApi(Build.VERSION_CODES.R)
+    private fun isPhotoPickerAvailable() =
+        (Build.VERSION_CODES.TIRAMISU <= VERSION.SDK_INT) || (
+            (Build.VERSION_CODES.R <= VERSION.SDK_INT) &&
+                (MIN_EXTENSION_VERSION <= SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R))
+        )
+
+    @RequiresExtension(extension = Build.VERSION_CODES.R, version = 2)
     private fun Intent.setImageCountLimit(): Intent {
-        if (!multipleAbleOption && SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R) < 2) return this
-        availableImageCount?.let { imageCount ->
-            if (MIN_COUNT_FOR_PICK_IMAGES_MAX < imageCount) {
-                putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, imageCount)
-            }
-        }
+        if (!multipleAbleOption || attachableImageCount < MIN_COUNT_FOR_PICK_IMAGES_MAX) return this
+        putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, attachableImageCount)
         return this
     }
 
@@ -299,14 +301,17 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private fun createImageContent(fileName: String): ContentValues =
         ContentValues().apply {
             put(MediaStore.Images.Media.DISPLAY_NAME, "img_$fileName.jpg")
-            put(MediaStore.Images.Media.MIME_TYPE, "image/jpg")
+            put(MediaStore.Images.Media.MIME_TYPE, IMAGE_JPG_TYPE)
         }
 
     companion object {
         const val TAG = "PhotoAttachModalBottomSheet"
         const val PACKAGE_SCHEME = "package"
+        private const val IMAGE_JPG_TYPE = "image/jpg"
+        private const val IMAGE_TYPE = "image/*"
         private const val FILENAME_DATE_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
-        private const val MIN_COUNT_FOR_PICK_IMAGES_MAX = 1
+        private const val MIN_COUNT_FOR_PICK_IMAGES_MAX = 2
+        private const val MIN_EXTENSION_VERSION = 2
         private val CAMERA_REQUIRED_PERMISSIONS =
             mutableListOf(
                 Manifest.permission.CAMERA,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/PhotoAttachFragment.kt
@@ -11,7 +11,9 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
+import android.os.Build.VERSION
 import android.os.Bundle
+import android.os.ext.SdkExtensions
 import android.provider.MediaStore
 import android.provider.Settings
 import android.view.LayoutInflater
@@ -19,6 +21,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
 import androidx.core.content.ContextCompat
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
@@ -43,6 +46,7 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     private lateinit var cameraLauncher: ActivityResultLauncher<Uri>
     private var multipleAbleOption: Boolean = false
     private var currentImageUri: Uri? = null
+    private var availableImageCount: Int? = null
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -94,6 +98,10 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         multipleAbleOption = option
     }
 
+    fun setCurrentImageCount(count: Int) {
+        availableImageCount = count
+    }
+
     private fun initUrisSelectedListener(context: Context) {
         if (context is OnUrisSelectedListener) {
             uriSelectedListener = context
@@ -103,8 +111,10 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
     }
 
     private fun initRequestPermissionLauncher() {
-        requestCameraPermissionLauncher = buildRequestPermissionLauncher { startCamera() }
-        requestGalleryPermissionLauncher = buildRequestPermissionLauncher { launchGallery() }
+        requestCameraPermissionLauncher =
+            buildRequestPermissionLauncher(::startCamera, ::handleCameraPermissionNotGranted)
+        requestGalleryPermissionLauncher =
+            buildRequestPermissionLauncher(::launchGallery, ::handleGalleryPermissionNotGranted)
     }
 
     private fun initCameraLauncher() {
@@ -133,12 +143,15 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
             }
     }
 
-    private fun buildRequestPermissionLauncher(actionOnPermissionGranted: () -> Unit): ActivityResultLauncher<Array<String>> =
+    private fun buildRequestPermissionLauncher(
+        actionOnPermissionGranted: () -> Unit,
+        actionOnPermissionNotGranted: () -> Unit,
+    ): ActivityResultLauncher<Array<String>> =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { permissions ->
             if (permissions.all { (_, isGranted) -> isGranted }) {
                 actionOnPermissionGranted()
             } else {
-                showPermissionSnackBar()
+                actionOnPermissionNotGranted()
             }
         }
 
@@ -188,8 +201,31 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         }
     }
 
-    private fun showPermissionSnackBar() {
-        showSettingSnackBar(R.string.snack_bar_require_photo_album_permission)
+    private fun handleCameraPermissionNotGranted() {
+        showSettingSnackBar(R.string.photo_require_camera_permission)
+    }
+
+    private fun handleGalleryPermissionNotGranted() {
+        if (VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val intent =
+                Intent(MediaStore.ACTION_PICK_IMAGES)
+                    .setDataAndType(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, "image/*")
+                    .setImageCountLimit()
+            galleryLauncher.launch(intent)
+        } else {
+            showSettingSnackBar(R.string.photo_require_photo_album_permission)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun Intent.setImageCountLimit(): Intent {
+        if (!multipleAbleOption && SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R) < 2) return this
+        availableImageCount?.let { imageCount ->
+            if (MIN_COUNT_FOR_PICK_IMAGES_MAX < imageCount) {
+                putExtra(MediaStore.EXTRA_PICK_IMAGES_MAX, imageCount)
+            }
+        }
+        return this
     }
 
     private fun showCameraErrorSnackBar() {
@@ -270,16 +306,17 @@ class PhotoAttachFragment : BottomSheetDialogFragment(), PhotoAttachHandler {
         const val TAG = "PhotoAttachModalBottomSheet"
         const val PACKAGE_SCHEME = "package"
         private const val FILENAME_DATE_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
+        private const val MIN_COUNT_FOR_PICK_IMAGES_MAX = 1
         private val CAMERA_REQUIRED_PERMISSIONS =
             mutableListOf(
                 Manifest.permission.CAMERA,
             ).apply {
-                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.P) {
+                if (VERSION.SDK_INT <= Build.VERSION_CODES.P) {
                     add(Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 }
             }.toTypedArray()
         private val GALLERY_REQUIRED_PERMISSION =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 READ_MEDIA_IMAGES
             } else {
                 READ_EXTERNAL_STORAGE

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -298,7 +298,7 @@ class StaccatoCreationActivity :
         viewModel.currentPhotos.observe(this) { photos ->
             photoAttachFragment.setCurrentImageCount(StaccatoCreationViewModel.MAX_PHOTO_NUMBER - photos.size)
             photoAttachAdapter.submitList(
-                listOf(AttachedPhotoUiModel.addPhotoButton).plus(photos.attachedPhotos),
+                listOf(AttachedPhotoUiModel.addPhotoButton, *photos.attachedPhotos.toTypedArray()),
             )
         }
         viewModel.memoryCandidates.observe(this) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -296,6 +296,7 @@ class StaccatoCreationActivity :
             viewModel.fetchPhotosUrlsByUris(this)
         }
         viewModel.currentPhotos.observe(this) { photos ->
+            photoAttachFragment.setCurrentImageCount(StaccatoCreationViewModel.MAX_PHOTO_NUMBER - photos.size)
             photoAttachAdapter.submitList(
                 listOf(AttachedPhotoUiModel.addPhotoButton).plus(photos.attachedPhotos),
             )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -27,6 +27,7 @@ import com.on.staccato.presentation.util.convertExcretaFile
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -246,7 +247,9 @@ class StaccatoCreationViewModel
             imageRepository.convertImageFileToUrl(multiPartBody)
                 .onSuccess {
                     updatePhotoWithUrl(photo, it.imageUrl)
-                }.onException(::handleException)
+                }.onException { e, message ->
+                    if (this.isActive) handleException(e, message)
+                }
                 .onServerError(::handleServerError)
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -296,7 +296,7 @@ class StaccatoUpdateActivity :
         viewModel.currentPhotos.observe(this) { photos ->
             photoAttachFragment.setCurrentImageCount(StaccatoCreationViewModel.MAX_PHOTO_NUMBER - photos.size)
             photoAttachAdapter.submitList(
-                listOf(AttachedPhotoUiModel.addPhotoButton).plus(photos.attachedPhotos),
+                listOf(AttachedPhotoUiModel.addPhotoButton, *photos.attachedPhotos.toTypedArray()),
             )
         }
         viewModel.memoryCandidates.observe(this) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -42,6 +42,7 @@ import com.on.staccato.presentation.staccatocreation.adapter.PhotoAttachAdapter
 import com.on.staccato.presentation.staccatocreation.dialog.MemorySelectionFragment
 import com.on.staccato.presentation.staccatocreation.dialog.VisitedAtSelectionFragment
 import com.on.staccato.presentation.staccatocreation.model.AttachedPhotoUiModel
+import com.on.staccato.presentation.staccatocreation.viewmodel.StaccatoCreationViewModel
 import com.on.staccato.presentation.staccatoupdate.viewmodel.StaccatoUpdateViewModel
 import com.on.staccato.presentation.util.getSnackBarWithAction
 import com.on.staccato.presentation.util.showToast
@@ -293,6 +294,7 @@ class StaccatoUpdateActivity :
             viewModel.fetchPhotosUrlsByUris(this)
         }
         viewModel.currentPhotos.observe(this) { photos ->
+            photoAttachFragment.setCurrentImageCount(StaccatoCreationViewModel.MAX_PHOTO_NUMBER - photos.size)
             photoAttachAdapter.submitList(
                 listOf(AttachedPhotoUiModel.addPhotoButton).plus(photos.attachedPhotos),
             )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -31,299 +31,302 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.time.LocalDateTime
 import javax.inject.Inject
 
 @HiltViewModel
 class StaccatoUpdateViewModel
-    @Inject
-    constructor(
-        private val timelineRepository: TimelineRepository,
-        private val staccatoRepository: StaccatoRepository,
-        private val imageRepository: ImageRepository,
-    ) : AttachedPhotoHandler, ViewModel() {
-        val staccatoTitle = ObservableField<String>()
+@Inject
+constructor(
+    private val timelineRepository: TimelineRepository,
+    private val staccatoRepository: StaccatoRepository,
+    private val imageRepository: ImageRepository,
+) : AttachedPhotoHandler, ViewModel() {
+    val staccatoTitle = ObservableField<String>()
 
-        private val _placeName = MutableLiveData<String?>(null)
-        val placeName: LiveData<String?> get() = _placeName
+    private val _placeName = MutableLiveData<String?>(null)
+    val placeName: LiveData<String?> get() = _placeName
 
-        private val _address = MutableLiveData<String?>(null)
-        val address: LiveData<String?> get() = _address
+    private val _address = MutableLiveData<String?>(null)
+    val address: LiveData<String?> get() = _address
 
-        private val _currentPhotos =
-            MutableLiveData(AttachedPhotosUiModel(emptyList()))
-        val currentPhotos: LiveData<AttachedPhotosUiModel> get() = _currentPhotos
+    private val _currentPhotos =
+        MutableLiveData(AttachedPhotosUiModel(emptyList()))
+    val currentPhotos: LiveData<AttachedPhotosUiModel> get() = _currentPhotos
 
-        private val _pendingPhotos = MutableSingleLiveData<List<AttachedPhotoUiModel>>()
-        val pendingPhotos: SingleLiveData<List<AttachedPhotoUiModel>> get() = _pendingPhotos
+    private val _pendingPhotos = MutableSingleLiveData<List<AttachedPhotoUiModel>>()
+    val pendingPhotos: SingleLiveData<List<AttachedPhotoUiModel>> get() = _pendingPhotos
 
-        private val _latitude = MutableLiveData<Double?>()
-        private val latitude: LiveData<Double?> get() = _latitude
+    private val _latitude = MutableLiveData<Double?>()
+    private val latitude: LiveData<Double?> get() = _latitude
 
-        private val _longitude = MutableLiveData<Double?>()
-        private val longitude: LiveData<Double?> get() = _longitude
+    private val _longitude = MutableLiveData<Double?>()
+    private val longitude: LiveData<Double?> get() = _longitude
 
-        private val _memoryCandidates = MutableLiveData<MemoryCandidates>()
-        val memoryCandidates: LiveData<MemoryCandidates> get() = _memoryCandidates
+    private val _memoryCandidates = MutableLiveData<MemoryCandidates>()
+    val memoryCandidates: LiveData<MemoryCandidates> get() = _memoryCandidates
 
-        private val _selectedVisitedAt = MutableLiveData<LocalDateTime?>()
-        val selectedVisitedAt: LiveData<LocalDateTime?> get() = _selectedVisitedAt
+    private val _selectedVisitedAt = MutableLiveData<LocalDateTime?>()
+    val selectedVisitedAt: LiveData<LocalDateTime?> get() = _selectedVisitedAt
 
-        private val _isCurrentLocationLoading = MutableLiveData(false)
-        val isCurrentLocationLoading: LiveData<Boolean> get() = _isCurrentLocationLoading
+    private val _isCurrentLocationLoading = MutableLiveData(false)
+    val isCurrentLocationLoading: LiveData<Boolean> get() = _isCurrentLocationLoading
 
-        private var targetMemoryId: Long = 0
+    private var targetMemoryId: Long = 0
 
-        private val _selectedMemory = MutableLiveData<MemoryCandidate>()
-        val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
+    private val _selectedMemory = MutableLiveData<MemoryCandidate>()
+    val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
 
-        private val _isUpdateCompleted = MutableLiveData(false)
-        val isUpdateCompleted: LiveData<Boolean> get() = _isUpdateCompleted
+    private val _isUpdateCompleted = MutableLiveData(false)
+    val isUpdateCompleted: LiveData<Boolean> get() = _isUpdateCompleted
 
-        private val _isPosting = MutableLiveData<Boolean>(false)
-        val isPosting: LiveData<Boolean> get() = _isPosting
+    private val _isPosting = MutableLiveData<Boolean>(false)
+    val isPosting: LiveData<Boolean> get() = _isPosting
 
-        private val _isAddPhotoClicked = MutableSingleLiveData(false)
-        val isAddPhotoClicked: SingleLiveData<Boolean> get() = _isAddPhotoClicked
+    private val _isAddPhotoClicked = MutableSingleLiveData(false)
+    val isAddPhotoClicked: SingleLiveData<Boolean> get() = _isAddPhotoClicked
 
-        private val photoJobs = mutableMapOf<String, Job>()
+    private val photoJobs = mutableMapOf<String, Job>()
 
-        private val _warningMessage = MutableSingleLiveData<String>()
-        val warningMessage: SingleLiveData<String> get() = _warningMessage
+    private val _warningMessage = MutableSingleLiveData<String>()
+    val warningMessage: SingleLiveData<String> get() = _warningMessage
 
-        private val _error = MutableSingleLiveData<StaccatoUpdateError>()
-        val error: SingleLiveData<StaccatoUpdateError> get() = _error
+    private val _error = MutableSingleLiveData<StaccatoUpdateError>()
+    val error: SingleLiveData<StaccatoUpdateError> get() = _error
 
-        override fun onAddClicked() {
-            if ((currentPhotos.value?.size ?: 0) == StaccatoCreationViewModel.MAX_PHOTO_NUMBER) {
-                _warningMessage.postValue(StaccatoCreationViewModel.MAX_PHOTO_NUMBER_MESSAGE)
-            } else {
-                _isAddPhotoClicked.postValue(true)
-            }
-        }
-
-        override fun onDeleteClicked(deletedPhoto: AttachedPhotoUiModel) {
-            _currentPhotos.value = currentPhotos.value?.removePhoto(deletedPhoto)
-            if (photoJobs[deletedPhoto.uri.toString()]?.isActive == true) {
-                photoJobs[deletedPhoto.uri.toString()]?.cancel()
-            }
-        }
-
-        fun selectMemory(memory: MemoryCandidate) {
-            _selectedMemory.value = memory
-        }
-
-        fun selectedVisitedAt(visitedAt: LocalDateTime) {
-            _selectedVisitedAt.value = visitedAt
-        }
-
-        fun fetchTargetData(
-            staccatoId: Long,
-            memoryId: Long,
-            memoryTitle: String,
-        ) {
-            targetMemoryId = memoryId
-            fetchMemoryCandidates()
-            fetchStaccatoBy(staccatoId)
-        }
-
-        fun selectNewPlace(
-            placeId: String,
-            name: String,
-            address: String,
-            longitude: Double,
-            latitude: Double,
-        ) {
-            _placeName.value = name
-            _address.value = address
-            _longitude.value = longitude
-            _latitude.value = latitude
-        }
-
-        fun clearPlace() {
-            _placeName.value = null
-            _address.value = null
-            _longitude.value = null
-            _latitude.value = null
-        }
-
-        fun setPlaceByCurrentAddress(
-            address: String?,
-            location: Location,
-        ) {
-            setCurrentLocationLoading(false)
-            _placeName.postValue(address)
-            _address.postValue(address)
-            _latitude.postValue(location.latitude)
-            _longitude.postValue(location.longitude)
-        }
-
-        fun setCurrentLocationLoading(newValue: Boolean) {
-            _isCurrentLocationLoading.postValue(newValue)
-        }
-
-        fun updateSelectedImageUris(newUris: Array<Uri>) {
-            val updatedPhotos = currentPhotos.value!!.addPhotosByUris(newUris.toList())
-            _currentPhotos.value = updatedPhotos
-            _pendingPhotos.postValue(updatedPhotos.getPhotosWithoutUrls())
-        }
-
-        fun setUrisWithNewOrder(list: List<AttachedPhotoUiModel>) {
-            _currentPhotos.value = AttachedPhotosUiModel(list)
-        }
-
-        fun fetchPhotosUrlsByUris(context: Context) {
-            pendingPhotos.getValue()?.forEach { photo ->
-                val job = createPhotoUploadJob(context, photo)
-                job.invokeOnCompletion { _ ->
-                    photoJobs.remove(photo.uri.toString())
-                }
-                photoJobs[photo.uri.toString()] = job
-            }
-        }
-
-        fun updateStaccato(staccatoId: Long) {
-            viewModelScope.launch {
-                val staccatoTitleValue = staccatoTitle.get() ?: return@launch handleException()
-                val placeNameValue = placeName.value ?: return@launch handleException()
-                val addressValue = address.value ?: return@launch handleException()
-                val latitudeValue = latitude.value ?: return@launch handleException()
-                val longitudeValue = longitude.value ?: return@launch handleException()
-                val visitedAtValue = selectedVisitedAt.value ?: return@launch handleException()
-                val memoryIdValue = selectedMemory.value?.memoryId ?: return@launch handleException()
-                val staccatoImageUrlsValue =
-                    currentPhotos.value?.attachedPhotos?.map { it.imageUrl!! }
-                        ?: emptyList()
-                _isPosting.value = true
-                staccatoRepository.updateStaccato(
-                    staccatoId = staccatoId,
-                    staccatoTitle = staccatoTitleValue,
-                    placeName = placeNameValue,
-                    address = addressValue,
-                    latitude = latitudeValue,
-                    longitude = longitudeValue,
-                    visitedAt = visitedAtValue,
-                    memoryId = memoryIdValue,
-                    staccatoImageUrls = staccatoImageUrlsValue,
-                ).onSuccess {
-                    _isUpdateCompleted.postValue(true)
-                }.onException(::handleUpdateException)
-                    .onServerError(::handleServerError)
-            }
-        }
-
-        private fun fetchStaccatoBy(staccatoId: Long) {
-            viewModelScope.launch {
-                staccatoRepository.getStaccato(staccatoId = staccatoId)
-                    .onSuccess { staccato ->
-                        staccatoTitle.set(staccato.staccatoTitle)
-                        _address.value = staccato.address
-                        _latitude.value = staccato.latitude
-                        _longitude.value = staccato.longitude
-                        _selectedVisitedAt.value = staccato.visitedAt
-                        _placeName.value = staccato.placeName
-                        _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
-                        _selectedMemory.value =
-                            MemoryCandidate(
-                                staccato.memoryId,
-                                staccato.memoryTitle,
-                                staccato.startAt,
-                                staccato.endAt,
-                            )
-                    }.onException(::handleInitializeException)
-                    .onServerError(::handleServerError)
-            }
-        }
-
-        private fun fetchMemoryCandidates() {
-            viewModelScope.launch {
-                timelineRepository.getMemoryCandidates()
-                    .onSuccess { memoryCandidates ->
-                        _memoryCandidates.value = memoryCandidates
-                    }.onException(::handleMemoryCandidatesException)
-                    .onServerError(::handleServerError)
-            }
-        }
-
-        private fun createPhotoUploadJob(
-            context: Context,
-            photo: AttachedPhotoUiModel,
-        ) = viewModelScope.async(buildCoroutineExceptionHandler()) {
-            val multiPartBody =
-                convertExcretaFile(
-                    context,
-                    photo.uri,
-                    StaccatoCreationViewModel.FORM_DATA_NAME,
-                )
-            imageRepository.convertImageFileToUrl(multiPartBody)
-                .onSuccess {
-                    updatePhotoWithUrl(photo, it.imageUrl)
-                }.onException(::handleUpdatePhotoException)
-                .onServerError(::handleServerError)
-        }
-
-        private fun buildCoroutineExceptionHandler(): CoroutineExceptionHandler {
-            return CoroutineExceptionHandler { _, throwable ->
-                _warningMessage.postValue(throwable.message ?: FAIL_IMAGE_UPLOAD_MESSAGE)
-            }
-        }
-
-        private fun updatePhotoWithUrl(
-            targetPhoto: AttachedPhotoUiModel,
-            url: String,
-        ) {
-            val updatedPhoto = targetPhoto.updateUrl(url)
-            _currentPhotos.value = currentPhotos.value?.updateOrAppendPhoto(updatedPhoto)
-        }
-
-        private fun handleServerError(
-            status: Status,
-            message: String,
-        ) {
-            _isPosting.value = false
-            _warningMessage.setValue(message)
-        }
-
-        private fun handleUpdatePhotoException(
-            e: Throwable = IllegalArgumentException(),
-            errorMessage: String = IMAGE_UPLOAD_ERROR_MESSAGE,
-        ) {
-            _warningMessage.setValue(errorMessage)
-        }
-
-        private fun handleException(
-            e: Throwable = IllegalArgumentException(),
-            errorMessage: String = REQUIRED_VALUES_ERROR_MESSAGE,
-        ) {
-            _isPosting.value = false
-            _warningMessage.setValue(errorMessage)
-        }
-
-        private fun handleMemoryCandidatesException(
-            e: Throwable,
-            message: String,
-        ) {
-            _error.setValue(StaccatoUpdateError.MemoryCandidates(message))
-        }
-
-        private fun handleInitializeException(
-            e: Throwable,
-            message: String,
-        ) {
-            _error.setValue(StaccatoUpdateError.StaccatoInitialize(message))
-        }
-
-        private fun handleUpdateException(
-            e: Throwable = IllegalArgumentException(),
-            message: String = REQUIRED_VALUES_ERROR_MESSAGE,
-        ) {
-            _isPosting.value = false
-            _error.setValue(StaccatoUpdateError.StaccatoUpdate(message))
-        }
-
-        companion object {
-            private const val IMAGE_UPLOAD_ERROR_MESSAGE = "이미지 업로드에 실패했습니다."
-            private const val REQUIRED_VALUES_ERROR_MESSAGE = "필수 값을 모두 입력해 주세요."
+    override fun onAddClicked() {
+        if ((currentPhotos.value?.size ?: 0) == StaccatoCreationViewModel.MAX_PHOTO_NUMBER) {
+            _warningMessage.postValue(StaccatoCreationViewModel.MAX_PHOTO_NUMBER_MESSAGE)
+        } else {
+            _isAddPhotoClicked.postValue(true)
         }
     }
+
+    override fun onDeleteClicked(deletedPhoto: AttachedPhotoUiModel) {
+        _currentPhotos.value = currentPhotos.value?.removePhoto(deletedPhoto)
+        if (photoJobs[deletedPhoto.uri.toString()]?.isActive == true) {
+            photoJobs[deletedPhoto.uri.toString()]?.cancel()
+        }
+    }
+
+    fun selectMemory(memory: MemoryCandidate) {
+        _selectedMemory.value = memory
+    }
+
+    fun selectedVisitedAt(visitedAt: LocalDateTime) {
+        _selectedVisitedAt.value = visitedAt
+    }
+
+    fun fetchTargetData(
+        staccatoId: Long,
+        memoryId: Long,
+        memoryTitle: String,
+    ) {
+        targetMemoryId = memoryId
+        fetchMemoryCandidates()
+        fetchStaccatoBy(staccatoId)
+    }
+
+    fun selectNewPlace(
+        placeId: String,
+        name: String,
+        address: String,
+        longitude: Double,
+        latitude: Double,
+    ) {
+        _placeName.value = name
+        _address.value = address
+        _longitude.value = longitude
+        _latitude.value = latitude
+    }
+
+    fun clearPlace() {
+        _placeName.value = null
+        _address.value = null
+        _longitude.value = null
+        _latitude.value = null
+    }
+
+    fun setPlaceByCurrentAddress(
+        address: String?,
+        location: Location,
+    ) {
+        setCurrentLocationLoading(false)
+        _placeName.postValue(address)
+        _address.postValue(address)
+        _latitude.postValue(location.latitude)
+        _longitude.postValue(location.longitude)
+    }
+
+    fun setCurrentLocationLoading(newValue: Boolean) {
+        _isCurrentLocationLoading.postValue(newValue)
+    }
+
+    fun updateSelectedImageUris(newUris: Array<Uri>) {
+        val updatedPhotos = currentPhotos.value!!.addPhotosByUris(newUris.toList())
+        _currentPhotos.value = updatedPhotos
+        _pendingPhotos.postValue(updatedPhotos.getPhotosWithoutUrls())
+    }
+
+    fun setUrisWithNewOrder(list: List<AttachedPhotoUiModel>) {
+        _currentPhotos.value = AttachedPhotosUiModel(list)
+    }
+
+    fun fetchPhotosUrlsByUris(context: Context) {
+        pendingPhotos.getValue()?.forEach { photo ->
+            val job = createPhotoUploadJob(context, photo)
+            job.invokeOnCompletion { _ ->
+                photoJobs.remove(photo.uri.toString())
+            }
+            photoJobs[photo.uri.toString()] = job
+        }
+    }
+
+    fun updateStaccato(staccatoId: Long) {
+        viewModelScope.launch {
+            val staccatoTitleValue = staccatoTitle.get() ?: return@launch handleException()
+            val placeNameValue = placeName.value ?: return@launch handleException()
+            val addressValue = address.value ?: return@launch handleException()
+            val latitudeValue = latitude.value ?: return@launch handleException()
+            val longitudeValue = longitude.value ?: return@launch handleException()
+            val visitedAtValue = selectedVisitedAt.value ?: return@launch handleException()
+            val memoryIdValue = selectedMemory.value?.memoryId ?: return@launch handleException()
+            val staccatoImageUrlsValue =
+                currentPhotos.value?.attachedPhotos?.map { it.imageUrl!! }
+                    ?: emptyList()
+            _isPosting.value = true
+            staccatoRepository.updateStaccato(
+                staccatoId = staccatoId,
+                staccatoTitle = staccatoTitleValue,
+                placeName = placeNameValue,
+                address = addressValue,
+                latitude = latitudeValue,
+                longitude = longitudeValue,
+                visitedAt = visitedAtValue,
+                memoryId = memoryIdValue,
+                staccatoImageUrls = staccatoImageUrlsValue,
+            ).onSuccess {
+                _isUpdateCompleted.postValue(true)
+            }.onException(::handleUpdateException)
+                .onServerError(::handleServerError)
+        }
+    }
+
+    private fun fetchStaccatoBy(staccatoId: Long) {
+        viewModelScope.launch {
+            staccatoRepository.getStaccato(staccatoId = staccatoId)
+                .onSuccess { staccato ->
+                    staccatoTitle.set(staccato.staccatoTitle)
+                    _address.value = staccato.address
+                    _latitude.value = staccato.latitude
+                    _longitude.value = staccato.longitude
+                    _selectedVisitedAt.value = staccato.visitedAt
+                    _placeName.value = staccato.placeName
+                    _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
+                    _selectedMemory.value =
+                        MemoryCandidate(
+                            staccato.memoryId,
+                            staccato.memoryTitle,
+                            staccato.startAt,
+                            staccato.endAt,
+                        )
+                }.onException(::handleInitializeException)
+                .onServerError(::handleServerError)
+        }
+    }
+
+    private fun fetchMemoryCandidates() {
+        viewModelScope.launch {
+            timelineRepository.getMemoryCandidates()
+                .onSuccess { memoryCandidates ->
+                    _memoryCandidates.value = memoryCandidates
+                }.onException(::handleMemoryCandidatesException)
+                .onServerError(::handleServerError)
+        }
+    }
+
+    private fun createPhotoUploadJob(
+        context: Context,
+        photo: AttachedPhotoUiModel,
+    ) = viewModelScope.async(buildCoroutineExceptionHandler()) {
+        val multiPartBody =
+            convertExcretaFile(
+                context,
+                photo.uri,
+                StaccatoCreationViewModel.FORM_DATA_NAME,
+            )
+        imageRepository.convertImageFileToUrl(multiPartBody)
+            .onSuccess {
+                updatePhotoWithUrl(photo, it.imageUrl)
+            }.onException { e, message ->
+                if (this.isActive) handleUpdatePhotoException(e, message)
+            }
+            .onServerError(::handleServerError)
+    }
+
+    private fun buildCoroutineExceptionHandler(): CoroutineExceptionHandler {
+        return CoroutineExceptionHandler { _, throwable ->
+            _warningMessage.postValue(throwable.message ?: FAIL_IMAGE_UPLOAD_MESSAGE)
+        }
+    }
+
+    private fun updatePhotoWithUrl(
+        targetPhoto: AttachedPhotoUiModel,
+        url: String,
+    ) {
+        val updatedPhoto = targetPhoto.updateUrl(url)
+        _currentPhotos.value = currentPhotos.value?.updateOrAppendPhoto(updatedPhoto)
+    }
+
+    private fun handleServerError(
+        status: Status,
+        message: String,
+    ) {
+        _isPosting.value = false
+        _warningMessage.setValue(message)
+    }
+
+    private fun handleUpdatePhotoException(
+        e: Throwable = IllegalArgumentException(),
+        errorMessage: String = IMAGE_UPLOAD_ERROR_MESSAGE,
+    ) {
+        _warningMessage.setValue(errorMessage)
+    }
+
+    private fun handleException(
+        e: Throwable = IllegalArgumentException(),
+        errorMessage: String = REQUIRED_VALUES_ERROR_MESSAGE,
+    ) {
+        _isPosting.value = false
+        _warningMessage.setValue(errorMessage)
+    }
+
+    private fun handleMemoryCandidatesException(
+        e: Throwable,
+        message: String,
+    ) {
+        _error.setValue(StaccatoUpdateError.MemoryCandidates(message))
+    }
+
+    private fun handleInitializeException(
+        e: Throwable,
+        message: String,
+    ) {
+        _error.setValue(StaccatoUpdateError.StaccatoInitialize(message))
+    }
+
+    private fun handleUpdateException(
+        e: Throwable = IllegalArgumentException(),
+        message: String = REQUIRED_VALUES_ERROR_MESSAGE,
+    ) {
+        _isPosting.value = false
+        _error.setValue(StaccatoUpdateError.StaccatoUpdate(message))
+    }
+
+    companion object {
+        private const val IMAGE_UPLOAD_ERROR_MESSAGE = "이미지 업로드에 실패했습니다."
+        private const val REQUIRED_VALUES_ERROR_MESSAGE = "필수 값을 모두 입력해 주세요."
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -38,295 +38,295 @@ import javax.inject.Inject
 
 @HiltViewModel
 class StaccatoUpdateViewModel
-@Inject
-constructor(
-    private val timelineRepository: TimelineRepository,
-    private val staccatoRepository: StaccatoRepository,
-    private val imageRepository: ImageRepository,
-) : AttachedPhotoHandler, ViewModel() {
-    val staccatoTitle = ObservableField<String>()
+    @Inject
+    constructor(
+        private val timelineRepository: TimelineRepository,
+        private val staccatoRepository: StaccatoRepository,
+        private val imageRepository: ImageRepository,
+    ) : AttachedPhotoHandler, ViewModel() {
+        val staccatoTitle = ObservableField<String>()
 
-    private val _placeName = MutableLiveData<String?>(null)
-    val placeName: LiveData<String?> get() = _placeName
+        private val _placeName = MutableLiveData<String?>(null)
+        val placeName: LiveData<String?> get() = _placeName
 
-    private val _address = MutableLiveData<String?>(null)
-    val address: LiveData<String?> get() = _address
+        private val _address = MutableLiveData<String?>(null)
+        val address: LiveData<String?> get() = _address
 
-    private val _currentPhotos =
-        MutableLiveData(AttachedPhotosUiModel(emptyList()))
-    val currentPhotos: LiveData<AttachedPhotosUiModel> get() = _currentPhotos
+        private val _currentPhotos =
+            MutableLiveData(AttachedPhotosUiModel(emptyList()))
+        val currentPhotos: LiveData<AttachedPhotosUiModel> get() = _currentPhotos
 
-    private val _pendingPhotos = MutableSingleLiveData<List<AttachedPhotoUiModel>>()
-    val pendingPhotos: SingleLiveData<List<AttachedPhotoUiModel>> get() = _pendingPhotos
+        private val _pendingPhotos = MutableSingleLiveData<List<AttachedPhotoUiModel>>()
+        val pendingPhotos: SingleLiveData<List<AttachedPhotoUiModel>> get() = _pendingPhotos
 
-    private val _latitude = MutableLiveData<Double?>()
-    private val latitude: LiveData<Double?> get() = _latitude
+        private val _latitude = MutableLiveData<Double?>()
+        private val latitude: LiveData<Double?> get() = _latitude
 
-    private val _longitude = MutableLiveData<Double?>()
-    private val longitude: LiveData<Double?> get() = _longitude
+        private val _longitude = MutableLiveData<Double?>()
+        private val longitude: LiveData<Double?> get() = _longitude
 
-    private val _memoryCandidates = MutableLiveData<MemoryCandidates>()
-    val memoryCandidates: LiveData<MemoryCandidates> get() = _memoryCandidates
+        private val _memoryCandidates = MutableLiveData<MemoryCandidates>()
+        val memoryCandidates: LiveData<MemoryCandidates> get() = _memoryCandidates
 
-    private val _selectedVisitedAt = MutableLiveData<LocalDateTime?>()
-    val selectedVisitedAt: LiveData<LocalDateTime?> get() = _selectedVisitedAt
+        private val _selectedVisitedAt = MutableLiveData<LocalDateTime?>()
+        val selectedVisitedAt: LiveData<LocalDateTime?> get() = _selectedVisitedAt
 
-    private val _isCurrentLocationLoading = MutableLiveData(false)
-    val isCurrentLocationLoading: LiveData<Boolean> get() = _isCurrentLocationLoading
+        private val _isCurrentLocationLoading = MutableLiveData(false)
+        val isCurrentLocationLoading: LiveData<Boolean> get() = _isCurrentLocationLoading
 
-    private var targetMemoryId: Long = 0
+        private var targetMemoryId: Long = 0
 
-    private val _selectedMemory = MutableLiveData<MemoryCandidate>()
-    val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
+        private val _selectedMemory = MutableLiveData<MemoryCandidate>()
+        val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
 
-    private val _isUpdateCompleted = MutableLiveData(false)
-    val isUpdateCompleted: LiveData<Boolean> get() = _isUpdateCompleted
+        private val _isUpdateCompleted = MutableLiveData(false)
+        val isUpdateCompleted: LiveData<Boolean> get() = _isUpdateCompleted
 
-    private val _isPosting = MutableLiveData<Boolean>(false)
-    val isPosting: LiveData<Boolean> get() = _isPosting
+        private val _isPosting = MutableLiveData<Boolean>(false)
+        val isPosting: LiveData<Boolean> get() = _isPosting
 
-    private val _isAddPhotoClicked = MutableSingleLiveData(false)
-    val isAddPhotoClicked: SingleLiveData<Boolean> get() = _isAddPhotoClicked
+        private val _isAddPhotoClicked = MutableSingleLiveData(false)
+        val isAddPhotoClicked: SingleLiveData<Boolean> get() = _isAddPhotoClicked
 
-    private val photoJobs = mutableMapOf<String, Job>()
+        private val photoJobs = mutableMapOf<String, Job>()
 
-    private val _warningMessage = MutableSingleLiveData<String>()
-    val warningMessage: SingleLiveData<String> get() = _warningMessage
+        private val _warningMessage = MutableSingleLiveData<String>()
+        val warningMessage: SingleLiveData<String> get() = _warningMessage
 
-    private val _error = MutableSingleLiveData<StaccatoUpdateError>()
-    val error: SingleLiveData<StaccatoUpdateError> get() = _error
+        private val _error = MutableSingleLiveData<StaccatoUpdateError>()
+        val error: SingleLiveData<StaccatoUpdateError> get() = _error
 
-    override fun onAddClicked() {
-        if ((currentPhotos.value?.size ?: 0) == StaccatoCreationViewModel.MAX_PHOTO_NUMBER) {
-            _warningMessage.postValue(StaccatoCreationViewModel.MAX_PHOTO_NUMBER_MESSAGE)
-        } else {
-            _isAddPhotoClicked.postValue(true)
-        }
-    }
-
-    override fun onDeleteClicked(deletedPhoto: AttachedPhotoUiModel) {
-        _currentPhotos.value = currentPhotos.value?.removePhoto(deletedPhoto)
-        if (photoJobs[deletedPhoto.uri.toString()]?.isActive == true) {
-            photoJobs[deletedPhoto.uri.toString()]?.cancel()
-        }
-    }
-
-    fun selectMemory(memory: MemoryCandidate) {
-        _selectedMemory.value = memory
-    }
-
-    fun selectedVisitedAt(visitedAt: LocalDateTime) {
-        _selectedVisitedAt.value = visitedAt
-    }
-
-    fun fetchTargetData(
-        staccatoId: Long,
-        memoryId: Long,
-        memoryTitle: String,
-    ) {
-        targetMemoryId = memoryId
-        fetchMemoryCandidates()
-        fetchStaccatoBy(staccatoId)
-    }
-
-    fun selectNewPlace(
-        placeId: String,
-        name: String,
-        address: String,
-        longitude: Double,
-        latitude: Double,
-    ) {
-        _placeName.value = name
-        _address.value = address
-        _longitude.value = longitude
-        _latitude.value = latitude
-    }
-
-    fun clearPlace() {
-        _placeName.value = null
-        _address.value = null
-        _longitude.value = null
-        _latitude.value = null
-    }
-
-    fun setPlaceByCurrentAddress(
-        address: String?,
-        location: Location,
-    ) {
-        setCurrentLocationLoading(false)
-        _placeName.postValue(address)
-        _address.postValue(address)
-        _latitude.postValue(location.latitude)
-        _longitude.postValue(location.longitude)
-    }
-
-    fun setCurrentLocationLoading(newValue: Boolean) {
-        _isCurrentLocationLoading.postValue(newValue)
-    }
-
-    fun updateSelectedImageUris(newUris: Array<Uri>) {
-        val updatedPhotos = currentPhotos.value!!.addPhotosByUris(newUris.toList())
-        _currentPhotos.value = updatedPhotos
-        _pendingPhotos.postValue(updatedPhotos.getPhotosWithoutUrls())
-    }
-
-    fun setUrisWithNewOrder(list: List<AttachedPhotoUiModel>) {
-        _currentPhotos.value = AttachedPhotosUiModel(list)
-    }
-
-    fun fetchPhotosUrlsByUris(context: Context) {
-        pendingPhotos.getValue()?.forEach { photo ->
-            val job = createPhotoUploadJob(context, photo)
-            job.invokeOnCompletion { _ ->
-                photoJobs.remove(photo.uri.toString())
+        override fun onAddClicked() {
+            if ((currentPhotos.value?.size ?: 0) == StaccatoCreationViewModel.MAX_PHOTO_NUMBER) {
+                _warningMessage.postValue(StaccatoCreationViewModel.MAX_PHOTO_NUMBER_MESSAGE)
+            } else {
+                _isAddPhotoClicked.postValue(true)
             }
-            photoJobs[photo.uri.toString()] = job
         }
-    }
 
-    fun updateStaccato(staccatoId: Long) {
-        viewModelScope.launch {
-            val staccatoTitleValue = staccatoTitle.get() ?: return@launch handleException()
-            val placeNameValue = placeName.value ?: return@launch handleException()
-            val addressValue = address.value ?: return@launch handleException()
-            val latitudeValue = latitude.value ?: return@launch handleException()
-            val longitudeValue = longitude.value ?: return@launch handleException()
-            val visitedAtValue = selectedVisitedAt.value ?: return@launch handleException()
-            val memoryIdValue = selectedMemory.value?.memoryId ?: return@launch handleException()
-            val staccatoImageUrlsValue =
-                currentPhotos.value?.attachedPhotos?.map { it.imageUrl!! }
-                    ?: emptyList()
-            _isPosting.value = true
-            staccatoRepository.updateStaccato(
-                staccatoId = staccatoId,
-                staccatoTitle = staccatoTitleValue,
-                placeName = placeNameValue,
-                address = addressValue,
-                latitude = latitudeValue,
-                longitude = longitudeValue,
-                visitedAt = visitedAtValue,
-                memoryId = memoryIdValue,
-                staccatoImageUrls = staccatoImageUrlsValue,
-            ).onSuccess {
-                _isUpdateCompleted.postValue(true)
-            }.onException(::handleUpdateException)
-                .onServerError(::handleServerError)
-        }
-    }
-
-    private fun fetchStaccatoBy(staccatoId: Long) {
-        viewModelScope.launch {
-            staccatoRepository.getStaccato(staccatoId = staccatoId)
-                .onSuccess { staccato ->
-                    staccatoTitle.set(staccato.staccatoTitle)
-                    _address.value = staccato.address
-                    _latitude.value = staccato.latitude
-                    _longitude.value = staccato.longitude
-                    _selectedVisitedAt.value = staccato.visitedAt
-                    _placeName.value = staccato.placeName
-                    _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
-                    _selectedMemory.value =
-                        MemoryCandidate(
-                            staccato.memoryId,
-                            staccato.memoryTitle,
-                            staccato.startAt,
-                            staccato.endAt,
-                        )
-                }.onException(::handleInitializeException)
-                .onServerError(::handleServerError)
-        }
-    }
-
-    private fun fetchMemoryCandidates() {
-        viewModelScope.launch {
-            timelineRepository.getMemoryCandidates()
-                .onSuccess { memoryCandidates ->
-                    _memoryCandidates.value = memoryCandidates
-                }.onException(::handleMemoryCandidatesException)
-                .onServerError(::handleServerError)
-        }
-    }
-
-    private fun createPhotoUploadJob(
-        context: Context,
-        photo: AttachedPhotoUiModel,
-    ) = viewModelScope.async(buildCoroutineExceptionHandler()) {
-        val multiPartBody =
-            convertExcretaFile(
-                context,
-                photo.uri,
-                StaccatoCreationViewModel.FORM_DATA_NAME,
-            )
-        imageRepository.convertImageFileToUrl(multiPartBody)
-            .onSuccess {
-                updatePhotoWithUrl(photo, it.imageUrl)
-            }.onException { e, message ->
-                if (this.isActive) handleUpdatePhotoException(e, message)
+        override fun onDeleteClicked(deletedPhoto: AttachedPhotoUiModel) {
+            _currentPhotos.value = currentPhotos.value?.removePhoto(deletedPhoto)
+            if (photoJobs[deletedPhoto.uri.toString()]?.isActive == true) {
+                photoJobs[deletedPhoto.uri.toString()]?.cancel()
             }
-            .onServerError(::handleServerError)
-    }
+        }
 
-    private fun buildCoroutineExceptionHandler(): CoroutineExceptionHandler {
-        return CoroutineExceptionHandler { _, throwable ->
-            _warningMessage.postValue(throwable.message ?: FAIL_IMAGE_UPLOAD_MESSAGE)
+        fun selectMemory(memory: MemoryCandidate) {
+            _selectedMemory.value = memory
+        }
+
+        fun selectedVisitedAt(visitedAt: LocalDateTime) {
+            _selectedVisitedAt.value = visitedAt
+        }
+
+        fun fetchTargetData(
+            staccatoId: Long,
+            memoryId: Long,
+            memoryTitle: String,
+        ) {
+            targetMemoryId = memoryId
+            fetchMemoryCandidates()
+            fetchStaccatoBy(staccatoId)
+        }
+
+        fun selectNewPlace(
+            placeId: String,
+            name: String,
+            address: String,
+            longitude: Double,
+            latitude: Double,
+        ) {
+            _placeName.value = name
+            _address.value = address
+            _longitude.value = longitude
+            _latitude.value = latitude
+        }
+
+        fun clearPlace() {
+            _placeName.value = null
+            _address.value = null
+            _longitude.value = null
+            _latitude.value = null
+        }
+
+        fun setPlaceByCurrentAddress(
+            address: String?,
+            location: Location,
+        ) {
+            setCurrentLocationLoading(false)
+            _placeName.postValue(address)
+            _address.postValue(address)
+            _latitude.postValue(location.latitude)
+            _longitude.postValue(location.longitude)
+        }
+
+        fun setCurrentLocationLoading(newValue: Boolean) {
+            _isCurrentLocationLoading.postValue(newValue)
+        }
+
+        fun updateSelectedImageUris(newUris: Array<Uri>) {
+            val updatedPhotos = currentPhotos.value!!.addPhotosByUris(newUris.toList())
+            _currentPhotos.value = updatedPhotos
+            _pendingPhotos.postValue(updatedPhotos.getPhotosWithoutUrls())
+        }
+
+        fun setUrisWithNewOrder(list: List<AttachedPhotoUiModel>) {
+            _currentPhotos.value = AttachedPhotosUiModel(list)
+        }
+
+        fun fetchPhotosUrlsByUris(context: Context) {
+            pendingPhotos.getValue()?.forEach { photo ->
+                val job = createPhotoUploadJob(context, photo)
+                job.invokeOnCompletion { _ ->
+                    photoJobs.remove(photo.uri.toString())
+                }
+                photoJobs[photo.uri.toString()] = job
+            }
+        }
+
+        fun updateStaccato(staccatoId: Long) {
+            viewModelScope.launch {
+                val staccatoTitleValue = staccatoTitle.get() ?: return@launch handleException()
+                val placeNameValue = placeName.value ?: return@launch handleException()
+                val addressValue = address.value ?: return@launch handleException()
+                val latitudeValue = latitude.value ?: return@launch handleException()
+                val longitudeValue = longitude.value ?: return@launch handleException()
+                val visitedAtValue = selectedVisitedAt.value ?: return@launch handleException()
+                val memoryIdValue = selectedMemory.value?.memoryId ?: return@launch handleException()
+                val staccatoImageUrlsValue =
+                    currentPhotos.value?.attachedPhotos?.map { it.imageUrl!! }
+                        ?: emptyList()
+                _isPosting.value = true
+                staccatoRepository.updateStaccato(
+                    staccatoId = staccatoId,
+                    staccatoTitle = staccatoTitleValue,
+                    placeName = placeNameValue,
+                    address = addressValue,
+                    latitude = latitudeValue,
+                    longitude = longitudeValue,
+                    visitedAt = visitedAtValue,
+                    memoryId = memoryIdValue,
+                    staccatoImageUrls = staccatoImageUrlsValue,
+                ).onSuccess {
+                    _isUpdateCompleted.postValue(true)
+                }.onException(::handleUpdateException)
+                    .onServerError(::handleServerError)
+            }
+        }
+
+        private fun fetchStaccatoBy(staccatoId: Long) {
+            viewModelScope.launch {
+                staccatoRepository.getStaccato(staccatoId = staccatoId)
+                    .onSuccess { staccato ->
+                        staccatoTitle.set(staccato.staccatoTitle)
+                        _address.value = staccato.address
+                        _latitude.value = staccato.latitude
+                        _longitude.value = staccato.longitude
+                        _selectedVisitedAt.value = staccato.visitedAt
+                        _placeName.value = staccato.placeName
+                        _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
+                        _selectedMemory.value =
+                            MemoryCandidate(
+                                staccato.memoryId,
+                                staccato.memoryTitle,
+                                staccato.startAt,
+                                staccato.endAt,
+                            )
+                    }.onException(::handleInitializeException)
+                    .onServerError(::handleServerError)
+            }
+        }
+
+        private fun fetchMemoryCandidates() {
+            viewModelScope.launch {
+                timelineRepository.getMemoryCandidates()
+                    .onSuccess { memoryCandidates ->
+                        _memoryCandidates.value = memoryCandidates
+                    }.onException(::handleMemoryCandidatesException)
+                    .onServerError(::handleServerError)
+            }
+        }
+
+        private fun createPhotoUploadJob(
+            context: Context,
+            photo: AttachedPhotoUiModel,
+        ) = viewModelScope.async(buildCoroutineExceptionHandler()) {
+            val multiPartBody =
+                convertExcretaFile(
+                    context,
+                    photo.uri,
+                    StaccatoCreationViewModel.FORM_DATA_NAME,
+                )
+            imageRepository.convertImageFileToUrl(multiPartBody)
+                .onSuccess {
+                    updatePhotoWithUrl(photo, it.imageUrl)
+                }.onException { e, message ->
+                    if (this.isActive) handleUpdatePhotoException(e, message)
+                }
+                .onServerError(::handleServerError)
+        }
+
+        private fun buildCoroutineExceptionHandler(): CoroutineExceptionHandler {
+            return CoroutineExceptionHandler { _, throwable ->
+                _warningMessage.postValue(throwable.message ?: FAIL_IMAGE_UPLOAD_MESSAGE)
+            }
+        }
+
+        private fun updatePhotoWithUrl(
+            targetPhoto: AttachedPhotoUiModel,
+            url: String,
+        ) {
+            val updatedPhoto = targetPhoto.updateUrl(url)
+            _currentPhotos.value = currentPhotos.value?.updateOrAppendPhoto(updatedPhoto)
+        }
+
+        private fun handleServerError(
+            status: Status,
+            message: String,
+        ) {
+            _isPosting.value = false
+            _warningMessage.setValue(message)
+        }
+
+        private fun handleUpdatePhotoException(
+            e: Throwable = IllegalArgumentException(),
+            errorMessage: String = IMAGE_UPLOAD_ERROR_MESSAGE,
+        ) {
+            _warningMessage.setValue(errorMessage)
+        }
+
+        private fun handleException(
+            e: Throwable = IllegalArgumentException(),
+            errorMessage: String = REQUIRED_VALUES_ERROR_MESSAGE,
+        ) {
+            _isPosting.value = false
+            _warningMessage.setValue(errorMessage)
+        }
+
+        private fun handleMemoryCandidatesException(
+            e: Throwable,
+            message: String,
+        ) {
+            _error.setValue(StaccatoUpdateError.MemoryCandidates(message))
+        }
+
+        private fun handleInitializeException(
+            e: Throwable,
+            message: String,
+        ) {
+            _error.setValue(StaccatoUpdateError.StaccatoInitialize(message))
+        }
+
+        private fun handleUpdateException(
+            e: Throwable = IllegalArgumentException(),
+            message: String = REQUIRED_VALUES_ERROR_MESSAGE,
+        ) {
+            _isPosting.value = false
+            _error.setValue(StaccatoUpdateError.StaccatoUpdate(message))
+        }
+
+        companion object {
+            private const val IMAGE_UPLOAD_ERROR_MESSAGE = "이미지 업로드에 실패했습니다."
+            private const val REQUIRED_VALUES_ERROR_MESSAGE = "필수 값을 모두 입력해 주세요."
         }
     }
-
-    private fun updatePhotoWithUrl(
-        targetPhoto: AttachedPhotoUiModel,
-        url: String,
-    ) {
-        val updatedPhoto = targetPhoto.updateUrl(url)
-        _currentPhotos.value = currentPhotos.value?.updateOrAppendPhoto(updatedPhoto)
-    }
-
-    private fun handleServerError(
-        status: Status,
-        message: String,
-    ) {
-        _isPosting.value = false
-        _warningMessage.setValue(message)
-    }
-
-    private fun handleUpdatePhotoException(
-        e: Throwable = IllegalArgumentException(),
-        errorMessage: String = IMAGE_UPLOAD_ERROR_MESSAGE,
-    ) {
-        _warningMessage.setValue(errorMessage)
-    }
-
-    private fun handleException(
-        e: Throwable = IllegalArgumentException(),
-        errorMessage: String = REQUIRED_VALUES_ERROR_MESSAGE,
-    ) {
-        _isPosting.value = false
-        _warningMessage.setValue(errorMessage)
-    }
-
-    private fun handleMemoryCandidatesException(
-        e: Throwable,
-        message: String,
-    ) {
-        _error.setValue(StaccatoUpdateError.MemoryCandidates(message))
-    }
-
-    private fun handleInitializeException(
-        e: Throwable,
-        message: String,
-    ) {
-        _error.setValue(StaccatoUpdateError.StaccatoInitialize(message))
-    }
-
-    private fun handleUpdateException(
-        e: Throwable = IllegalArgumentException(),
-        message: String = REQUIRED_VALUES_ERROR_MESSAGE,
-    ) {
-        _isPosting.value = false
-        _error.setValue(StaccatoUpdateError.StaccatoUpdate(message))
-    }
-
-    companion object {
-        private const val IMAGE_UPLOAD_ERROR_MESSAGE = "이미지 업로드에 실패했습니다."
-        private const val REQUIRED_VALUES_ERROR_MESSAGE = "필수 값을 모두 입력해 주세요."
-    }
-}

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -167,11 +167,12 @@
     <string name="photo_attach_title">사진을 등록해 주세요</string>
     <string name="photo_attach_camera">카메라 열기</string>
     <string name="photo_attach_album">앨범에서 가져오기</string>
-    <string name="snack_bar_require_photo_album_permission">카메라와 사진 및 동영상 접근 권한이 필요합니다.\n설정에서 권한을 허용해 주세요.</string>
-    <string name="snack_bar_camera_error">카메라 실행 중 에러가 발생했습니다.\n잠시 후에 다시 시도해주세요.</string>
-    <string name="snack_bar_gallery_error">사진을 불러올 수 없습니다.\n잠시 후에 다시 시도해주세요.</string>
+    <string name="photo_require_camera_permission">카메라 권한을 허용해 주세요.</string>
+    <string name="photo_require_photo_album_permission">사진 접근 권한을 허용해 주세요.</string>
+    <string name="snack_bar_camera_error">카메라 실행 중 에러가 발생했습니다.\n잠시 후에 다시 시도해 주세요.</string>
+    <string name="snack_bar_gallery_error">사진을 불러올 수 없습니다.\n잠시 후에 다시 시도해 주세요.</string>
     <string name="snack_bar_no_camera">실행할 수 있는 카메라 앱이 없습니다.</string>
-    <string name="snack_bar_move_to_setting">설정으로 이동하기</string>
+    <string name="snack_bar_move_to_setting">설정하기</string>
 
     // dialog_delete_impossibility
     <string name="memory_delete_title">추억을 삭제할 수 없어요.</string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #536

## 🚩 Summary

- [x] 카메라와 사진 권한 메시지 분리
- [x] API 33 이상에서 `MediaStore.ACTION_PICK_IMAGES` 적용
- [x] `MediaStore.ACTION_PICK_IMAGES`사용 중 사진을 여러 장 선택하는 경우 앨범에서 최대 선택 가능 수 제한
- [x] `imageRepository.convertImageFileToUrl`에서 예외 반환 시 isActive로 취소 예외 무시

## 🛠️ Technical Concerns

### 작업 1 (feat) : 안드로이드 API 33 이상에서 `MediaStore.ACTION_PICK_IMAGES` 적용

|ACTION_PICK_IMAGES|ACTION_PICK_IMAGES(사진 수 경고)|앨범|
|---|---|---|
|<img src="https://github.com/user-attachments/assets/e2c5f20c-7a88-4a46-85a8-0c2809aae50a" width="230" />|<img src="https://github.com/user-attachments/assets/2d8554c8-4f97-418d-958f-cd0c4f4d0a65" width="230" />|<img src="https://github.com/user-attachments/assets/c1103c26-a907-4949-8ad2-7898063ef3ae" width="230" />|

티라미수 이상 버전에서는 권한이 없어도 `MediaStore.ACTION_PICK_IMAGES`로 기기의 사진 파일에 접근 가능합니다.
해당 작업으로 얻을 수 있는 이점은 다음과 같습니다.

1. **권한이 없어도 사진**을 불러올 수 있음. (권한이 있다면 그대로 앨범으로 접근)
2. `MediaStore.ACTION_PICK_IMAGES`에서 **선택 가능한 사진 장 수 제한 가능**

---

### 작업 2 (fix) : 스타카토 생성/수정 화면 사진 삭제 시 코루틴 취소 예외 처리

* 버그 영상

https://github.com/user-attachments/assets/d097749d-3a66-4091-b9eb-c6f6d6255fe4

코루틴 Job은 취소 시 내부의 중단 가능 지점(suspend fun)에서 `JobCancellationException`를 발생시킵니다.
직전의 네트워크 에러 핸들링 작업에서 모든 예외를 '네트워크 불안정'으로 처리하였습니다.
따라서 무시되고 있던 해당 예외가 잘못 핸들링 되며 나타난 버그로 보여집니다.

```kotlin
if (this.isActive) handleException(e, message)
```

위 코드 처럼 예외 핸들링 지점에서 `isActive`를 검사해 코루틴 취소 예외는 무시되도록 수정했습니다.

## 🙂 To Reviewer
> 예외 핸들링 지점에서 `isActive`를 검사해 코루틴 취소 예외는 무시되도록 수정했습니다.

적절한 방법일지에 대해 의논해 보면 좋을 것 같아요~