### PR TITLE
refactor: comments api uri 수정 #544

### DIFF
--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -1,21 +1,18 @@
 package com.staccato.comment.controller;
 
 import java.net.URI;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.comment.controller.docs.CommentControllerDocs;
 import com.staccato.comment.service.CommentService;
 import com.staccato.comment.service.dto.request.CommentRequest;
@@ -24,18 +21,16 @@ import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
 @RestController
-@RequestMapping("/comments")
 @RequiredArgsConstructor
 @Validated
 public class CommentController implements CommentControllerDocs {
     private final CommentService commentService;
 
-    @PostMapping
+    @PostMapping("/comments")
     public ResponseEntity<Void> createComment(
             @LoginMember Member member,
             @Valid @RequestBody CommentRequest commentRequest
@@ -45,7 +40,7 @@ public class CommentController implements CommentControllerDocs {
                 .build();
     }
 
-    @GetMapping
+    @GetMapping("/comments")
     public ResponseEntity<CommentResponses> readCommentsByMomentId(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.") long momentId
@@ -54,7 +49,7 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().body(commentResponses);
     }
 
-    @PutMapping
+    @PutMapping("/comments")
     public ResponseEntity<Void> updateComment(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
@@ -64,9 +59,28 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping
+    @PutMapping("/v2/comments/{commentId}")
+    public ResponseEntity<Void> updateCommentV2(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @Valid @RequestBody CommentUpdateRequest commentUpdateRequest
+    ) {
+        commentService.updateComment(member, commentId, commentUpdateRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/comments")
     public ResponseEntity<Void> deleteComment(
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @LoginMember Member member
+    ) {
+        commentService.deleteComment(commentId, member);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/v2/comments/{commentId}")
+    public ResponseEntity<Void> deleteCommentV2(
+            @PathVariable @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
             @LoginMember Member member
     ) {
         commentService.deleteComment(commentId, member);

--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.staccato.comment.controller.docs.CommentControllerDocs;
@@ -25,12 +26,13 @@ import lombok.RequiredArgsConstructor;
 
 @Trace
 @RestController
+@RequestMapping("/comments")
 @RequiredArgsConstructor
 @Validated
 public class CommentController implements CommentControllerDocs {
     private final CommentService commentService;
 
-    @PostMapping("/comments")
+    @PostMapping
     public ResponseEntity<Void> createComment(
             @LoginMember Member member,
             @Valid @RequestBody CommentRequest commentRequest
@@ -40,7 +42,7 @@ public class CommentController implements CommentControllerDocs {
                 .build();
     }
 
-    @GetMapping("/comments")
+    @GetMapping
     public ResponseEntity<CommentResponses> readCommentsByMomentId(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.") long momentId
@@ -49,7 +51,7 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().body(commentResponses);
     }
 
-    @PutMapping("/comments")
+    @PutMapping
     public ResponseEntity<Void> updateComment(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
@@ -59,7 +61,7 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-    @PutMapping("/v2/comments/{commentId}")
+    @PutMapping("/v2/{commentId}")
     public ResponseEntity<Void> updateCommentV2(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
@@ -69,7 +71,7 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/comments")
+    @DeleteMapping
     public ResponseEntity<Void> deleteComment(
             @RequestParam @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
             @LoginMember Member member
@@ -78,7 +80,7 @@ public class CommentController implements CommentControllerDocs {
         return ResponseEntity.ok().build();
     }
 
-    @DeleteMapping("/v2/comments/{commentId}")
+    @DeleteMapping("/v2/{commentId}")
     public ResponseEntity<Void> deleteCommentV2(
             @PathVariable @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
             @LoginMember Member member

--- a/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
+++ b/backend/src/main/java/com/staccato/comment/controller/docs/CommentControllerDocs.java
@@ -2,14 +2,11 @@ package com.staccato.comment.controller.docs;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
-
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.member.domain.Member;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -70,6 +67,28 @@ public interface CommentControllerDocs {
             @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
             @Parameter(description = "댓글 수정 시 요구 형식") @Valid CommentUpdateRequest commentUpdateRequest);
 
+    @Operation(summary = "댓글 수정", description = "댓글을 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "댓글 수정 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                                        
+                    (1) 댓글 식별자가 양수가 아닐 때
+                                        
+                    (2) 요청한 댓글을 찾을 수 없을 때
+                                        
+                    (3) 댓글 내용이 공백 뿐이거나 없을 때
+                                        
+                    (4) 댓글이 공백 포함 500자 초과일 때
+                    """,
+                    responseCode = "400")
+    })
+    public ResponseEntity<Void> updateCommentV2(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @Parameter(description = "댓글 수정 시 요구 형식") @Valid CommentUpdateRequest commentUpdateRequest
+    );
+
     @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "댓글 삭제 성공", responseCode = "200"),
@@ -78,4 +97,14 @@ public interface CommentControllerDocs {
     ResponseEntity<Void> deleteComment(
             @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
             @Parameter(hidden = true) Member member);
+
+    @Operation(summary = "댓글 삭제", description = "댓글을 삭제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "댓글 삭제 성공", responseCode = "200"),
+            @ApiResponse(description = "댓글 식별자가 양수가 아닐 시 댓글 삭제 실패", responseCode = "400")
+    })
+    public ResponseEntity<Void> deleteCommentV2(
+            @Parameter(description = "댓글 식별자", example = "1") @Min(value = 1L, message = "댓글 식별자는 양수로 이루어져야 합니다.") long commentId,
+            @Parameter(hidden = true) Member member
+    );
 }

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -185,7 +185,7 @@ public class CommentControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(put("/v2/comments/{commentId}", 1)
+        mockMvc.perform(put("/comments/v2/{commentId}", 1)
                         .content(commentUpdateRequest)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
@@ -243,7 +243,7 @@ public class CommentControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());
 
-        mockMvc.perform(delete("/v2/comments/{commentId}", 1)
+        mockMvc.perform(delete("/comments/v2/{commentId}", 1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -184,6 +184,12 @@ public class CommentControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());
+
+        mockMvc.perform(put("/v2/comments/{commentId}", 1)
+                        .content(commentUpdateRequest)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk());
     }
 
     @DisplayName("댓글 식별자가 양수가 아닐 경우 댓글 수정에 실패한다.")
@@ -233,6 +239,11 @@ public class CommentControllerTest {
         // when & then
         mockMvc.perform(delete("/comments")
                         .param("commentId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(delete("/v2/comments/{commentId}", 1)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk());


### PR DESCRIPTION
## ⭐️ Issue Number
- #544 

## 🚩 Summary
- `PUT/DELETE /v2/comments/{commentId}`형태의 API로 버저닝하였습니다.
- comments를 필터링하는 것이 아닌 특정 식별자를 가진 자원을 접근하는 것이므로 path varaible 형태를 사용하도록 구현하였습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
- 안드로이드 반영