### PR TITLE
refactor: 카테고리, 일시 선택 순서 변경 및 리팩터링 (스타카토 생성/수정) #564

### DIFF
--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -140,8 +140,10 @@ dependencies {
     implementation(libs.androidx.fragment.ktx)
 
     // Mockk
-    testImplementation(libs.mockk.android)
+    testImplementation(libs.mockk)
     testImplementation(libs.mockk.agent)
+    androidTestImplementation(libs.mockk.agent)
+    androidTestImplementation(libs.mockk.android)
 
     // Navigation
     implementation(libs.androidx.navigation.fragment.ktx)

--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.arch.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
@@ -138,6 +139,9 @@ dependencies {
 
     // Fragment
     implementation(libs.androidx.fragment.ktx)
+
+    // Coroutines Test
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // Mockk
     testImplementation(libs.mockk)

--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     // Mockk
+    testImplementation(libs.junitparams)
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.agent)
     androidTestImplementation(libs.mockk.agent)

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -1,6 +1,7 @@
 package com.on.staccato.domain.model
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 data class MemoryCandidate(
@@ -9,6 +10,21 @@ data class MemoryCandidate(
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
+    fun getClosestDateTime(
+        date : LocalDateTime
+    ): LocalDateTime {
+        if (startAt == null || endAt == null) return date
+
+        val startDateTime = startAt.atStartOfDay()
+        val endDateTime = endAt.atStartOfDay()
+
+        return when {
+            date.isBefore(startDateTime) -> startDateTime // 현재 시간이 startAt 이전일 때 startAt 반환
+            date.isAfter(endDateTime) -> endDateTime // 현재 시간이 endAt 이후일 때 endAt 반환
+            else -> date // 현재 시간이 범위 내에 있을 때 now 반환
+        }
+    }
+
     fun isDateWithinPeriod(date: LocalDate): Boolean {
         if (startAt == null || endAt == null) return true
         return date in startAt..endAt

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -10,9 +10,7 @@ data class MemoryCandidate(
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
-    fun getClosestDateTime(
-        date : LocalDateTime
-    ): LocalDateTime {
+    fun getClosestDateTime(date: LocalDateTime): LocalDateTime {
         if (startAt == null || endAt == null) return date
 
         val startDateTime = startAt.atStartOfDay()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -3,14 +3,17 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>)
-
 data class MemoryCandidate(
     val memoryId: Long,
     val memoryTitle: String,
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
+    fun isDateWithinPeriod(date: LocalDate): Boolean {
+        if (startAt == null || endAt == null) return true
+        return date in startAt..endAt
+    }
+
     companion object {
         fun buildNumberPickerDates(
             startAt: LocalDate?,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -14,12 +14,16 @@ data class MemoryCandidate(
         if (startAt == null || endAt == null) return date
 
         val startDateTime = startAt.atStartOfDay()
-        val endDateTime = endAt.atStartOfDay()
+        val endDateTime = endAt.atTime(23, 59)
 
         return when {
-            date.isBefore(startDateTime) -> startDateTime // 현재 시간이 startAt 이전일 때 startAt 반환
-            date.isAfter(endDateTime) -> endDateTime // 현재 시간이 endAt 이후일 때 endAt 반환
-            else -> date // 현재 시간이 범위 내에 있을 때 now 반환
+            date.isBefore(startDateTime) ->
+                startDateTime.toLocalDate()
+                    .atTime(12, 0)
+            date.isAfter(endDateTime) ->
+                endDateTime.toLocalDate()
+                    .atTime(12, 0)
+            else -> date
         }
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -4,4 +4,6 @@ import java.time.LocalDate
 
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
     fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+
+    fun getValidMemoryCandidate(memoryId: Long) = memoryCandidate.filter { it.memoryId == memoryId }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -1,0 +1,7 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+
+data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
+    fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -3,7 +3,7 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
-    fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+    fun filterCandidatesBy(date: LocalDate): List<MemoryCandidate> = memoryCandidate.filter { it.isDateWithinPeriod(date) }
 
-    fun getValidMemoryCandidate(memoryId: Long) = memoryCandidate.filter { it.memoryId == memoryId }
+    fun filterCandidatesBy(memoryId: Long): List<MemoryCandidate> = memoryCandidate.filter { it.memoryId == memoryId }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -17,37 +17,29 @@ fun TextView.setSelectedMemory(
     memoryCandidates: MemoryCandidates?,
 ) {
     if (memoryCandidates?.memoryCandidate?.isEmpty() == true) {
-        text = resources.getString(R.string.staccato_creation_no_memory_hint)
+        text = resources.getString(R.string.staccato_creation_no_memory)
         setTextColor(resources.getColor(R.color.gray3, null))
         isClickable = false
         isFocusable = false
     } else if (selectedMemory == null) {
-        text = resources.getString(R.string.staccato_creation_memory_selection_hint)
-        setTextColor(resources.getColor(R.color.gray3, null))
-        isClickable = true
-        isFocusable = true
-    } else {
-        text = selectedMemory.memoryTitle
-        setTextColor(resources.getColor(R.color.staccato_black, null))
-    }
-}
-
-@BindingAdapter(value = ["dateTimeWithAmPm", "memoryCandidates"])
-fun TextView.setDateTimeWithAmPm(
-    dateTime: LocalDateTime?,
-    memoryCandidates: MemoryCandidates?,
-) {
-    if (memoryCandidates?.memoryCandidate?.isEmpty() == true) {
-        text = resources.getString(R.string.staccato_creation_memory_selection_hint)
+        text = resources.getString(R.string.staccato_creation_no_memory_in_this_date)
         setTextColor(resources.getColor(R.color.gray3, null))
         isClickable = false
         isFocusable = false
     } else {
-        text = dateTime?.let(::getFormattedLocalDateTime) ?: EMPTY_TEXT
-        setTextColor(resources.getColor(R.color.staccato_black, null))
+        text = selectedMemory.memoryTitle
         isClickable = true
         isFocusable = true
+        setTextColor(resources.getColor(R.color.staccato_black, null))
     }
+}
+
+@BindingAdapter("dateTimeWithAmPm")
+fun TextView.setDateTimeWithAmPm(dateTime: LocalDateTime?) {
+    text = dateTime?.let(::getFormattedLocalDateTime) ?: EMPTY_TEXT
+    setTextColor(resources.getColor(R.color.staccato_black, null))
+    isClickable = true
+    isFocusable = true
 }
 
 @BindingAdapter(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -65,11 +65,6 @@ fun TextView.setIsMemoryCandidatesEmptyVisibility(memoryCandidates: MemoryCandid
     isGone = !memoryCandidates?.memoryCandidate.isNullOrEmpty()
 }
 
-@BindingAdapter("isMemoryEmpty")
-fun TextView.setIsMemoryEmptyVisibility(items: List<Int>?) {
-    isGone = !items.isNullOrEmpty()
-}
-
 @BindingAdapter("visitedAtHistory")
 fun TextView.formatVisitedAtHistory(visitedAt: LocalDateTime?) {
     text = visitedAt?.let {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -183,12 +183,13 @@ class StaccatoCreationViewModel
         }
 
         fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
-            _selectableMemories.value =
-                memoryCandidates.value?.filterCandidatesBy(visitedAt.toLocalDate())
-            _selectedMemory.value =
-                selectableMemories.value?.let { selectableMemories ->
-                    selectableMemories.find { it.memoryId == selectedMemory.value?.memoryId } ?: selectableMemories.first()
-                }
+            val filteredMemories =
+                memoryCandidates.value
+                    ?.filterCandidatesBy(visitedAt.toLocalDate())
+                    ?: emptyList()
+            _selectableMemories.value = filteredMemories
+            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
+                ?: filteredMemories.firstOrNull()
         }
 
         private fun setMemoryCandidateById(memoryId: Long) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -182,12 +182,13 @@ class StaccatoUpdateViewModel
         }
 
         fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
-            _selectableMemories.value =
-                memoryCandidates.value?.filterCandidatesBy(visitedAt.toLocalDate())
-            _selectedMemory.value =
-                selectableMemories.value?.let { selectableMemories ->
-                    selectableMemories.find { it.memoryId == selectedMemory.value?.memoryId } ?: selectableMemories.first()
-                }
+            val filteredMemories =
+                memoryCandidates.value
+                    ?.filterCandidatesBy(visitedAt.toLocalDate())
+                    ?: emptyList()
+            _selectableMemories.value = filteredMemories
+            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
+                ?: filteredMemories.firstOrNull()
         }
 
         fun updateStaccato(staccatoId: Long) {

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
@@ -227,8 +227,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}" />
 
                 <TextView
                     android:id="@+id/tv_memory_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
@@ -205,12 +205,38 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
+                    android:id="@+id/tv_visited_at_selection_title"
+                    style="@style/SubTitleStyle"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/all_visited_at"
+                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
+                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+
+                <TextView
+                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
+                    style="@style/RequiredMarkStyle"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintStart_toEndOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toTopOf="@id/tv_visited_at_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    style="@style/BackgroundedTextStyle"
+                    android:layout_marginTop="8dp"
+                    android:onClick="@{() -> staccatoCreationHandler.onVisitedAtSelectionClicked()}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+
+                <TextView
                     android:id="@+id/tv_memory_selection_title"
                     style="@style/SubTitleStyle"
                     android:layout_marginTop="40dp"
                     android:text="@string/staccato_creation_memory_selection"
-                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
-                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+                    app:layout_constraintStart_toStartOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
 
                 <TextView
                     android:id="@+id/tv_staccato_creation_required_mark_third"
@@ -231,32 +257,6 @@
                     bind:memoryCandidates="@{viewModel.memoryCandidates}"
                     bind:selectedMemory="@{viewModel.selectedMemory}" />
 
-                <TextView
-                    android:id="@+id/tv_select_memory_title"
-                    style="@style/SubTitleStyle"
-                    android:layout_marginTop="40dp"
-                    android:text="@string/all_visited_at"
-                    app:layout_constraintStart_toStartOf="@id/tv_memory_selection_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection" />
-
-                <TextView
-                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
-                    style="@style/RequiredMarkStyle"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_select_memory_title"
-                    app:layout_constraintStart_toEndOf="@id/tv_select_memory_title"
-                    app:layout_constraintTop_toTopOf="@id/tv_select_memory_title" />
-
-                <TextView
-                    android:id="@+id/tv_visited_at"
-                    style="@style/BackgroundedTextStyle"
-                    android:layout_marginTop="8dp"
-                    android:onClick="@{() -> staccatoCreationHandler.onVisitedAtSelectionClicked()}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_select_memory_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
-
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_staccato_create_done"
                     style="@style/ButtonStyle.Save.Active"
@@ -268,7 +268,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at"
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection"
                     bind:staccatoAddress="@{viewModel.placeName}"
                     bind:staccatoMemory="@{viewModel.selectedMemory}"
                     bind:staccatoPhotos="@{viewModel.currentPhotos}"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
@@ -230,8 +230,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}" />
 
                 <TextView
                     android:id="@+id/tv_memory_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
@@ -208,15 +208,41 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
+                    android:id="@+id/tv_visited_at_selection_title"
+                    style="@style/SubTitleStyle"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/all_visited_at"
+                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
+                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+
+                <TextView
+                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
+                    style="@style/RequiredMarkStyle"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintStart_toEndOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toTopOf="@id/tv_visited_at_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    style="@style/BackgroundedTextStyle"
+                    android:layout_marginTop="8dp"
+                    android:onClick="@{() -> staccatoUpdateHandler.onVisitedAtSelectionClicked()}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+
+                <TextView
                     android:id="@+id/tv_memory_selection_title"
                     style="@style/SubTitleStyle"
                     android:layout_marginTop="40dp"
                     android:text="@string/staccato_creation_memory_selection"
-                    app:layout_constraintStart_toStartOf="@id/tv_photo_title"
-                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+                    app:layout_constraintStart_toStartOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
 
                 <TextView
-                    android:id="@+id/tv_staccato_update_required_mark_third"
+                    android:id="@+id/tv_staccato_creation_required_mark_third"
                     style="@style/RequiredMarkStyle"
                     app:layout_constraintBottom_toBottomOf="@id/tv_memory_selection_title"
                     app:layout_constraintStart_toEndOf="@id/tv_memory_selection_title"
@@ -230,34 +256,9 @@
                     android:text="@{viewModel.selectedMemory.memoryTitle}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection_title" />
-
-                <TextView
-                    android:id="@+id/tv_select_memory_title"
-                    style="@style/SubTitleStyle"
-                    android:layout_marginTop="40dp"
-                    android:text="@string/all_visited_at"
-                    app:layout_constraintStart_toStartOf="@id/tv_memory_selection_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection" />
-
-                <TextView
-                    android:id="@+id/tv_staccato_update_required_mark_fourth"
-                    style="@style/RequiredMarkStyle"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_select_memory_title"
-                    app:layout_constraintStart_toEndOf="@id/tv_select_memory_title"
-                    app:layout_constraintTop_toTopOf="@id/tv_select_memory_title" />
-
-                <TextView
-                    android:id="@+id/tv_visited_at"
-                    style="@style/BackgroundedTextStyle"
-                    android:layout_marginTop="8dp"
-                    android:background="@drawable/shape_button_gray1_5dp"
-                    android:onClick="@{() -> staccatoUpdateHandler.onVisitedAtSelectionClicked()}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_select_memory_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection_title"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}"
+                    bind:selectedMemory="@{viewModel.selectedMemory}" />
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_staccato_update_done"
@@ -270,7 +271,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at"
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection"
                     bind:staccatoAddress="@{viewModel.address}"
                     bind:staccatoMemory="@{viewModel.selectedMemory}"
                     bind:staccatoPhotos="@{viewModel.currentPhotos}"

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_memory_visited_at_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_memory_visited_at_selection.xml
@@ -23,7 +23,7 @@
         <TextView
             android:id="@+id/tv_select_memory_title"
             style="@style/SubTitleStyle"
-            android:text="@string/staccato_creation_memory_selection_hint"
+            android:text="@string/staccato_creation_no_memory_in_this_date"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -34,7 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_marginVertical="50dp"
             android:gravity="center"
-            android:text="@string/staccato_creation_no_memory_hint"
+            android:text="@string/staccato_creation_no_memory"
             app:layout_constraintBottom_toTopOf="@id/btn_memory_visited_at_confirm"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
@@ -23,20 +23,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_memory_is_empty"
-            style="@style/Typography.Body2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="50dp"
-            android:gravity="center"
-            android:text="@string/staccato_creation_unselected_memory"
-            app:layout_constraintBottom_toTopOf="@id/btn_visited_at_confirm"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title"
-            bind:isMemoryEmpty="@{years}" />
-
         <NumberPicker
             android:id="@+id/picker_year"
             android:layout_width="0dp"

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -119,8 +119,8 @@
     <string name="staccato_creation_empty_address">"장소를 선택하면 상세 주소가 나타나요"</string>
     <string name="staccato_creation_address">상세 주소</string>
     <string name="staccato_creation_memory_selection">추억 선택</string>
-    <string name="staccato_creation_memory_selection_hint">추억을 선택해 주세요</string>
-    <string name="staccato_creation_no_memory_hint">스타카토를 남길 수 있는 추억이 없어요</string>
+    <string name="staccato_creation_no_memory_in_this_date">선택하신 날짜에는 추억이 없어요</string>
+    <string name="staccato_creation_no_memory">스타카토를 남길 수 있는 추억이 없어요</string>
     <string name="staccato_creation_unselected_memory">추억을 먼저 선택해 주세요</string>
     <string name="staccato_creation_toolbar_subtitle">기억하고 싶은 순간을 남겨 보세요!</string>
     <string name="staccato_creation_toolbar_title">스타카토 기록하기</string>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -121,7 +121,6 @@
     <string name="staccato_creation_memory_selection">추억 선택</string>
     <string name="staccato_creation_no_memory_in_this_date">선택하신 날짜에는 추억이 없어요</string>
     <string name="staccato_creation_no_memory">스타카토를 남길 수 있는 추억이 없어요</string>
-    <string name="staccato_creation_unselected_memory">추억을 먼저 선택해 주세요</string>
     <string name="staccato_creation_toolbar_subtitle">기억하고 싶은 순간을 남겨 보세요!</string>
     <string name="staccato_creation_toolbar_title">스타카토 기록하기</string>
     <string name="staccato_creation_not_found_address">주소를 찾지 못했습니다</string>

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -10,7 +10,7 @@ internal val yearStart2025 = LocalDate.of(2025, 1, 1)
 
 internal const val TARGET_MEMORY_ID = 4L
 
-internal val firstMemoryCandidate =
+internal val newMemoryCandidate =
     makeTestMemoryCandidate(
         memoryId = 1L,
         startAt = yearEnd2023,
@@ -28,11 +28,30 @@ val dummyMemoryCandidates =
     MemoryCandidates(
         memoryCandidate =
             listOf(
-                firstMemoryCandidate,
+                newMemoryCandidate,
                 makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearMiddle2024),
                 makeTestMemoryCandidate(memoryId = 3L, startAt = yearMiddle2024, endAt = yearEnd2024),
                 targetMemoryCandidate,
             ),
+    )
+
+internal const val TARGET_STACCATO_ID = 4L
+
+internal val targetStaccato =
+    Staccato(
+        staccatoId = TARGET_STACCATO_ID,
+        staccatoTitle = "테스트용 스타카토",
+        placeName = "Elmer Moon",
+        address = "nunc",
+        latitude = 8.9,
+        longitude = 10.11,
+        staccatoImageUrls = listOf(),
+        memoryId = targetMemoryCandidate.memoryId,
+        memoryTitle = targetMemoryCandidate.memoryTitle,
+        visitedAt = yearEnd2024.atTime(12, 0),
+        startAt = targetMemoryCandidate.startAt,
+        endAt = targetMemoryCandidate.endAt,
+        feeling = Feeling.EXCITED,
     )
 
 internal fun makeTestMemoryCandidate(

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -1,0 +1,48 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+
+internal val yearEnd2023 = LocalDate.of(2023, 12, 31)
+internal val yearStart2024 = LocalDate.of(2024, 1, 1)
+internal val yearMiddle2024 = LocalDate.of(2024, 7, 1)
+internal val yearEnd2024 = LocalDate.of(2024, 12, 31)
+internal val yearStart2025 = LocalDate.of(2025, 1, 1)
+
+internal const val TARGET_MEMORY_ID = 4L
+
+internal val firstMemoryCandidate =
+    makeTestMemoryCandidate(
+        memoryId = 1L,
+        startAt = yearEnd2023,
+        endAt = yearStart2024,
+    )
+
+internal val targetMemoryCandidate =
+    makeTestMemoryCandidate(
+        memoryId = TARGET_MEMORY_ID,
+        startAt = yearEnd2024,
+        endAt = yearStart2025,
+    )
+
+val dummyMemoryCandidates =
+    MemoryCandidates(
+        memoryCandidate =
+            listOf(
+                firstMemoryCandidate,
+                makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearMiddle2024),
+                makeTestMemoryCandidate(memoryId = 3L, startAt = yearMiddle2024, endAt = yearEnd2024),
+                targetMemoryCandidate,
+            ),
+    )
+
+internal fun makeTestMemoryCandidate(
+    memoryId: Long = 1L,
+    memoryTitle: String = "임시 카테고리",
+    startAt: LocalDate? = null,
+    endAt: LocalDate? = null,
+) = MemoryCandidate(
+    memoryId = memoryId,
+    memoryTitle = memoryTitle,
+    startAt = startAt,
+    endAt = endAt,
+)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -99,40 +99,42 @@ class MemoryCandidateTest {
 
     // 아래부터 getClosestDateTime 테스트
     @Test
-    fun `2024년 중 2023년 마지막 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+    fun `현재 시간이 startAt과 endAt의 범위 내일 때 현재 시간을 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearMiddle2024.atTime(13, 30)
 
         // when & then
-        val actual = category.getClosestDateTime(yearEnd2023.atTime(12, 0))
-        val expected = yearStart2024.atTime(0, 0)
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+
+        assertEquals(currentLocalDateTime, actual)
+    }
+
+    @Test
+    fun `현재 시간이 startAt보다 과거일 때 startAt의 정오를 반환`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearEnd2023.atTime(13, 30)
+
+        // when & then
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+        val expected = yearStart2024.atTime(12, 0)
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `2024년 중 2024년 7월 1일 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+    fun `현재 시간이 endAt보다 미래일 때 endAt의 정오를 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearStart2025.atTime(13, 30)
 
         // when & then
-        val actual = category.getClosestDateTime(yearMiddle2024.atTime(12, 0))
-        val expected = yearMiddle2024.atTime(12, 0)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `2024년 중 2025년 첫번째 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
-        // given
-        val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-
-        // when & then
-        val actual = category.getClosestDateTime(yearStart2025.atTime(12, 0))
-        val expected = yearEnd2024.atTime(0, 0)
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+        val expected = yearEnd2024.atTime(12, 0)
 
         assertEquals(expected, actual)
     }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MemoryCandidateTest {
+    // 아래부터 isDateWithinPeriod 테스트
     @Test
     fun `특정 날짜가 startAt과 endAt 사이에 포함되면 true 반환`() {
         val category =
@@ -94,5 +95,45 @@ class MemoryCandidateTest {
         assertEquals(expected1, actual1)
         assertEquals(expected2, actual2)
         assertEquals(expected3, actual3)
+    }
+
+    // 아래부터 getClosestDateTime 테스트
+    @Test
+    fun `2024년 중 2023년 마지막 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearEnd2023.atTime(12, 0))
+        val expected = yearStart2024.atTime(0, 0)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `2024년 중 2024년 7월 1일 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearMiddle2024.atTime(12, 0))
+        val expected = yearMiddle2024.atTime(12, 0)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `2024년 중 2025년 첫번째 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearStart2025.atTime(12, 0))
+        val expected = yearEnd2024.atTime(0, 0)
+
+        assertEquals(expected, actual)
     }
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -1,0 +1,98 @@
+package com.on.staccato.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MemoryCandidateTest {
+    @Test
+    fun `특정 날짜가 startAt과 endAt 사이에 포함되면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearMiddle2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜와 startAt이 같으면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearStart2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜와 endAt이 같으면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearEnd2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜가 startAt 이전이면 false 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearEnd2023)
+        val expected = false
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜가 endAt 이후면 false 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearStart2025)
+        val expected = false
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `startAt과 endAt이 null이면 모든 날짜에 true 반환`() {
+        // given
+        val categoryWithoutPeriod =
+            makeTestMemoryCandidate(
+                startAt = null,
+                endAt = null,
+            )
+
+        // when & then
+        val actual1 = categoryWithoutPeriod.isDateWithinPeriod(yearEnd2023)
+        val expected1 = true
+        val actual2 = categoryWithoutPeriod.isDateWithinPeriod(yearMiddle2024)
+        val expected2 = true
+        val actual3 = categoryWithoutPeriod.isDateWithinPeriod(yearStart2025)
+        val expected3 = true
+
+        assertEquals(expected1, actual1)
+        assertEquals(expected2, actual2)
+        assertEquals(expected3, actual3)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -2,6 +2,7 @@ package com.on.staccato.domain.model
 
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,7 +12,7 @@ import java.time.LocalDate
 class MemoryCandidatesTest {
     @Test
     @Parameters(method = "parameters")
-    fun `getValidMemoryCandidate는 date를 포함하는 후보만 필터링`(date: LocalDate) {
+    fun `date를 포함하는 후보들을 필터링해 반환`(date: LocalDate) {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
@@ -19,8 +20,21 @@ class MemoryCandidatesTest {
         val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
 
         // then
-        val actual = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
-        assertTrue(actual)
+        val isEveryCandidatesContainDate = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        assertTrue(isEveryCandidatesContainDate)
+    }
+
+    @Test
+    fun `아이디가 정확히 일치하는 memoryCandidate를 찾아 반환`() {
+        // given
+        val memoryCandidates = dummyMemoryCandidates
+
+        // when
+        val actual = memoryCandidates.getValidMemoryCandidate(TARGET_MEMORY_ID)
+        val expected = listOf(targetMemoryCandidate)
+
+        // then
+        assertEquals(expected, actual)
     }
 
     private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -1,0 +1,27 @@
+package com.on.staccato.domain.model
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(JUnitParamsRunner::class)
+class MemoryCandidatesTest {
+    @Test
+    @Parameters(method = "parameters")
+    fun `getValidMemoryCandidate는 date를 포함하는 후보만 필터링`(date: LocalDate) {
+        // given
+        val memoryCandidates = dummyMemoryCandidates
+
+        // when
+        val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
+
+        // then
+        val actual = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        assertTrue(actual)
+    }
+
+    private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -12,25 +12,25 @@ import java.time.LocalDate
 class MemoryCandidatesTest {
     @Test
     @Parameters(method = "parameters")
-    fun `date를 포함하는 후보들을 필터링해 반환`(date: LocalDate) {
+    fun `date를 포함하는 후보들을 필터링 하여 반환`(date: LocalDate) {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
         // when
-        val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
+        val actual = memoryCandidates.filterCandidatesBy(date)
 
         // then
-        val isEveryCandidatesContainDate = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        val isEveryCandidatesContainDate = actual.all { it.isDateWithinPeriod(date) }
         assertTrue(isEveryCandidatesContainDate)
     }
 
     @Test
-    fun `아이디가 정확히 일치하는 memoryCandidate를 찾아 반환`() {
+    fun `아이디가 일치하는 memoryCandidate를 찾아 반환`() {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = memoryCandidates.getValidMemoryCandidate(TARGET_MEMORY_ID)
+        val actual = memoryCandidates.filterCandidatesBy(TARGET_MEMORY_ID)
         val expected = listOf(targetMemoryCandidate)
 
         // then

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/LiveDataTestUtil.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/LiveDataTestUtil.kt
@@ -1,0 +1,33 @@
+package com.on.staccato.presentation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer =
+        object : Observer<T> {
+            override fun onChanged(value: T) {
+                data = value
+                latch.countDown()
+                this@getOrAwaitValue.removeObserver(this)
+            }
+        }
+
+    this.observeForever(observer)
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/MainDispatcherRule.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.on.staccato.presentation
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.on.staccato.presentation.staccatocreation.viewmodel
 
-import android.os.Looper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
@@ -13,33 +12,27 @@ import com.on.staccato.domain.model.yearMiddle2024
 import com.on.staccato.domain.model.yearStart2024
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.MainDispatcherRule
 import com.on.staccato.presentation.getOrAwaitValue
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executors
 
 @RunWith(JUnit4::class)
 class StaccatoCreationViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @MockK
     private lateinit var timelineRepository: TimelineRepository
@@ -53,25 +46,9 @@ class StaccatoCreationViewModelTest {
     @InjectMockKs
     private lateinit var viewModel: StaccatoCreationViewModel
 
-    private val dispatcher =
-        Executors
-            .newSingleThreadExecutor()
-            .asCoroutineDispatcher()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        dispatcher.close()
     }
 
     @Test

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -1,0 +1,176 @@
+package com.on.staccato.presentation.staccatocreation.viewmodel
+
+import android.os.Looper
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.on.staccato.data.ResponseResult
+import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.TARGET_MEMORY_ID
+import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.targetMemoryCandidate
+import com.on.staccato.domain.model.yearEnd2023
+import com.on.staccato.domain.model.yearMiddle2024
+import com.on.staccato.domain.model.yearStart2024
+import com.on.staccato.domain.repository.StaccatoRepository
+import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.getOrAwaitValue
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
+
+@RunWith(JUnit4::class)
+class StaccatoCreationViewModelTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var timelineRepository: TimelineRepository
+
+    @MockK
+    private lateinit var staccatoRepository: StaccatoRepository
+
+    @MockK
+    private lateinit var imageRepository: ImageDefaultRepository
+
+    @InjectMockKs
+    private lateinit var viewModel: StaccatoCreationViewModel
+
+    private val dispatcher =
+        Executors
+            .newSingleThreadExecutor()
+            .asCoroutineDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() } returns mockk(relaxed = true)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        dispatcher.close()
+    }
+
+    @Test
+    fun `viewModel 초기화 시 카테고리 후보를 불러온다`() =
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+
+            // when
+            viewModel.fetchMemoryCandidates()
+
+            // when & then
+            val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+            assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+        }
+
+    @Test
+    fun `카테고리 ID가 0L일 때는 현재 날짜를 기준으로 일시와 카테고리 후보를 정한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        // when
+        val currentLocalDate = yearMiddle2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(0L, currentLocalDate)
+
+        // then
+        val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        val selectableMemories = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024)
+        val selectedMemory = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024).first()
+
+        assertEquals(currentLocalDate, actualVisitedAt)
+        assertEquals(selectableMemories, actualMemories)
+        assertEquals(selectedMemory, actualMemory)
+    }
+
+    @Test
+    fun `카테고리 ID가 0L이 아닐 때는 특정 카테고리로 고정, 현재와 가장 가까운 일시를 선택한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        // when
+        val currentVisitedAt = yearMiddle2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, currentVisitedAt)
+
+        // then
+        val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        val closestVisitedAt = targetMemoryCandidate.getClosestDateTime(currentVisitedAt)
+        val fixedMemories = listOf(targetMemoryCandidate)
+        val fixedMemory = targetMemoryCandidate
+
+        assertEquals(closestVisitedAt, actualVisitedAt)
+        assertEquals(fixedMemories, actualMemories)
+        assertEquals(fixedMemory, actualMemory)
+    }
+
+    @Test
+    fun `카테고리 ID가 0L일 때는 일시가 바뀌면 memoryCandidate도 바뀐다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        val oldLocalDate = yearStart2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, oldLocalDate)
+
+        // when
+        val newLocalDate = yearEnd2023.atStartOfDay()
+        viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+
+        // then
+        val expectedMemories = listOf(newMemoryCandidate)
+        val expectedMemory = newMemoryCandidate
+
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        assertEquals(expectedMemories, actualMemories)
+        assertEquals(expectedMemory, actualMemory)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.on.staccato.presentation.staccatoupdate.viewmodel
 
-import android.os.Looper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
@@ -13,30 +12,24 @@ import com.on.staccato.domain.model.targetStaccato
 import com.on.staccato.domain.model.yearEnd2023
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.MainDispatcherRule
 import com.on.staccato.presentation.getOrAwaitValue
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.concurrent.Executors
 
 class StaccatoUpdateViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @MockK
     private lateinit var timelineRepository: TimelineRepository
@@ -50,25 +43,9 @@ class StaccatoUpdateViewModelTest {
     @InjectMockKs
     private lateinit var viewModel: StaccatoUpdateViewModel
 
-    private val dispatcher =
-        Executors
-            .newSingleThreadExecutor()
-            .asCoroutineDispatcher()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        dispatcher.close()
     }
 
     @Test
@@ -95,7 +72,8 @@ class StaccatoUpdateViewModelTest {
         Assert.assertEquals(targetStaccato.address, actualAddress)
 
         // 일시 선택을 위한 값 검사
-        val expectedSelectableMemories = dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+        val expectedSelectableMemories =
+            dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
         val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
         Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
 

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -1,0 +1,139 @@
+package com.on.staccato.presentation.staccatoupdate.viewmodel
+
+import android.os.Looper
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.on.staccato.data.ResponseResult
+import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.TARGET_MEMORY_ID
+import com.on.staccato.domain.model.TARGET_STACCATO_ID
+import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.targetMemoryCandidate
+import com.on.staccato.domain.model.targetStaccato
+import com.on.staccato.domain.model.yearEnd2023
+import com.on.staccato.domain.repository.StaccatoRepository
+import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.getOrAwaitValue
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.Executors
+
+class StaccatoUpdateViewModelTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var timelineRepository: TimelineRepository
+
+    @MockK
+    private lateinit var staccatoRepository: StaccatoRepository
+
+    @MockK
+    private lateinit var imageRepository: ImageDefaultRepository
+
+    @InjectMockKs
+    private lateinit var viewModel: StaccatoUpdateViewModel
+
+    private val dispatcher =
+        Executors
+            .newSingleThreadExecutor()
+            .asCoroutineDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() } returns mockk(relaxed = true)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        dispatcher.close()
+    }
+
+    @Test
+    fun `수정하려는 스타카토와 추억 후보를 불러와 스타카토, 일시 및 추억 선택 값을 초기화 한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+                ResponseResult.Success(targetStaccato)
+
+            // when
+            viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+        }
+
+        // then
+        // 스타카토 관련 값 검사
+        val actualPlaceName = viewModel.placeName.getOrAwaitValue()
+        val actualAddress = viewModel.address.getOrAwaitValue()
+
+        Assert.assertEquals(targetStaccato.placeName, actualPlaceName)
+        Assert.assertEquals(targetStaccato.address, actualAddress)
+
+        // 일시 선택을 위한 값 검사
+        val expectedSelectableMemories = dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+        val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+        Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
+
+        // 추억 선택을 위한 값 검사
+        val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+        val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
+        val actualSelectedVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+
+        Assert.assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+        Assert.assertEquals(targetMemoryCandidate, actualSelectedMemory)
+        Assert.assertEquals(targetStaccato.visitedAt, actualSelectedVisitedAt)
+    }
+
+    @Test
+    fun `일시가 바뀌면 그에 따라 선택 가능 카테고리, 선택된 카테고리를 업데이트 한다`() {
+        // given
+        runTest {
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+                ResponseResult.Success(targetStaccato)
+            viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+        }
+
+        // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
+        val newLocalDate = yearEnd2023.atStartOfDay()
+        viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+
+        // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
+        val expectedMemories = listOf(newMemoryCandidate)
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+
+        val expectedMemory = newMemoryCandidate
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        Assert.assertEquals(expectedMemories, actualMemories)
+        Assert.assertEquals(expectedMemory, actualMemory)
+    }
+}

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ converterScalars = "2.9.0"
 dotsindicator = "5.0"
 hiltAndroid = "2.51.1"
 archTestingVersion = "2.2.0"
+junitparams = "1.1.0"
 kotlin = "1.9.0"
 ktlint = "12.1.0"
 coreKtx = "1.13.1"
@@ -48,6 +49,7 @@ dotsindicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dotsindi
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+junitparams = { module = "pl.pragmatists:JUnitParams",version.ref = "junitparams" }
 androidx-arch-core = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTestingVersion" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "8.3.0"
 converterScalars = "2.9.0"
 dotsindicator = "5.0"
 hiltAndroid = "2.51.1"
+archTestingVersion = "2.2.0"
 kotlin = "1.9.0"
 ktlint = "12.1.0"
 coreKtx = "1.13.1"
@@ -20,6 +21,7 @@ playServicesLocation = "21.3.0"
 retrofit = "2.11.0"
 retrofit-serialization-converter = "1.0.0"
 kotlinx-serialization-json = "1.6.3"
+kotlinx-coroutines-test = "1.8.1"
 okhttp-logging-interceptor = "4.12.0"
 mockk = "1.13.11"
 lifecycle = "2.8.3"
@@ -46,6 +48,7 @@ dotsindicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dotsindi
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-arch-core = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTestingVersion" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -60,6 +63,7 @@ play-services-location = { module = "com.google.android.gms:play-services-locati
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-serialization-converter" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -62,7 +62,8 @@ retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
-mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
+mockk-agent = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 lifecycle-livedata = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }


### PR DESCRIPTION
## ⭐️ Issue Number
- #564 

## 🚩 Summary
스타카토 생성/수정 화면의 카테고리, 일시 관련 로직에 아래의 작업들을 수행했습니다.
- [x] 카테고리, 일시 선택 순서 변경
- [x] 카테고리, 일시 선택 코드 리팩터링
- [x] 카테고리, 일시 선택 로직 테스트 추가

### 리팩터링 내용 정리
#### 생성 화면

1. `fetchMemoryCandidates()`로 사용자의 모든 추억을 불러와 `_memoryCandidates`를 업데이트 합니다.
2. 이 때 `_memoryCandidates`는 최초 한 번 업데이트된 후엔 변하지 않습니다.
3. `memoryCandidates.observe` 람다에서 `initMemoryAndVisitedAt()`를 수행하여 일시, 추억의 초기값을 세팅합니다.
    1. 메인 화면에서 생성 (memoryId == 0L)
        - **일시** 먼저 초기화 → `LocalDateTime.now()` (선택 가능한 일시 범위는 selectedVisitedAt ±10년)
        - 일시를 기준으로 **추억**을 초기화 → `updateMemoryCandidateAndVisitedAt()`
        - 일시가 바뀌면 추억을 다시 세팅
    2. 추억 화면에서 생성 (memoryId를 알고 있는 경우)
        - **추억** 먼저 초기화 → memoryId가 일치하는 추억으로 고정
        - 추억을 기준으로 **일시**를 초기화 → 추억 기간 안에서 'LocalDate.now()'와 가장 인접한 날짜 선택 (`MemoryCandidate`의 `getClosestDateTime()` 참고)
        - 선택 가능한 일시 범위는 추억 기간으로 세팅

#### 수정 화면
1. 사용자의 모든 추억을 불러옵니다. (`fetchMemoryCandidates()`)
2. 수정 대상인 스타카토의 정보를 불러옵니다. (`fetchStaccatoBy()`)
3. 불러온 스타카토 정보로 추억, 일시를 초기화 합니다.
4. 일시가 바뀌면 추억을 다시 세팅합니다.

## 🛠️ Technical Concerns

### 스타카토 생성/수정 ViewModel 테스트

MVVM 구조의 뷰모델 내부 LiveData 값을 테스트하기 위해 아래 Rule을 설정하고 getOrAwaitValue를 추가했습니다.

```kotlin
    @get:Rule
    var instantTaskExecutorRule = InstantTaskExecutorRule()

    @get:Rule
    val mainDispatcherRule = MainDispatcherRule()
```

또한 mockK의 coEvery와 coroutines.test의 runTest를 사용했습니다.

## 🙂 To Reviewer