### PR TITLE
refactor: 스타카토 목록 조회 시 최신순 정렬

### DIFF
--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -74,7 +74,7 @@ public class MemoryService {
     public MemoryDetailResponse readMemoryById(long memoryId, Member member) {
         Memory memory = getMemoryById(memoryId);
         validateOwner(memory, member);
-        List<MomentResponse> momentResponses = getMomentResponses(momentRepository.findAllByMemoryIdOrderByVisitedAt(memoryId));
+        List<MomentResponse> momentResponses = getMomentResponses(momentRepository.findAllByMemoryIdOrderByVisitedAtDesc(memoryId));
         return new MemoryDetailResponse(memory, momentResponses);
     }
 
@@ -99,7 +99,7 @@ public class MemoryService {
         if (originMemory.isNotSameTitle(memoryRequest.memoryTitle())) {
             validateMemoryTitle(updatedMemory, member);
         }
-        List<Moment> moments = momentRepository.findAllByMemoryIdOrderByVisitedAt(memoryId);
+        List<Moment> moments = momentRepository.findAllByMemoryIdOrderByVisitedAtDesc(memoryId);
         originMemory.update(updatedMemory, moments);
     }
 

--- a/backend/src/main/java/com/staccato/moment/repository/MomentRepository.java
+++ b/backend/src/main/java/com/staccato/moment/repository/MomentRepository.java
@@ -9,7 +9,7 @@ import com.staccato.member.domain.Member;
 import com.staccato.moment.domain.Moment;
 
 public interface MomentRepository extends JpaRepository<Moment, Long> {
-    List<Moment> findAllByMemoryIdOrderByVisitedAt(long memoryId);
+    List<Moment> findAllByMemoryIdOrderByVisitedAtDesc(long memoryId);
 
     List<Moment> findAllByMemory_MemoryMembers_Member(Member member);
 

--- a/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryServiceTest.java
@@ -239,7 +239,7 @@ class MemoryServiceTest extends ServiceSliceTest {
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
     }
 
-    @DisplayName("특정 추억을 조회하면 스타카토는 오래된 순으로 반환한다.")
+    @DisplayName("특정 추억을 조회하면 스타카토는 최신순으로 반환한다.")
     @Test
     void readMemoryByIdOrderByVisitedAt() {
         // given
@@ -258,7 +258,7 @@ class MemoryServiceTest extends ServiceSliceTest {
                 () -> assertThat(memoryDetailResponse.memoryId()).isEqualTo(memoryIdResponse.memoryId()),
                 () -> assertThat(memoryDetailResponse.moments()).hasSize(3),
                 () -> assertThat(memoryDetailResponse.moments().stream().map(MomentResponse::momentId).toList())
-                        .containsExactly(firstMoment.getId(), secondMoment.getId(), lastMoment.getId())
+                        .containsExactly(lastMoment.getId(), secondMoment.getId(), firstMoment.getId())
         );
     }
 

--- a/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
@@ -94,7 +94,7 @@ class MomentRepositoryTest {
         );
     }
 
-    @DisplayName("사용자의 특정 추억에 해당하는 모든 스타카토를 조회한다.")
+    @DisplayName("사용자의 특정 추억에 해당하는 모든 스타카토를 최신순으로 조회한다.")
     @Test
     void findAllByMemoryIdOrderByVisitedAt() {
         // given
@@ -107,12 +107,12 @@ class MomentRepositoryTest {
         Moment moment3 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2024, 1, 10, 23, 21)));
 
         // when
-        List<Moment> moments = momentRepository.findAllByMemoryIdOrderByVisitedAt(memory.getId());
+        List<Moment> moments = momentRepository.findAllByMemoryIdOrderByVisitedAtDesc(memory.getId());
 
         // then
         assertAll(
                 () -> assertThat(moments.size()).isEqualTo(3),
-                () -> assertThat(moments).containsExactlyInAnyOrder(moment1, moment2, moment3)
+                () -> assertThat(moments).containsExactlyInAnyOrder(moment3, moment2, moment1)
         );
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #545

## 🚩 Summary
- 추억 조회 시 스타카토 목록을 최신순으로 정렬하도록 정렬 기준을 변경했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
