### PR TITLE
refactor: comment API의 URI 수정 #560

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
@@ -15,7 +15,7 @@ import retrofit2.http.Query
 interface CommentApiService {
     @GET(COMMENTS_URI)
     suspend fun getComments(
-        @Query(MOMENT_ID) momentId: Long,
+        @Query(STACCATO_ID) staccatoId: Long,
     ): Response<CommentsResponse>
 
     @POST(COMMENTS_URI)
@@ -36,7 +36,7 @@ interface CommentApiService {
 
     companion object {
         private const val COMMENTS_URI = "/comments"
-        private const val MOMENT_ID = "momentId"
+        private const val STACCATO_ID = "momentId"
         private const val COMMENT_ID = "commentId"
         private const val COMMENTS_URI_WITH_COMMENT_ID = "$COMMENTS_URI/v2/{$COMMENT_ID}"
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
@@ -9,33 +9,35 @@ import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
+import retrofit2.http.Path
 import retrofit2.http.Query
 
 interface CommentApiService {
-    @GET(COMMENTS_PATH)
+    @GET(COMMENTS_URI)
     suspend fun getComments(
-        @Query("momentId") momentId: Long,
+        @Query(MOMENT_ID) momentId: Long,
     ): Response<CommentsResponse>
 
-    @POST(COMMENTS_PATH)
+    @POST(COMMENTS_URI)
     suspend fun postComment(
         @Body commentRequest: CommentRequest,
     ): Response<Unit>
 
-    @PUT(COMMENTS_PATH)
+    @PUT(COMMENTS_URI_WITH_COMMENT_ID)
     suspend fun putComment(
-        @Query("commentId") commentId: Long,
+        @Path(COMMENT_ID) commentId: Long,
         @Body commentUpdateRequest: CommentUpdateRequest,
     ): Response<Unit>
 
-    @DELETE(COMMENTS_PATH)
+    @DELETE(COMMENTS_URI_WITH_COMMENT_ID)
     suspend fun deleteComment(
-        @Query("commentId") commentId: Long,
+        @Path(COMMENT_ID) commentId: Long,
     ): Response<Unit>
 
     companion object {
-        private const val COMMENTS_PATH = "/comments"
-        private const val COMMENT_ID = "/{commentId}"
-        private const val COMMENTS_PATH_WITH_ID = "$COMMENTS_PATH$COMMENT_ID"
+        private const val COMMENTS_URI = "/comments"
+        private const val MOMENT_ID = "momentId"
+        private const val COMMENT_ID = "commentId"
+        private const val COMMENTS_URI_WITH_COMMENT_ID = "$COMMENTS_URI/v2/{$COMMENT_ID}"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/comment/CommentRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/comment/CommentRequest.kt
@@ -5,6 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CommentRequest(
-    @SerialName("momentId") val momentId: Long,
+    @SerialName("momentId") val staccatoId: Long,
     @SerialName("content") val content: String,
 )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/mapper/CommentMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/mapper/CommentMapper.kt
@@ -19,6 +19,6 @@ fun CommentDto.toDomain(): Comment =
 
 fun NewComment.toDto(): CommentRequest =
     CommentRequest(
-        momentId = staccatoId,
+        staccatoId = staccatoId,
         content = content,
     )


### PR DESCRIPTION
## ⭐️ Issue Number
- #560 

## 🚩 Summary
### 댓글 API URI 수정사항 반영

기존 댓글 수정, 삭제( `PUT` , `DELETE` ) API의 URI가 `Query String` 에서 `Path Variable` 형태로 변경되었습니다.
- `Query String` : `"/comments?commentId={commentId}"` 형태
  - `GET` 요청 등 주로 데이터 조회 API에서 활용
- `Path Variable` : `"/comments/{commentId}"` 형태
  - `POST`, `PUT`, `DELETE` 등 주로 데이터 수정, 삭제 API에서 활용

**변경 사항**
- [x] [Swagger UI](https://stage.staccato.kr/swagger-ui/index.html#/Comment) 를 참고하여 API의 URI를 수정하였습니다.
    ```kotlin
    // 예시
    @DELETE("comments/v2/{commentId}")
    suspend fun deleteComment(
        @Path("commentId") commentId: Long,
    ): Response<Unit>
    ```
  - [x] `Query String` 에서 `Path Variable` 형태로 변경하였습니다.
  - [x] `Path Variable`이 담긴 URI를 상수 활용했습니다.
  - [x] URI 중간의 `v2`는 버저닝을 위한 것으로, 추후 제거될 예정입니다.
- [x] 댓글 API URI 경로 상수의 이름을 `COMMENTS_PATH` 에서 `COMMENTS_URI` 로 변경하였습니다. ➡️ 혼동 방지
- [x] `momentId`, `commentId`를 상수화하였습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer
- 변경된 URI로 댓글 기능이 잘 동작하는걸 확인했습니다.
- URI 리팩터링이 잘 이루어졌는지 확인해주세요.

## 📋 To Do
추후에 버저닝 제거하기