### PR TITLE
refactor: 카테고리, 일시 선택 순서 변경 및 리팩터링 (스타카토 생성/수정) #564

### DIFF
--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -140,8 +140,10 @@ dependencies {
     implementation(libs.androidx.fragment.ktx)
 
     // Mockk
-    testImplementation(libs.mockk.android)
+    testImplementation(libs.mockk)
     testImplementation(libs.mockk.agent)
+    androidTestImplementation(libs.mockk.agent)
+    androidTestImplementation(libs.mockk.android)
 
     // Navigation
     implementation(libs.androidx.navigation.fragment.ktx)

--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -98,6 +98,7 @@ dependencies {
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
+    testImplementation(libs.androidx.arch.core)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 
@@ -138,6 +139,9 @@ dependencies {
 
     // Fragment
     implementation(libs.androidx.fragment.ktx)
+
+    // Coroutines Test
+    testImplementation(libs.kotlinx.coroutines.test)
 
     // Mockk
     testImplementation(libs.mockk)

--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -144,6 +144,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 
     // Mockk
+    testImplementation(libs.junitparams)
     testImplementation(libs.mockk)
     testImplementation(libs.mockk.agent)
     androidTestImplementation(libs.mockk.agent)

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
@@ -15,19 +15,21 @@ data class DateCalendar private constructor(val availableDates: List<Int>) {
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
         ): DateCalendar {
-            if (periodStart != null && periodEnd != null) checkValid(year, month, periodStart, periodEnd)
-            val dateRange = createDateRangeIn(year, month, periodStart, periodEnd)
+            val lastDateOfMonth = YearMonth.of(year, month).lengthOfMonth()
+            if (periodStart != null && periodEnd != null) checkValid(year, month, lastDateOfMonth, periodStart, periodEnd)
+            val dateRange = createDateRangeIn(year, month, lastDateOfMonth, periodStart, periodEnd)
             return DateCalendar(dateRange)
         }
 
         private fun checkValid(
             year: Int,
             month: Int,
+            lastDateOfMonth: Int,
             periodStart: LocalDate,
             periodEnd: LocalDate,
         ) {
-            val startDate = LocalDate.of(year, month, periodStart.dayOfMonth)
-            val endDate = LocalDate.of(year, month, periodEnd.dayOfMonth)
+            val startDate = LocalDate.of(year, month, periodStart.dayOfMonth.coerceAtMost(lastDateOfMonth))
+            val endDate = LocalDate.of(year, month, periodEnd.dayOfMonth.coerceAtMost(lastDateOfMonth))
             val isBetweenPeriod = periodStart.isBeforeOrEqual(startDate) && periodEnd.isAfterOrEqual(endDate)
             val isValidPeriod = periodStart.isBeforeOrEqual(periodEnd)
             require(isBetweenPeriod) { IllegalArgumentException("${year}년 ${month}월은 $periodStart $periodEnd 사이여야 합니다.") }
@@ -41,10 +43,10 @@ data class DateCalendar private constructor(val availableDates: List<Int>) {
         private fun createDateRangeIn(
             year: Int,
             month: Int,
+            lastDateOfMonth: Int,
             periodStart: LocalDate?,
             periodEnd: LocalDate?,
         ): List<Int> {
-            val lastDateOfMonth = YearMonth.of(year, month).lengthOfMonth()
             return if (periodStart != null && periodEnd != null) {
                 calculateDateRangeIn(year, month, lastDateOfMonth, periodStart, periodEnd)
             } else {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
@@ -3,7 +3,9 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class DateCalendar(private val availableDates: List<Int>) {
+data class DateCalendar private constructor(val availableDates: List<Int>) {
+    fun getClosestDate(target: Int): Int = target.coerceIn(availableDates.first(), availableDates.last())
+
     companion object {
         private const val FIRST_DATE = 1
 
@@ -13,9 +15,28 @@ data class DateCalendar(private val availableDates: List<Int>) {
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
         ): DateCalendar {
+            if (periodStart != null && periodEnd != null) checkValid(year, month, periodStart, periodEnd)
             val dateRange = createDateRangeIn(year, month, periodStart, periodEnd)
             return DateCalendar(dateRange)
         }
+
+        private fun checkValid(
+            year: Int,
+            month: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ) {
+            val startDate = LocalDate.of(year, month, periodStart.dayOfMonth)
+            val endDate = LocalDate.of(year, month, periodEnd.dayOfMonth)
+            val isBetweenPeriod = periodStart.isBeforeOrEqual(startDate) && periodEnd.isAfterOrEqual(endDate)
+            val isValidPeriod = periodStart.isBeforeOrEqual(periodEnd)
+            require(isBetweenPeriod) { IllegalArgumentException("${year}년 ${month}월은 $periodStart $periodEnd 사이여야 합니다.") }
+            require(isValidPeriod) { IllegalArgumentException("$year $month $periodStart $periodEnd 기간이 유효하지 않습니다.") }
+        }
+
+        private fun LocalDate.isAfterOrEqual(target: LocalDate?) = (isAfter(target) || isEqual(target))
+
+        private fun LocalDate.isBeforeOrEqual(target: LocalDate?) = (isBefore(target) || isEqual(target))
 
         private fun createDateRangeIn(
             year: Int,
@@ -39,8 +60,19 @@ data class DateCalendar(private val availableDates: List<Int>) {
             periodEnd: LocalDate,
         ): List<Int> =
             when {
-                isInSameMonth(year, month, periodStart, periodEnd) -> createDatesBetween(periodStart.dayOfMonth, periodEnd.dayOfMonth)
-                isStartMonth(year, month, periodStart) -> createDatesBetween(periodStart.dayOfMonth, lastDateOfMonth)
+                isInSameMonth(
+                    year,
+                    month,
+                    periodStart,
+                    periodEnd,
+                ) -> createDatesBetween(periodStart.dayOfMonth, periodEnd.dayOfMonth)
+
+                isStartMonth(year, month, periodStart) ->
+                    createDatesBetween(
+                        periodStart.dayOfMonth,
+                        lastDateOfMonth,
+                    )
+
                 isEndMonth(year, month, periodEnd) -> createDatesBetween(1, periodEnd.dayOfMonth)
                 else -> createDatesBetween(1, lastDateOfMonth)
             }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/DateCalendar.kt
@@ -1,0 +1,72 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+import java.time.YearMonth
+
+data class DateCalendar(private val availableDates: List<Int>) {
+    companion object {
+        private const val FIRST_DATE = 1
+
+        fun of(
+            year: Int,
+            month: Int,
+            periodStart: LocalDate? = null,
+            periodEnd: LocalDate? = null,
+        ): DateCalendar {
+            val dateRange = createDateRangeIn(year, month, periodStart, periodEnd)
+            return DateCalendar(dateRange)
+        }
+
+        private fun createDateRangeIn(
+            year: Int,
+            month: Int,
+            periodStart: LocalDate?,
+            periodEnd: LocalDate?,
+        ): List<Int> {
+            val lastDateOfMonth = YearMonth.of(year, month).lengthOfMonth()
+            return if (periodStart != null && periodEnd != null) {
+                calculateDateRangeIn(year, month, lastDateOfMonth, periodStart, periodEnd)
+            } else {
+                createDatesBetween(FIRST_DATE, lastDateOfMonth)
+            }
+        }
+
+        private fun calculateDateRangeIn(
+            year: Int,
+            month: Int,
+            lastDateOfMonth: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ): List<Int> =
+            when {
+                isInSameMonth(year, month, periodStart, periodEnd) -> createDatesBetween(periodStart.dayOfMonth, periodEnd.dayOfMonth)
+                isStartMonth(year, month, periodStart) -> createDatesBetween(periodStart.dayOfMonth, lastDateOfMonth)
+                isEndMonth(year, month, periodEnd) -> createDatesBetween(1, periodEnd.dayOfMonth)
+                else -> createDatesBetween(1, lastDateOfMonth)
+            }
+
+        private fun isInSameMonth(
+            year: Int,
+            month: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ) = isStartMonth(year, month, periodStart) && isEndMonth(year, month, periodEnd)
+
+        private fun isStartMonth(
+            year: Int,
+            month: Int,
+            periodStart: LocalDate,
+        ) = (year == periodStart.year && month == periodStart.monthValue)
+
+        private fun isEndMonth(
+            year: Int,
+            month: Int,
+            periodEnd: LocalDate,
+        ) = (year == periodEnd.year && month == periodEnd.monthValue)
+
+        private fun createDatesBetween(
+            startDate: Int,
+            endDate: Int,
+        ) = (startDate..endDate).toList()
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -2,7 +2,6 @@ package com.on.staccato.domain.model
 
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.YearMonth
 
 data class MemoryCandidate(
     val memoryId: Long,
@@ -33,96 +32,4 @@ data class MemoryCandidate(
     }
 
     private fun LocalDateTime.changeTimeToNoon(): LocalDateTime = withHour(12).withMinute(0)
-
-    companion object {
-        fun buildNumberPickerDates(
-            startAt: LocalDate?,
-            endAt: LocalDate?,
-        ): Map<Int, Map<Int, List<Int>>> {
-            return if (startAt != null && endAt != null) {
-                buildAvailableDates(startAt, endAt)
-            } else {
-                buildDefaultDates()
-            }
-        }
-
-        private fun buildAvailableDates(
-            startAt: LocalDate,
-            endAt: LocalDate,
-        ) = getAvailableYears(startAt, endAt).associateWith { year ->
-            getAvailableMonths(year, startAt, endAt).associateWith { month ->
-                getAvailableDays(year, month, startAt, endAt)
-            }
-        }
-
-        private fun getAvailableYears(
-            startAt: LocalDate,
-            endAt: LocalDate,
-        ): List<Int> {
-            return (startAt.year..endAt.year).toList()
-        }
-
-        private fun getAvailableMonths(
-            year: Int,
-            startAt: LocalDate,
-            endAt: LocalDate,
-        ): List<Int> {
-            return when {
-                year == startAt.year && year == endAt.year -> (startAt.monthValue..endAt.monthValue).toList()
-                year == startAt.year -> (startAt.monthValue..12).toList()
-                year == endAt.year -> (1..endAt.monthValue).toList()
-                else -> (1..12).toList()
-            }
-        }
-
-        private fun getAvailableDays(
-            year: Int,
-            month: Int,
-            startAt: LocalDate,
-            endAt: LocalDate,
-        ): List<Int> {
-            val yearMonth = YearMonth.of(year, month)
-            val daysInMonth = yearMonth.lengthOfMonth()
-
-            return when {
-                year == startAt.year && month == startAt.monthValue && year == endAt.year && month == endAt.monthValue -> {
-                    (startAt.dayOfMonth..endAt.dayOfMonth).toList()
-                }
-
-                year == startAt.year && month == startAt.monthValue -> (startAt.dayOfMonth..daysInMonth).toList()
-                year == endAt.year && month == endAt.monthValue -> (1..endAt.dayOfMonth).toList()
-                else -> (1..daysInMonth).toList()
-            }
-        }
-
-        private fun buildDefaultDates(): Map<Int, Map<Int, List<Int>>> {
-            val defaultStart = LocalDate.now().minusYears(10)
-            val defaultEnd = LocalDate.now().plusYears(10)
-            return getDefaultYears(defaultStart, defaultEnd).associateWith { year ->
-                getDefaultMonths().associateWith { month ->
-                    getDefaultDays(year, month)
-                }
-            }
-        }
-
-        private fun getDefaultYears(
-            startAt: LocalDate,
-            endAt: LocalDate,
-        ): List<Int> {
-            return (startAt.year..endAt.year).toList()
-        }
-
-        private fun getDefaultMonths(): List<Int> {
-            return (1..12).toList()
-        }
-
-        private fun getDefaultDays(
-            year: Int,
-            month: Int,
-        ): List<Int> {
-            val yearMonth = YearMonth.of(year, month)
-            val daysInMonth = yearMonth.lengthOfMonth()
-            return (1..daysInMonth).toList()
-        }
-    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -1,6 +1,7 @@
 package com.on.staccato.domain.model
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.YearMonth
 
 data class MemoryCandidate(
@@ -9,6 +10,21 @@ data class MemoryCandidate(
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
+    fun getClosestDateTime(
+        date : LocalDateTime
+    ): LocalDateTime {
+        if (startAt == null || endAt == null) return date
+
+        val startDateTime = startAt.atStartOfDay()
+        val endDateTime = endAt.atStartOfDay()
+
+        return when {
+            date.isBefore(startDateTime) -> startDateTime // 현재 시간이 startAt 이전일 때 startAt 반환
+            date.isAfter(endDateTime) -> endDateTime // 현재 시간이 endAt 이후일 때 endAt 반환
+            else -> date // 현재 시간이 범위 내에 있을 때 now 반환
+        }
+    }
+
     fun isDateWithinPeriod(date: LocalDate): Boolean {
         if (startAt == null || endAt == null) return true
         return date in startAt..endAt

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -10,9 +10,7 @@ data class MemoryCandidate(
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
-    fun getClosestDateTime(
-        date : LocalDateTime
-    ): LocalDateTime {
+    fun getClosestDateTime(date: LocalDateTime): LocalDateTime {
         if (startAt == null || endAt == null) return date
 
         val startDateTime = startAt.atStartOfDay()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -18,11 +18,11 @@ data class MemoryCandidate(
 
         return when {
             date.isBefore(startDateTime) ->
-                startDateTime.toLocalDate()
-                    .atTime(12, 0)
+                startDateTime.changeTimeToNoon()
+
             date.isAfter(endDateTime) ->
-                endDateTime.toLocalDate()
-                    .atTime(12, 0)
+                endDateTime.changeTimeToNoon()
+
             else -> date
         }
     }
@@ -31,6 +31,8 @@ data class MemoryCandidate(
         if (startAt == null || endAt == null) return true
         return date in startAt..endAt
     }
+
+    private fun LocalDateTime.changeTimeToNoon(): LocalDateTime = withHour(12).withMinute(0)
 
     companion object {
         fun buildNumberPickerDates(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -3,14 +3,17 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 import java.time.YearMonth
 
-data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>)
-
 data class MemoryCandidate(
     val memoryId: Long,
     val memoryTitle: String,
     val startAt: LocalDate?,
     val endAt: LocalDate?,
 ) {
+    fun isDateWithinPeriod(date: LocalDate): Boolean {
+        if (startAt == null || endAt == null) return true
+        return date in startAt..endAt
+    }
+
     companion object {
         fun buildNumberPickerDates(
             startAt: LocalDate?,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidate.kt
@@ -14,12 +14,16 @@ data class MemoryCandidate(
         if (startAt == null || endAt == null) return date
 
         val startDateTime = startAt.atStartOfDay()
-        val endDateTime = endAt.atStartOfDay()
+        val endDateTime = endAt.atTime(23, 59)
 
         return when {
-            date.isBefore(startDateTime) -> startDateTime // 현재 시간이 startAt 이전일 때 startAt 반환
-            date.isAfter(endDateTime) -> endDateTime // 현재 시간이 endAt 이후일 때 endAt 반환
-            else -> date // 현재 시간이 범위 내에 있을 때 now 반환
+            date.isBefore(startDateTime) ->
+                startDateTime.toLocalDate()
+                    .atTime(12, 0)
+            date.isAfter(endDateTime) ->
+                endDateTime.toLocalDate()
+                    .atTime(12, 0)
+            else -> date
         }
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -5,5 +5,5 @@ import java.time.LocalDate
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
     fun filterCandidatesBy(date: LocalDate): List<MemoryCandidate> = memoryCandidate.filter { it.isDateWithinPeriod(date) }
 
-    fun filterCandidatesBy(memoryId: Long): List<MemoryCandidate> = memoryCandidate.filter { it.memoryId == memoryId }
+    fun findCandidatesBy(memoryId: Long): MemoryCandidate? = memoryCandidate.find { it.memoryId == memoryId }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -4,4 +4,6 @@ import java.time.LocalDate
 
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
     fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+
+    fun getValidMemoryCandidate(memoryId: Long) = memoryCandidate.filter { it.memoryId == memoryId }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -1,0 +1,7 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+
+data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
+    fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -3,7 +3,7 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
-    fun getValidMemoryCandidate(date: LocalDate) = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+    fun filterCandidatesBy(date: LocalDate): List<MemoryCandidate> = memoryCandidate.filter { it.isDateWithinPeriod(date) }
 
-    fun getValidMemoryCandidate(memoryId: Long) = memoryCandidate.filter { it.memoryId == memoryId }
+    fun filterCandidatesBy(memoryId: Long): List<MemoryCandidate> = memoryCandidate.filter { it.memoryId == memoryId }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MemoryCandidates.kt
@@ -3,7 +3,17 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 
 data class MemoryCandidates(val memoryCandidate: List<MemoryCandidate>) {
-    fun filterCandidatesBy(date: LocalDate): List<MemoryCandidate> = memoryCandidate.filter { it.isDateWithinPeriod(date) }
+    fun filterBy(date: LocalDate): MemoryCandidates = copy(memoryCandidate = memoryCandidate.filter { it.isDateWithinPeriod(date) })
 
-    fun findCandidatesBy(memoryId: Long): MemoryCandidate? = memoryCandidate.find { it.memoryId == memoryId }
+    fun findBy(memoryId: Long): MemoryCandidate? = memoryCandidate.find { it.memoryId == memoryId }
+
+    fun findByIdOrFirst(targetId: Long?): MemoryCandidate? =
+        memoryCandidate.find { it.memoryId == targetId }
+            ?: memoryCandidate.firstOrNull()
+
+    companion object {
+        val emptyMemoryCandidates = MemoryCandidates(emptyList())
+
+        fun from(vararg memoryCandidate: MemoryCandidate) = MemoryCandidates(listOf(*memoryCandidate))
+    }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MonthCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MonthCalendar.kt
@@ -3,7 +3,19 @@ package com.on.staccato.domain.model
 import com.on.staccato.domain.model.DateCalendar.Companion.of
 import java.time.LocalDate
 
-data class MonthCalendar(private val monthToDateCalendar: Map<Int, DateCalendar>) {
+data class MonthCalendar private constructor(private val monthToDateCalendar: Map<Int, DateCalendar>) {
+    fun getAvailableMonths(): List<Int> = monthToDateCalendar.keys.toList()
+
+    fun getAvailableDates(selectedMonth: Int): List<Int> =
+        monthToDateCalendar[selectedMonth]?.availableDates ?: throw IllegalArgumentException()
+
+    fun getClosestMonth(targetMonth: Int): Int {
+        val availableMonths = getAvailableMonths()
+        return targetMonth.coerceIn(availableMonths.first(), availableMonths.last())
+    }
+
+    fun findDateCalendar(selectedMonth: Int): DateCalendar? = monthToDateCalendar[selectedMonth]
+
     companion object {
         private const val JANUARY = 1
         private const val DECEMBER = 12
@@ -14,6 +26,7 @@ data class MonthCalendar(private val monthToDateCalendar: Map<Int, DateCalendar>
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
         ): MonthCalendar {
+            if (periodStart != null && periodEnd != null) checkValid(year, periodStart, periodEnd)
             val monthRange = createMonthRangeIn(year, periodStart, periodEnd)
             return MonthCalendar(
                 monthRange.associateWith { month ->
@@ -21,6 +34,19 @@ data class MonthCalendar(private val monthToDateCalendar: Map<Int, DateCalendar>
                 },
             )
         }
+
+        private fun checkValid(
+            year: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ) {
+            val isBetweenPeriod = (year in periodStart.year..periodEnd.year)
+            val isValidPeriod = periodStart.isBeforeOrEqual(periodEnd)
+            require(isBetweenPeriod) { IllegalArgumentException("${year}년은 ${periodStart.year}년과 ${periodEnd.year}년 사이여야 합니다.") }
+            require(isValidPeriod) { IllegalArgumentException("시작 날짜 ${periodStart}는 종료 날짜 ${periodEnd}보다 같거나 빨라야 합니다.") }
+        }
+
+        private fun LocalDate.isBeforeOrEqual(target: LocalDate?) = (isBefore(target) || isEqual(target))
 
         private fun createMonthRangeIn(
             year: Int,
@@ -39,8 +65,18 @@ data class MonthCalendar(private val monthToDateCalendar: Map<Int, DateCalendar>
             periodEnd: LocalDate,
         ): List<Int> =
             when {
-                isInSameYear(year, periodStart, periodEnd) -> createMonthsBetween(periodStart.monthValue, periodEnd.monthValue)
-                isStartYear(year, periodStart) -> createMonthsBetween(periodStart.monthValue, DECEMBER)
+                isInSameYear(
+                    year,
+                    periodStart,
+                    periodEnd,
+                ) -> createMonthsBetween(periodStart.monthValue, periodEnd.monthValue)
+
+                isStartYear(year, periodStart) ->
+                    createMonthsBetween(
+                        periodStart.monthValue,
+                        DECEMBER,
+                    )
+
                 isEndYear(year, periodEnd) -> createMonthsBetween(JANUARY, periodEnd.monthValue)
                 else -> fullMonths
             }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MonthCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/MonthCalendar.kt
@@ -1,0 +1,69 @@
+package com.on.staccato.domain.model
+
+import com.on.staccato.domain.model.DateCalendar.Companion.of
+import java.time.LocalDate
+
+data class MonthCalendar(private val monthToDateCalendar: Map<Int, DateCalendar>) {
+    companion object {
+        private const val JANUARY = 1
+        private const val DECEMBER = 12
+        private val fullMonths: List<Int> = (JANUARY..DECEMBER).toList()
+
+        fun of(
+            year: Int,
+            periodStart: LocalDate? = null,
+            periodEnd: LocalDate? = null,
+        ): MonthCalendar {
+            val monthRange = createMonthRangeIn(year, periodStart, periodEnd)
+            return MonthCalendar(
+                monthRange.associateWith { month ->
+                    of(year, month, periodStart, periodEnd)
+                },
+            )
+        }
+
+        private fun createMonthRangeIn(
+            year: Int,
+            periodStart: LocalDate?,
+            periodEnd: LocalDate?,
+        ): List<Int> =
+            if (periodStart != null && periodEnd != null) {
+                calculateMonthRangeIn(year, periodStart, periodEnd)
+            } else {
+                fullMonths
+            }
+
+        private fun calculateMonthRangeIn(
+            year: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ): List<Int> =
+            when {
+                isInSameYear(year, periodStart, periodEnd) -> createMonthsBetween(periodStart.monthValue, periodEnd.monthValue)
+                isStartYear(year, periodStart) -> createMonthsBetween(periodStart.monthValue, DECEMBER)
+                isEndYear(year, periodEnd) -> createMonthsBetween(JANUARY, periodEnd.monthValue)
+                else -> fullMonths
+            }
+
+        private fun isInSameYear(
+            year: Int,
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ) = isStartYear(year, periodStart) && isEndYear(year, periodEnd)
+
+        private fun isStartYear(
+            year: Int,
+            periodStart: LocalDate,
+        ) = year == periodStart.year
+
+        private fun isEndYear(
+            year: Int,
+            periodEnd: LocalDate,
+        ) = year == periodEnd.year
+
+        private fun createMonthsBetween(
+            startMonth: Int,
+            endMonth: Int,
+        ) = (startMonth..endMonth).toList()
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -74,6 +74,15 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
         private const val DECADE_RANGE: Long = 10L
         val hours = (0 until 24).toList()
 
+        fun from(visitedAt: LocalDate): YearCalendar {
+            val yearRange = createDecadeOfYearsAroundCurrent(visitedAt)
+            return YearCalendar(
+                yearRange.associateWith { year ->
+                    of(year)
+                },
+            )
+        }
+
         fun of(
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
@@ -104,7 +113,7 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
             if (periodStart != null && periodEnd != null) {
                 createYearsBetween(periodStart.year, periodEnd.year)
             } else {
-                createDecadeOfYearsAroundCurrent()
+                createDecadeOfYearsAroundCurrent(LocalDate.now())
             }
 
         private fun createYearsBetween(
@@ -114,10 +123,9 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
             return (startYear..endYear).toList()
         }
 
-        private fun createDecadeOfYearsAroundCurrent(): List<Int> {
-            val now = LocalDate.now()
-            val decadeAgo = now.minusYears(DECADE_RANGE)
-            val decadeAhead = now.plusYears(DECADE_RANGE)
+        private fun createDecadeOfYearsAroundCurrent(targetDate: LocalDate): List<Int> {
+            val decadeAgo = targetDate.minusYears(DECADE_RANGE)
+            val decadeAhead = targetDate.plusYears(DECADE_RANGE)
             return createYearsBetween(decadeAgo.year, decadeAhead.year)
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -2,8 +2,72 @@ package com.on.staccato.domain.model
 
 import com.on.staccato.domain.model.MonthCalendar.Companion.of
 import java.time.LocalDate
+import java.time.LocalDateTime
 
-data class YearCalendar(private val yearToMonthCalender: Map<Int, MonthCalendar>) {
+data class YearCalendar private constructor(private val yearToMonthCalender: Map<Int, MonthCalendar>) {
+    var selectedYear: Int = yearToMonthCalender.keys.first()
+        private set
+    var selectedMonth: Int = getAvailableMonths().first()
+        private set
+    var selectedDate: Int = getAvailableDates().first()
+        private set
+    var selectedHour: Int = DEFAULT_HOUR
+        private set
+
+    var selectedDateTime: LocalDateTime = LocalDateTime.of(selectedYear, selectedMonth, selectedDate, selectedHour, DEFAULT_MINUTE)
+        get() = LocalDateTime.of(selectedYear, selectedMonth, selectedDate, selectedHour, DEFAULT_MINUTE)
+        private set
+
+    fun getAvailableYears(): List<Int> = yearToMonthCalender.keys.toList()
+
+    fun getAvailableMonths(): List<Int> = yearToMonthCalender[selectedYear]?.getAvailableMonths() ?: throw IllegalArgumentException()
+
+    fun getAvailableDates(): List<Int> =
+        yearToMonthCalender[selectedYear]?.getAvailableDates(selectedMonth)
+            ?: throw IllegalArgumentException()
+
+    fun initSelectedDateTime(dateTime: LocalDateTime) {
+        selectedYear = dateTime.year
+        selectedMonth = dateTime.monthValue
+        selectedDate = dateTime.dayOfMonth
+        selectedHour = dateTime.hour
+    }
+
+    fun changeSelectedYear(newYear: Int) {
+        selectedYear = newYear
+        resetSelectedMonths()
+    }
+
+    fun changeSelectedMonth(newMonth: Int) {
+        selectedMonth = newMonth
+        resetSelectedDates()
+    }
+
+    fun changeSelectedDate(newDate: Int) {
+        selectedDate = newDate
+    }
+
+    fun changeSelectedHour(newHour: Int) {
+        selectedHour = newHour
+    }
+
+    private fun resetSelectedMonths() {
+        findMonthCalendar()?.let { newMonthCalender ->
+            selectedMonth = newMonthCalender.getClosestMonth(selectedMonth)
+            resetSelectedDates()
+        }
+    }
+
+    private fun resetSelectedDates() {
+        findDateCalendar()?.let { newDateCalender ->
+            selectedDate = newDateCalender.getClosestDate(selectedDate)
+        }
+    }
+
+    private fun findMonthCalendar(): MonthCalendar? = yearToMonthCalender[selectedYear]
+
+    private fun findDateCalendar(): DateCalendar? = findMonthCalendar()?.findDateCalendar(selectedMonth)
+
     companion object {
         private const val DEFAULT_HOUR: Int = 12
         private const val DEFAULT_MINUTE: Int = 0

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -5,12 +5,16 @@ import java.time.LocalDate
 
 data class YearCalendar(private val yearToMonthCalender: Map<Int, MonthCalendar>) {
     companion object {
+        private const val DEFAULT_HOUR: Int = 12
+        private const val DEFAULT_MINUTE: Int = 0
         private const val DECADE_RANGE: Long = 10L
+        val hours = (0 until 24).toList()
 
         fun of(
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
         ): YearCalendar {
+            if (periodStart != null && periodEnd != null) checkValid(periodStart, periodEnd)
             val yearRange = createYearRange(periodStart, periodEnd)
             return YearCalendar(
                 yearRange.associateWith { year ->
@@ -18,6 +22,16 @@ data class YearCalendar(private val yearToMonthCalender: Map<Int, MonthCalendar>
                 },
             )
         }
+
+        private fun checkValid(
+            periodStart: LocalDate,
+            periodEnd: LocalDate,
+        ) {
+            val isValidPeriod = periodStart.isBeforeOrEqual(periodEnd)
+            require(isValidPeriod) { IllegalArgumentException("시작 날짜 ${periodStart}는 종료 날짜 ${periodEnd}보다 같거나 빨라야 합니다.") }
+        }
+
+        private fun LocalDate.isBeforeOrEqual(target: LocalDate?) = (isBefore(target) || isEqual(target))
 
         private fun createYearRange(
             periodStart: LocalDate?,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -1,0 +1,46 @@
+package com.on.staccato.domain.model
+
+import com.on.staccato.domain.model.MonthCalendar.Companion.of
+import java.time.LocalDate
+
+data class YearCalendar(private val yearToMonthCalender: Map<Int, MonthCalendar>) {
+    companion object {
+        private const val DECADE_RANGE: Long = 10L
+
+        fun of(
+            periodStart: LocalDate? = null,
+            periodEnd: LocalDate? = null,
+        ): YearCalendar {
+            val yearRange = createYearRange(periodStart, periodEnd)
+            return YearCalendar(
+                yearRange.associateWith { year ->
+                    of(year, periodStart, periodEnd)
+                },
+            )
+        }
+
+        private fun createYearRange(
+            periodStart: LocalDate?,
+            periodEnd: LocalDate?,
+        ): List<Int> =
+            if (periodStart != null && periodEnd != null) {
+                createYearsBetween(periodStart.year, periodEnd.year)
+            } else {
+                createDecadeOfYearsAroundCurrent()
+            }
+
+        private fun createYearsBetween(
+            startYear: Int,
+            endYear: Int,
+        ): List<Int> {
+            return (startYear..endYear).toList()
+        }
+
+        private fun createDecadeOfYearsAroundCurrent(): List<Int> {
+            val now = LocalDate.now()
+            val decadeAgo = now.minusYears(DECADE_RANGE)
+            val decadeAhead = now.plusYears(DECADE_RANGE)
+            return createYearsBetween(decadeAgo.year, decadeAhead.year)
+        }
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -71,11 +71,11 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
     companion object {
         private const val DEFAULT_HOUR: Int = 12
         private const val DEFAULT_MINUTE: Int = 0
-        private const val DECADE_RANGE: Long = 10L
+        private const val HUNDRED_RANGE: Long = 100L
         val hours = (0 until 24).toList()
 
         fun from(visitedAt: LocalDate): YearCalendar {
-            val yearRange = createDecadeOfYearsAroundCurrent(visitedAt)
+            val yearRange = createHundredOfYearsAroundCurrent(visitedAt)
             return YearCalendar(
                 yearRange.associateWith { year ->
                     of(year)
@@ -113,7 +113,7 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
             if (periodStart != null && periodEnd != null) {
                 createYearsBetween(periodStart.year, periodEnd.year)
             } else {
-                createDecadeOfYearsAroundCurrent(LocalDate.now())
+                createHundredOfYearsAroundCurrent(LocalDate.now())
             }
 
         private fun createYearsBetween(
@@ -123,10 +123,10 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
             return (startYear..endYear).toList()
         }
 
-        private fun createDecadeOfYearsAroundCurrent(targetDate: LocalDate): List<Int> {
-            val decadeAgo = targetDate.minusYears(DECADE_RANGE)
-            val decadeAhead = targetDate.plusYears(DECADE_RANGE)
-            return createYearsBetween(decadeAgo.year, decadeAhead.year)
+        private fun createHundredOfYearsAroundCurrent(targetDate: LocalDate): List<Int> {
+            val hundredYearsAgo = targetDate.minusYears(HUNDRED_RANGE)
+            val hundredYearsAhead = targetDate.plusYears(HUNDRED_RANGE)
+            return createYearsBetween(hundredYearsAgo.year, hundredYearsAhead.year)
         }
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -16,21 +16,25 @@ fun TextView.setSelectedMemory(
     selectedMemory: MemoryCandidate?,
     memoryCandidates: MemoryCandidates?,
 ) {
-    if (memoryCandidates?.memoryCandidate?.isEmpty() == true) {
-        text = resources.getString(R.string.staccato_creation_no_memory)
-        setTextColor(resources.getColor(R.color.gray3, null))
-        isClickable = false
-        isFocusable = false
-    } else if (selectedMemory == null) {
-        text = resources.getString(R.string.staccato_creation_no_memory_in_this_date)
-        setTextColor(resources.getColor(R.color.gray3, null))
-        isClickable = false
-        isFocusable = false
-    } else {
-        text = selectedMemory.memoryTitle
-        isClickable = true
-        isFocusable = true
-        setTextColor(resources.getColor(R.color.staccato_black, null))
+    when {
+        (memoryCandidates?.memoryCandidate?.isEmpty() == true) -> {
+            text = resources.getString(R.string.staccato_creation_no_memory)
+            setTextColor(resources.getColor(R.color.gray3, null))
+            isClickable = false
+            isFocusable = false
+        }
+        (selectedMemory == null) -> {
+            text = resources.getString(R.string.staccato_creation_no_memory_in_this_date)
+            setTextColor(resources.getColor(R.color.gray3, null))
+            isClickable = false
+            isFocusable = false
+        }
+        else -> {
+            text = selectedMemory.memoryTitle
+            isClickable = true
+            isFocusable = true
+            setTextColor(resources.getColor(R.color.staccato_black, null))
+        }
     }
 }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -17,37 +17,29 @@ fun TextView.setSelectedMemory(
     memoryCandidates: MemoryCandidates?,
 ) {
     if (memoryCandidates?.memoryCandidate?.isEmpty() == true) {
-        text = resources.getString(R.string.staccato_creation_no_memory_hint)
+        text = resources.getString(R.string.staccato_creation_no_memory)
         setTextColor(resources.getColor(R.color.gray3, null))
         isClickable = false
         isFocusable = false
     } else if (selectedMemory == null) {
-        text = resources.getString(R.string.staccato_creation_memory_selection_hint)
-        setTextColor(resources.getColor(R.color.gray3, null))
-        isClickable = true
-        isFocusable = true
-    } else {
-        text = selectedMemory.memoryTitle
-        setTextColor(resources.getColor(R.color.staccato_black, null))
-    }
-}
-
-@BindingAdapter(value = ["dateTimeWithAmPm", "memoryCandidates"])
-fun TextView.setDateTimeWithAmPm(
-    dateTime: LocalDateTime?,
-    memoryCandidates: MemoryCandidates?,
-) {
-    if (memoryCandidates?.memoryCandidate?.isEmpty() == true) {
-        text = resources.getString(R.string.staccato_creation_memory_selection_hint)
+        text = resources.getString(R.string.staccato_creation_no_memory_in_this_date)
         setTextColor(resources.getColor(R.color.gray3, null))
         isClickable = false
         isFocusable = false
     } else {
-        text = dateTime?.let(::getFormattedLocalDateTime) ?: EMPTY_TEXT
-        setTextColor(resources.getColor(R.color.staccato_black, null))
+        text = selectedMemory.memoryTitle
         isClickable = true
         isFocusable = true
+        setTextColor(resources.getColor(R.color.staccato_black, null))
     }
+}
+
+@BindingAdapter("dateTimeWithAmPm")
+fun TextView.setDateTimeWithAmPm(dateTime: LocalDateTime?) {
+    text = dateTime?.let(::getFormattedLocalDateTime) ?: EMPTY_TEXT
+    setTextColor(resources.getColor(R.color.staccato_black, null))
+    isClickable = true
+    isFocusable = true
 }
 
 @BindingAdapter(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -65,11 +65,6 @@ fun TextView.setIsMemoryCandidatesEmptyVisibility(memoryCandidates: MemoryCandid
     isGone = !memoryCandidates?.memoryCandidate.isNullOrEmpty()
 }
 
-@BindingAdapter("isMemoryEmpty")
-fun TextView.setIsMemoryEmptyVisibility(items: List<Int>?) {
-    isGone = !items.isNullOrEmpty()
-}
-
 @BindingAdapter("visitedAtHistory")
 fun TextView.formatVisitedAtHistory(visitedAt: LocalDateTime?) {
     text = visitedAt?.let {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/MainActivity.kt
@@ -108,10 +108,8 @@ class MainActivity :
 
     override fun onStaccatoCreationClicked() {
         StaccatoCreationActivity.startWithResultLauncher(
-            0L,
-            "임시 추억",
-            this,
-            staccatoCreationLauncher,
+            context = this,
+            activityLauncher = staccatoCreationLauncher,
         )
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memory/MemoryFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/memory/MemoryFragment.kt
@@ -87,10 +87,10 @@ class MemoryFragment :
         viewModel.memory.value?.let {
             val staccatoCreationLauncher = (activity as MainActivity).staccatoCreationLauncher
             StaccatoCreationActivity.startWithResultLauncher(
-                memoryId,
-                it.title,
                 requireContext(),
                 staccatoCreationLauncher,
+                memoryId,
+                it.title,
             )
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/StaccatoFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/StaccatoFragment.kt
@@ -39,7 +39,10 @@ class StaccatoFragment :
         DeleteDialogFragment {
             staccatoViewModel.deleteStaccato(staccatoId)
         }
-    private val staccatoId by lazy { arguments?.getLong(STACCATO_ID_KEY) ?: DEFAULT_STACCATO_ID }
+    private val staccatoId by lazy {
+        arguments?.getLong(STACCATO_ID_KEY)
+            ?: throw IllegalStateException("staccatoId must not be null")
+    }
 
     override fun onViewCreated(
         view: View,
@@ -231,6 +234,5 @@ class StaccatoFragment :
 
     companion object {
         const val STACCATO_ID_KEY = "staccatoId"
-        const val DEFAULT_STACCATO_ID = -1L
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/StaccatoFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/StaccatoFragment.kt
@@ -40,8 +40,7 @@ class StaccatoFragment :
             staccatoViewModel.deleteStaccato(staccatoId)
         }
     private val staccatoId by lazy {
-        arguments?.getLong(STACCATO_ID_KEY)
-            ?: throw IllegalStateException("staccatoId must not be null")
+        arguments?.getLong(STACCATO_ID_KEY) ?: DEFAULT_STACCATO_ID
     }
 
     override fun onViewCreated(
@@ -234,5 +233,6 @@ class StaccatoFragment :
 
     companion object {
         const val STACCATO_ID_KEY = "staccatoId"
+        const val DEFAULT_STACCATO_ID = 0L
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/feeling/StaccatoFeelingSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/feeling/StaccatoFeelingSelectionFragment.kt
@@ -6,6 +6,7 @@ import androidx.fragment.app.viewModels
 import com.on.staccato.R
 import com.on.staccato.databinding.FragmentStaccatoFeelingSelectionBinding
 import com.on.staccato.presentation.base.BindingFragment
+import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.DEFAULT_STACCATO_ID
 import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.STACCATO_ID_KEY
 import com.on.staccato.presentation.staccato.viewmodel.StaccatoViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,8 +18,7 @@ class StaccatoFeelingSelectionFragment :
     private val staccatoViewModel: StaccatoViewModel by viewModels({ requireParentFragment() })
     private val staccatoFeelingSelectionViewModel: StaccatoFeelingSelectionViewModel by viewModels()
     private val staccatoId by lazy {
-        arguments?.getLong(STACCATO_ID_KEY)
-            ?: throw IllegalStateException("staccatoId must not be null")
+        arguments?.getLong(STACCATO_ID_KEY) ?: DEFAULT_STACCATO_ID
     }
 
     override fun onViewCreated(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/feeling/StaccatoFeelingSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/feeling/StaccatoFeelingSelectionFragment.kt
@@ -6,7 +6,6 @@ import androidx.fragment.app.viewModels
 import com.on.staccato.R
 import com.on.staccato.databinding.FragmentStaccatoFeelingSelectionBinding
 import com.on.staccato.presentation.base.BindingFragment
-import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.DEFAULT_STACCATO_ID
 import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.STACCATO_ID_KEY
 import com.on.staccato.presentation.staccato.viewmodel.StaccatoViewModel
 import dagger.hilt.android.AndroidEntryPoint
@@ -17,7 +16,10 @@ class StaccatoFeelingSelectionFragment :
     private lateinit var feelingSelectionAdapter: FeelingSelectionAdapter
     private val staccatoViewModel: StaccatoViewModel by viewModels({ requireParentFragment() })
     private val staccatoFeelingSelectionViewModel: StaccatoFeelingSelectionViewModel by viewModels()
-    private val staccatoId by lazy { arguments?.getLong(STACCATO_ID_KEY) ?: DEFAULT_STACCATO_ID }
+    private val staccatoId by lazy {
+        arguments?.getLong(STACCATO_ID_KEY)
+            ?: throw IllegalStateException("staccatoId must not be null")
+    }
 
     override fun onViewCreated(
         view: View,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -337,11 +337,11 @@ class StaccatoCreationActivity :
         }
     }
 
-    private fun updateMemoryCandidateAndVisitedAt(it: LocalDateTime) {
-        viewModel.setMemoryCandidateByVisitedAt(it)
+    private fun updateMemoryCandidateAndVisitedAt(visitedAt: LocalDateTime) {
+        viewModel.setMemoryCandidateByVisitedAt(visitedAt)
         visitedAtSelectionFragment.setVisitedAtPeriod(
-            it.toLocalDate().minusYears(10),
-            it.toLocalDate().plusYears(10),
+            visitedAt.toLocalDate().minusYears(10),
+            visitedAt.toLocalDate().plusYears(10),
         )
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -358,7 +358,7 @@ class StaccatoCreationActivity :
     }
 
     private fun updateMemoryCandidateAndVisitedAt(visitedAt: LocalDateTime) {
-        viewModel.setMemoryCandidateByVisitedAt(visitedAt)
+        viewModel.setMemoryCandidateBy(visitedAt)
         val visitedDate = visitedAt.toLocalDate()
         visitedAtSelectionFragment.setVisitedAtPeriod(
             visitedDate.minusYears(10),

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -358,7 +358,7 @@ class StaccatoCreationActivity :
     }
 
     private fun updateMemoryCandidateAndVisitedAt(visitedAt: LocalDateTime) {
-        viewModel.setMemoryCandidateBy(visitedAt)
+        viewModel.updateMemorySelectionBy(visitedAt)
         val visitedDate = visitedAt.toLocalDate()
         visitedAtSelectionFragment.setVisitedAtPeriod(
             visitedDate.minusYears(10),

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -75,7 +75,7 @@ class StaccatoCreationActivity :
     private lateinit var photoAttachAdapter: PhotoAttachAdapter
     private lateinit var itemTouchHelper: ItemTouchHelper
 
-    private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, 0L) }
+    private val memoryId by lazy { intent.getLongExtra(MEMORY_ID_KEY, DEFAULT_CATEGORY_ID) }
     private val memoryTitle by lazy { intent.getStringExtra(MEMORY_TITLE_KEY) ?: "" }
 
     private val locationPermissionManager =
@@ -313,7 +313,7 @@ class StaccatoCreationActivity :
         viewModel.selectedVisitedAt.observe(this) {
             it?.let {
                 visitedAtSelectionFragment.updateSelectedVisitedAt(it)
-                if (memoryId == 0L) {
+                if (memoryId == DEFAULT_CATEGORY_ID) {
                     updateMemoryCandidateAndVisitedAt(it)
                 }
             }
@@ -334,7 +334,7 @@ class StaccatoCreationActivity :
         viewModel.selectedMemory.observe(this) { it ->
             it?.let {
                 memorySelectionFragment.updateKeyMemory(it)
-                if (memoryId != 0L) {
+                if (memoryId != DEFAULT_CATEGORY_ID) {
                     visitedAtSelectionFragment.setVisitedAtPeriod(
                         it.startAt,
                         it.endAt,
@@ -466,12 +466,14 @@ class StaccatoCreationActivity :
 
     companion object {
         const val MEMORY_TITLE_KEY = "memoryTitle"
+        const val DEFAULT_CATEGORY_ID = 0L
+        private const val DEFAULT_CATEGORY_TITLE = ""
 
         fun startWithResultLauncher(
-            memoryId: Long,
-            memoryTitle: String,
             context: Context,
             activityLauncher: ActivityResultLauncher<Intent>,
+            memoryId: Long = DEFAULT_CATEGORY_ID,
+            memoryTitle: String = DEFAULT_CATEGORY_TITLE,
         ) {
             Intent(context, StaccatoCreationActivity::class.java).apply {
                 putExtra(MEMORY_ID_KEY, memoryId)

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -359,9 +359,10 @@ class StaccatoCreationActivity :
 
     private fun updateMemoryCandidateAndVisitedAt(visitedAt: LocalDateTime) {
         viewModel.setMemoryCandidateByVisitedAt(visitedAt)
+        val visitedDate = visitedAt.toLocalDate()
         visitedAtSelectionFragment.setVisitedAtPeriod(
-            visitedAt.toLocalDate().minusYears(10),
-            visitedAt.toLocalDate().plusYears(10),
+            visitedDate.minusYears(10),
+            visitedDate.plusYears(10),
         )
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -328,7 +328,7 @@ class StaccatoCreationActivity :
         }
         viewModel.selectableMemories.observe(this) {
             it?.let {
-                memorySelectionFragment.setItems(it)
+                memorySelectionFragment.setItems(it.memoryCandidate)
             }
         }
         viewModel.selectedMemory.observe(this) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -331,7 +331,7 @@ class StaccatoCreationActivity :
                 memorySelectionFragment.setItems(it)
             }
         }
-        viewModel.selectedMemory.observe(this) { it ->
+        viewModel.selectedMemory.observe(this) {
             it?.let {
                 memorySelectionFragment.updateKeyMemory(it)
                 if (memoryId != DEFAULT_CATEGORY_ID) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -279,9 +279,14 @@ class StaccatoCreationActivity :
     }
 
     private fun observeViewModelData() {
-        viewModel.placeName.observe(this) {
-            autocompleteFragment.setText(it)
-        }
+        observePhotoData()
+        observePlaceData()
+        observeVisitedAtData()
+        observeMemoryData()
+        observeCreatedStaccatoId()
+    }
+
+    private fun observePhotoData() {
         viewModel.isAddPhotoClicked.observe(this) {
             if (!photoAttachFragment.isAdded && it) {
                 photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
@@ -296,6 +301,26 @@ class StaccatoCreationActivity :
                 listOf(AttachedPhotoUiModel.addPhotoButton, *photos.attachedPhotos.toTypedArray()),
             )
         }
+    }
+
+    private fun observePlaceData() {
+        viewModel.placeName.observe(this) {
+            autocompleteFragment.setText(it)
+        }
+    }
+
+    private fun observeVisitedAtData() {
+        viewModel.selectedVisitedAt.observe(this) {
+            it?.let {
+                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
+                if (memoryId == 0L) {
+                    updateMemoryCandidateAndVisitedAt(it)
+                }
+            }
+        }
+    }
+
+    private fun observeMemoryData() {
         viewModel.memoryCandidates.observe(this) {
             it?.let {
                 viewModel.initMemoryAndVisitedAt(memoryId, LocalDateTime.now())
@@ -317,14 +342,9 @@ class StaccatoCreationActivity :
                 }
             }
         }
-        viewModel.selectedVisitedAt.observe(this) {
-            it?.let {
-                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
-                if (memoryId == 0L) {
-                    updateMemoryCandidateAndVisitedAt(it)
-                }
-            }
-        }
+    }
+
+    private fun observeCreatedStaccatoId() {
         viewModel.createdStaccatoId.observe(this) { createdStaccatoId ->
             val resultIntent =
                 Intent()

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -153,6 +153,9 @@ class StaccatoCreationActivity :
 
     override fun onVisitedAtSelectionClicked() {
         if (!visitedAtSelectionFragment.isAdded) {
+            viewModel.selectedVisitedAt.value?.let {
+                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
+            }
             visitedAtSelectionFragment.show(
                 fragmentManager,
                 VisitedAtSelectionFragment.TAG,
@@ -314,7 +317,7 @@ class StaccatoCreationActivity :
             it?.let {
                 visitedAtSelectionFragment.updateSelectedVisitedAt(it)
                 if (memoryId == DEFAULT_CATEGORY_ID) {
-                    updateMemoryCandidateAndVisitedAt(it)
+                    viewModel.updateMemorySelectionBy(it)
                 }
             }
         }
@@ -323,6 +326,9 @@ class StaccatoCreationActivity :
     private fun observeMemoryData() {
         viewModel.memoryCandidates.observe(this) {
             it?.let {
+                if (memoryId == DEFAULT_CATEGORY_ID) {
+                    visitedAtSelectionFragment.initCalendarByPeriod()
+                }
                 viewModel.initMemoryAndVisitedAt(memoryId, LocalDateTime.now())
             }
         }
@@ -335,7 +341,7 @@ class StaccatoCreationActivity :
             it?.let {
                 memorySelectionFragment.updateKeyMemory(it)
                 if (memoryId != DEFAULT_CATEGORY_ID) {
-                    visitedAtSelectionFragment.setVisitedAtPeriod(
+                    visitedAtSelectionFragment.initCalendarByPeriod(
                         it.startAt,
                         it.endAt,
                     )
@@ -355,15 +361,6 @@ class StaccatoCreationActivity :
             window.clearFlags(FLAG_NOT_TOUCHABLE)
             finish()
         }
-    }
-
-    private fun updateMemoryCandidateAndVisitedAt(visitedAt: LocalDateTime) {
-        viewModel.updateMemorySelectionBy(visitedAt)
-        val visitedDate = visitedAt.toLocalDate()
-        visitedAtSelectionFragment.setVisitedAtPeriod(
-            visitedDate.minusYears(10),
-            visitedDate.plusYears(10),
-        )
     }
 
     private fun fetchAddress(location: Location) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/dialog/VisitedAtSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/dialog/VisitedAtSelectionFragment.kt
@@ -49,15 +49,20 @@ class VisitedAtSelectionFragment : BottomSheetDialogFragment() {
         handler = newHandler
     }
 
+    fun initCalendarByVisitedAt(visitedAt: LocalDateTime) {
+        yearCalendar = YearCalendar.from(visitedAt.toLocalDate())
+        updateSelectedVisitedAt(visitedAt)
+    }
+
+    fun updateSelectedVisitedAt(visitedAt: LocalDateTime) {
+        yearCalendar.initSelectedDateTime(visitedAt)
+    }
+
     fun initCalendarByPeriod(
         startAt: LocalDate? = null,
         endAt: LocalDate? = null,
     ) {
         yearCalendar = YearCalendar.of(startAt, endAt)
-    }
-
-    fun updateSelectedVisitedAt(visitedAt: LocalDateTime) {
-        yearCalendar.initSelectedDateTime(visitedAt)
     }
 
     private fun initPickerPosition() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/dialog/VisitedAtSelectionFragment.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/dialog/VisitedAtSelectionFragment.kt
@@ -32,24 +32,6 @@ class VisitedAtSelectionFragment : BottomSheetDialogFragment() {
 
     private lateinit var handler: VisitedAtSelectionHandler
 
-    fun setOnVisitedAtSelected(newHandler: VisitedAtSelectionHandler) {
-        handler = newHandler
-    }
-
-    fun setVisitedAtPeriod(
-        startAt: LocalDate?,
-        endAt: LocalDate?,
-    ) {
-        yearCandidates = buildNumberPickerDates(startAt, endAt)
-    }
-
-    fun updateSelectedVisitedAt(visitedAt: LocalDateTime) {
-        selectedYear = visitedAt.year
-        selectedMonth = visitedAt.monthValue
-        selectedDay = visitedAt.dayOfMonth
-        selectedHour = visitedAt.hour
-    }
-
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -69,6 +51,29 @@ class VisitedAtSelectionFragment : BottomSheetDialogFragment() {
         setupPickerListeners()
         initConfirmButton()
         initPickerPosition()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    fun setOnVisitedAtSelected(newHandler: VisitedAtSelectionHandler) {
+        handler = newHandler
+    }
+
+    fun setVisitedAtPeriod(
+        startAt: LocalDate?,
+        endAt: LocalDate?,
+    ) {
+        yearCandidates = buildNumberPickerDates(startAt, endAt)
+    }
+
+    fun updateSelectedVisitedAt(visitedAt: LocalDateTime) {
+        selectedYear = visitedAt.year
+        selectedMonth = visitedAt.monthValue
+        selectedDay = visitedAt.dayOfMonth
+        selectedHour = visitedAt.hour
     }
 
     private fun setYearsByPeriod() {
@@ -98,11 +103,6 @@ class VisitedAtSelectionFragment : BottomSheetDialogFragment() {
         targetKey: Int,
     ) {
         this.value = targetList.indexOf(targetKey).takeIf { it >= 0 } ?: 0
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
     }
 
     private fun resetMonthsBy(year: Int) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -171,8 +171,8 @@ class StaccatoCreationViewModel
             currentDateTime: LocalDateTime,
         ) {
             if (memoryId == DEFAULT_CATEGORY_ID) {
-                setCurrentDateTimeAs(currentDateTime)
                 updateMemorySelectionBy(currentDateTime)
+                setCurrentDateTimeAs(currentDateTime)
             } else {
                 updateMemorySelectionBy(memoryId)
                 setClosestDateTimeAs(currentDateTime)

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -172,9 +172,9 @@ class StaccatoCreationViewModel
         ) {
             if (memoryId == DEFAULT_CATEGORY_ID) {
                 setCurrentDateTimeAs(currentDateTime)
-                setMemoryCandidateBy(currentDateTime)
+                updateMemorySelectionBy(currentDateTime)
             } else {
-                setMemoryCandidateBy(memoryId)
+                updateMemorySelectionBy(memoryId)
                 setClosestDateTimeAs(currentDateTime)
             }
         }
@@ -183,13 +183,13 @@ class StaccatoCreationViewModel
             _selectedVisitedAt.value = visitedAt
         }
 
-        fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
+        fun updateMemorySelectionBy(visitedAt: LocalDateTime) {
             val filteredMemories = memoryCandidates.value?.filterBy(visitedAt.toLocalDate()) ?: MemoryCandidates.emptyMemoryCandidates
             _selectableMemories.value = filteredMemories
             _selectedMemory.value = filteredMemories.findByIdOrFirst(selectedMemory.value?.memoryId)
         }
 
-        private fun setMemoryCandidateBy(memoryId: Long) {
+        private fun updateMemorySelectionBy(memoryId: Long) {
             val selectedMemory = memoryCandidates.value?.findBy(memoryId) ?: throw IllegalArgumentException()
             _selectableMemories.value = MemoryCandidates.from(selectedMemory)
             _selectedMemory.value = selectedMemory

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -171,19 +171,19 @@ class StaccatoCreationViewModel
             currentDateTime: LocalDateTime,
         ) {
             if (memoryId == DEFAULT_CATEGORY_ID) {
-                setCurrentDateTimeAsVisitedAt(currentDateTime)
-                setMemoryCandidateByVisitedAt(currentDateTime)
+                setCurrentDateTimeAs(currentDateTime)
+                setMemoryCandidateBy(currentDateTime)
             } else {
-                setMemoryCandidateById(memoryId)
-                setClosestDateTimeAsVisitedAt(currentDateTime)
+                setMemoryCandidateBy(memoryId)
+                setClosestDateTimeAs(currentDateTime)
             }
         }
 
-        private fun setCurrentDateTimeAsVisitedAt(visitedAt: LocalDateTime) {
+        private fun setCurrentDateTimeAs(visitedAt: LocalDateTime) {
             _selectedVisitedAt.value = visitedAt
         }
 
-        fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
+        fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
             val filteredMemories =
                 memoryCandidates.value
                     ?.filterCandidatesBy(visitedAt.toLocalDate())
@@ -193,12 +193,12 @@ class StaccatoCreationViewModel
                 ?: filteredMemories.firstOrNull()
         }
 
-        private fun setMemoryCandidateById(memoryId: Long) {
+        private fun setMemoryCandidateBy(memoryId: Long) {
             _selectableMemories.value = memoryCandidates.value?.filterCandidatesBy(memoryId)
             _selectedMemory.value = selectableMemories.value?.first()
         }
 
-        private fun setClosestDateTimeAsVisitedAt(visitedAt: LocalDateTime) {
+        private fun setClosestDateTimeAs(visitedAt: LocalDateTime) {
             _selectedVisitedAt.value = selectedMemory.value?.getClosestDateTime(visitedAt)
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -65,8 +65,8 @@ class StaccatoCreationViewModel
         private val _selectedMemory = MutableLiveData<MemoryCandidate>()
         val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
 
-        private val _selectableMemories = MutableLiveData<List<MemoryCandidate>>()
-        val selectableMemories: LiveData<List<MemoryCandidate>> get() = _selectableMemories
+        private val _selectableMemories = MutableLiveData<MemoryCandidates>()
+        val selectableMemories: LiveData<MemoryCandidates> get() = _selectableMemories
 
         private val _memoryCandidates = MutableLiveData<MemoryCandidates>()
         val memoryCandidates: LiveData<MemoryCandidates> get() = _memoryCandidates
@@ -184,18 +184,14 @@ class StaccatoCreationViewModel
         }
 
         fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
-            val filteredMemories =
-                memoryCandidates.value
-                    ?.filterCandidatesBy(visitedAt.toLocalDate())
-                    ?: emptyList()
+            val filteredMemories = memoryCandidates.value?.filterBy(visitedAt.toLocalDate()) ?: MemoryCandidates.emptyMemoryCandidates
             _selectableMemories.value = filteredMemories
-            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
-                ?: filteredMemories.firstOrNull()
+            _selectedMemory.value = filteredMemories.findByIdOrFirst(selectedMemory.value?.memoryId)
         }
 
         private fun setMemoryCandidateBy(memoryId: Long) {
-            val selectedMemory = memoryCandidates.value?.findCandidatesBy(memoryId) ?: throw IllegalArgumentException()
-            _selectableMemories.value = listOf(selectedMemory)
+            val selectedMemory = memoryCandidates.value?.findBy(memoryId) ?: throw IllegalArgumentException()
+            _selectableMemories.value = MemoryCandidates.from(selectedMemory)
             _selectedMemory.value = selectedMemory
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -183,12 +183,13 @@ class StaccatoCreationViewModel
         }
 
         fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
-            _selectableMemories.value =
-                memoryCandidates.value?.filterCandidatesBy(visitedAt.toLocalDate())
-            _selectedMemory.value =
-                selectableMemories.value?.let { selectableMemories ->
-                    selectableMemories.find { it.memoryId == selectedMemory.value?.memoryId } ?: selectableMemories.first()
-                }
+            val filteredMemories =
+                memoryCandidates.value
+                    ?.filterCandidatesBy(visitedAt.toLocalDate())
+                    ?: emptyList()
+            _selectableMemories.value = filteredMemories
+            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
+                ?: filteredMemories.firstOrNull()
         }
 
         private fun setMemoryCandidateById(memoryId: Long) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -20,6 +20,7 @@ import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.common.AttachedPhotoHandler
 import com.on.staccato.presentation.common.MutableSingleLiveData
 import com.on.staccato.presentation.common.SingleLiveData
+import com.on.staccato.presentation.staccatocreation.StaccatoCreationActivity.Companion.DEFAULT_CATEGORY_ID
 import com.on.staccato.presentation.staccatocreation.StaccatoCreationError
 import com.on.staccato.presentation.staccatocreation.model.AttachedPhotoUiModel
 import com.on.staccato.presentation.staccatocreation.model.AttachedPhotosUiModel
@@ -169,7 +170,7 @@ class StaccatoCreationViewModel
             memoryId: Long,
             currentDateTime: LocalDateTime,
         ) {
-            if (memoryId == 0L) {
+            if (memoryId == DEFAULT_CATEGORY_ID) {
                 setCurrentDateTimeAsVisitedAt(currentDateTime)
                 setMemoryCandidateByVisitedAt(currentDateTime)
             } else {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -194,8 +194,9 @@ class StaccatoCreationViewModel
         }
 
         private fun setMemoryCandidateBy(memoryId: Long) {
-            _selectableMemories.value = memoryCandidates.value?.filterCandidatesBy(memoryId)
-            _selectedMemory.value = selectableMemories.value?.first()
+            val selectedMemory = memoryCandidates.value?.findCandidatesBy(memoryId) ?: throw IllegalArgumentException()
+            _selectableMemories.value = listOf(selectedMemory)
+            _selectedMemory.value = selectedMemory
         }
 
         private fun setClosestDateTimeAs(visitedAt: LocalDateTime) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -319,7 +319,7 @@ class StaccatoUpdateActivity :
     private fun observeMemoryData() {
         viewModel.selectableMemories.observe(this) {
             it?.let {
-                memorySelectionFragment.setItems(it)
+                memorySelectionFragment.setItems(it.memoryCandidate)
             }
         }
         viewModel.selectedMemory.observe(this) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -309,11 +309,7 @@ class StaccatoUpdateActivity :
     private fun observeVisitedAtData() {
         viewModel.selectedVisitedAt.observe(this) {
             it?.let {
-                visitedAtSelectionFragment.initCalendarByPeriod(
-                    it.toLocalDate().minusYears(10),
-                    it.toLocalDate().plusYears(10),
-                )
-                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
+                visitedAtSelectionFragment.initCalendarByVisitedAt(it)
                 viewModel.updateMemorySelectionBy(it)
             }
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -126,6 +126,9 @@ class StaccatoUpdateActivity :
 
     override fun onVisitedAtSelectionClicked() {
         if (!visitedAtSelectionFragment.isAdded) {
+            viewModel.selectedVisitedAt.value?.let {
+                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
+            }
             visitedAtSelectionFragment.show(
                 fragmentManager,
                 VisitedAtSelectionFragment.TAG,
@@ -268,7 +271,7 @@ class StaccatoUpdateActivity :
 
     private fun initVisitedAtSelectionFragment() {
         visitedAtSelectionFragment.setOnVisitedAtSelected { selectedVisitedAt ->
-            viewModel.selectedVisitedAt(selectedVisitedAt)
+            viewModel.selectVisitedAt(selectedVisitedAt)
         }
     }
 
@@ -306,11 +309,11 @@ class StaccatoUpdateActivity :
     private fun observeVisitedAtData() {
         viewModel.selectedVisitedAt.observe(this) {
             it?.let {
-                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
-                visitedAtSelectionFragment.setVisitedAtPeriod(
+                visitedAtSelectionFragment.initCalendarByPeriod(
                     it.toLocalDate().minusYears(10),
                     it.toLocalDate().plusYears(10),
                 )
+                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
                 viewModel.updateMemorySelectionBy(it)
             }
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -311,7 +311,7 @@ class StaccatoUpdateActivity :
                     it.toLocalDate().minusYears(10),
                     it.toLocalDate().plusYears(10),
                 )
-                viewModel.setMemoryCandidateBy(it)
+                viewModel.updateMemorySelectionBy(it)
             }
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -273,16 +273,18 @@ class StaccatoUpdateActivity :
     }
 
     private fun observeViewModelData() {
-        viewModel.placeName.observe(this) {
-            autocompleteFragment.setText(it)
-        }
+        observePhotoData()
+        observePlaceData()
+        observeVisitedAtData()
+        observeMemoryData()
+        observeIsUpdateComplete()
+    }
+
+    private fun observePhotoData() {
         viewModel.isAddPhotoClicked.observe(this) {
             if (!photoAttachFragment.isAdded && it) {
                 photoAttachFragment.show(fragmentManager, PhotoAttachFragment.TAG)
             }
-        }
-        viewModel.isUpdateCompleted.observe(this) { isUpdateCompleted ->
-            handleUpdateComplete(isUpdateCompleted)
         }
         viewModel.pendingPhotos.observe(this) {
             viewModel.fetchPhotosUrlsByUris(this)
@@ -293,6 +295,28 @@ class StaccatoUpdateActivity :
                 listOf(AttachedPhotoUiModel.addPhotoButton, *photos.attachedPhotos.toTypedArray()),
             )
         }
+    }
+
+    private fun observePlaceData() {
+        viewModel.placeName.observe(this) {
+            autocompleteFragment.setText(it)
+        }
+    }
+
+    private fun observeVisitedAtData() {
+        viewModel.selectedVisitedAt.observe(this) {
+            it?.let {
+                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
+                visitedAtSelectionFragment.setVisitedAtPeriod(
+                    it.toLocalDate().minusYears(10),
+                    it.toLocalDate().plusYears(10),
+                )
+                viewModel.setMemoryCandidateByVisitedAt(it)
+            }
+        }
+    }
+
+    private fun observeMemoryData() {
         viewModel.selectableMemories.observe(this) {
             it?.let {
                 memorySelectionFragment.setItems(it)
@@ -303,15 +327,11 @@ class StaccatoUpdateActivity :
                 memorySelectionFragment.updateKeyMemory(it)
             }
         }
-        viewModel.selectedVisitedAt.observe(this) {
-            it?.let {
-                visitedAtSelectionFragment.updateSelectedVisitedAt(it)
-                visitedAtSelectionFragment.setVisitedAtPeriod(
-                    it.toLocalDate().minusYears(10),
-                    it.toLocalDate().plusYears(10),
-                )
-                viewModel.setMemoryCandidateByVisitedAt(it)
-            }
+    }
+
+    private fun observeIsUpdateComplete() {
+        viewModel.isUpdateCompleted.observe(this) { isUpdateCompleted ->
+            handleUpdateComplete(isUpdateCompleted)
         }
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -311,7 +311,7 @@ class StaccatoUpdateActivity :
                     it.toLocalDate().minusYears(10),
                     it.toLocalDate().plusYears(10),
                 )
-                viewModel.setMemoryCandidateByVisitedAt(it)
+                viewModel.setMemoryCandidateBy(it)
             }
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -182,12 +182,13 @@ class StaccatoUpdateViewModel
         }
 
         fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
-            _selectableMemories.value =
-                memoryCandidates.value?.filterCandidatesBy(visitedAt.toLocalDate())
-            _selectedMemory.value =
-                selectableMemories.value?.let { selectableMemories ->
-                    selectableMemories.find { it.memoryId == selectedMemory.value?.memoryId } ?: selectableMemories.first()
-                }
+            val filteredMemories =
+                memoryCandidates.value
+                    ?.filterCandidatesBy(visitedAt.toLocalDate())
+                    ?: emptyList()
+            _selectableMemories.value = filteredMemories
+            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
+                ?: filteredMemories.firstOrNull()
         }
 
         fun updateStaccato(staccatoId: Long) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -118,7 +118,7 @@ class StaccatoUpdateViewModel
             _selectedMemory.value = memory
         }
 
-        fun selectedVisitedAt(visitedAt: LocalDateTime) {
+        fun selectVisitedAt(visitedAt: LocalDateTime) {
             _selectedVisitedAt.value = visitedAt
         }
 
@@ -225,7 +225,8 @@ class StaccatoUpdateViewModel
                         staccatoTitle.set(staccato.staccatoTitle)
                         _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
                         initializePlaceBy(staccato)
-                        initMemoryAndVisitedAt(staccato)
+                        selectVisitedAt(staccato.visitedAt)
+                        initMemory(staccato)
                     }.onException(::handleInitializeException)
                     .onServerError(::handleServerError)
             }
@@ -241,8 +242,7 @@ class StaccatoUpdateViewModel
             )
         }
 
-        private fun initMemoryAndVisitedAt(staccato: Staccato) {
-            _selectedVisitedAt.value = staccato.visitedAt
+        private fun initMemory(staccato: Staccato) {
             _selectedMemory.value =
                 MemoryCandidate(
                     staccato.memoryId,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -181,7 +181,7 @@ class StaccatoUpdateViewModel
             }
         }
 
-        fun setMemoryCandidateByVisitedAt(visitedAt: LocalDateTime) {
+        fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
             val filteredMemories =
                 memoryCandidates.value
                     ?.filterCandidatesBy(visitedAt.toLocalDate())
@@ -227,14 +227,14 @@ class StaccatoUpdateViewModel
                     .onSuccess { staccato ->
                         staccatoTitle.set(staccato.staccatoTitle)
                         _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
-                        initializePlaceByStaccato(staccato)
+                        initializePlaceBy(staccato)
                         initMemoryAndVisitedAt(staccato)
                     }.onException(::handleInitializeException)
                     .onServerError(::handleServerError)
             }
         }
 
-        private fun initializePlaceByStaccato(staccato: Staccato) {
+        private fun initializePlaceBy(staccato: Staccato) {
             selectNewPlace(
                 placeId = "필요 없는 파라미터",
                 name = staccato.placeName,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -14,6 +14,7 @@ import com.on.staccato.data.ApiResponseHandler.onSuccess
 import com.on.staccato.data.dto.Status
 import com.on.staccato.domain.model.MemoryCandidate
 import com.on.staccato.domain.model.MemoryCandidates
+import com.on.staccato.domain.model.MemoryCandidates.Companion.emptyMemoryCandidates
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.repository.ImageRepository
 import com.on.staccato.domain.repository.StaccatoRepository
@@ -78,8 +79,8 @@ class StaccatoUpdateViewModel
         private val _selectedMemory = MutableLiveData<MemoryCandidate>()
         val selectedMemory: LiveData<MemoryCandidate> get() = _selectedMemory
 
-        private val _selectableMemories = MutableLiveData<List<MemoryCandidate>>()
-        val selectableMemories: LiveData<List<MemoryCandidate>> get() = _selectableMemories
+        private val _selectableMemories = MutableLiveData<MemoryCandidates>()
+        val selectableMemories: LiveData<MemoryCandidates> get() = _selectableMemories
 
         private val _isUpdateCompleted = MutableLiveData(false)
         val isUpdateCompleted: LiveData<Boolean> get() = _isUpdateCompleted
@@ -182,13 +183,9 @@ class StaccatoUpdateViewModel
         }
 
         fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
-            val filteredMemories =
-                memoryCandidates.value
-                    ?.filterCandidatesBy(visitedAt.toLocalDate())
-                    ?: emptyList()
+            val filteredMemories = memoryCandidates.value?.filterBy(visitedAt.toLocalDate()) ?: emptyMemoryCandidates
             _selectableMemories.value = filteredMemories
-            _selectedMemory.value = filteredMemories.find { it.memoryId == selectedMemory.value?.memoryId }
-                ?: filteredMemories.firstOrNull()
+            _selectedMemory.value = filteredMemories.findByIdOrFirst(selectedMemory.value?.memoryId)
         }
 
         fun updateStaccato(staccatoId: Long) {
@@ -254,7 +251,7 @@ class StaccatoUpdateViewModel
                     staccato.endAt,
                 )
             _selectableMemories.value =
-                memoryCandidates.value?.filterCandidatesBy(staccato.visitedAt.toLocalDate())
+                memoryCandidates.value?.filterBy(staccato.visitedAt.toLocalDate())
         }
 
         private fun fetchMemoryCandidates() {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -182,7 +182,7 @@ class StaccatoUpdateViewModel
             }
         }
 
-        fun setMemoryCandidateBy(visitedAt: LocalDateTime) {
+        fun updateMemorySelectionBy(visitedAt: LocalDateTime) {
             val filteredMemories = memoryCandidates.value?.filterBy(visitedAt.toLocalDate()) ?: emptyMemoryCandidates
             _selectableMemories.value = filteredMemories
             _selectedMemory.value = filteredMemories.findByIdOrFirst(selectedMemory.value?.memoryId)

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
@@ -227,8 +227,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}" />
 
                 <TextView
                     android:id="@+id/tv_memory_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_creation.xml
@@ -205,12 +205,38 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
+                    android:id="@+id/tv_visited_at_selection_title"
+                    style="@style/SubTitleStyle"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/all_visited_at"
+                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
+                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+
+                <TextView
+                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
+                    style="@style/RequiredMarkStyle"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintStart_toEndOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toTopOf="@id/tv_visited_at_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    style="@style/BackgroundedTextStyle"
+                    android:layout_marginTop="8dp"
+                    android:onClick="@{() -> staccatoCreationHandler.onVisitedAtSelectionClicked()}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+
+                <TextView
                     android:id="@+id/tv_memory_selection_title"
                     style="@style/SubTitleStyle"
                     android:layout_marginTop="40dp"
                     android:text="@string/staccato_creation_memory_selection"
-                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
-                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+                    app:layout_constraintStart_toStartOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
 
                 <TextView
                     android:id="@+id/tv_staccato_creation_required_mark_third"
@@ -231,32 +257,6 @@
                     bind:memoryCandidates="@{viewModel.memoryCandidates}"
                     bind:selectedMemory="@{viewModel.selectedMemory}" />
 
-                <TextView
-                    android:id="@+id/tv_select_memory_title"
-                    style="@style/SubTitleStyle"
-                    android:layout_marginTop="40dp"
-                    android:text="@string/all_visited_at"
-                    app:layout_constraintStart_toStartOf="@id/tv_memory_selection_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection" />
-
-                <TextView
-                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
-                    style="@style/RequiredMarkStyle"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_select_memory_title"
-                    app:layout_constraintStart_toEndOf="@id/tv_select_memory_title"
-                    app:layout_constraintTop_toTopOf="@id/tv_select_memory_title" />
-
-                <TextView
-                    android:id="@+id/tv_visited_at"
-                    style="@style/BackgroundedTextStyle"
-                    android:layout_marginTop="8dp"
-                    android:onClick="@{() -> staccatoCreationHandler.onVisitedAtSelectionClicked()}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_select_memory_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
-
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_staccato_create_done"
                     style="@style/ButtonStyle.Save.Active"
@@ -268,7 +268,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at"
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection"
                     bind:staccatoAddress="@{viewModel.placeName}"
                     bind:staccatoMemory="@{viewModel.selectedMemory}"
                     bind:staccatoPhotos="@{viewModel.currentPhotos}"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
@@ -230,8 +230,7 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}" />
 
                 <TextView
                     android:id="@+id/tv_memory_selection_title"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_staccato_update.xml
@@ -208,15 +208,41 @@
                 </androidx.constraintlayout.widget.ConstraintLayout>
 
                 <TextView
+                    android:id="@+id/tv_visited_at_selection_title"
+                    style="@style/SubTitleStyle"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/all_visited_at"
+                    app:layout_constraintStart_toStartOf="@id/constraint_current_location"
+                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+
+                <TextView
+                    android:id="@+id/tv_staccato_creation_required_mark_fourth"
+                    style="@style/RequiredMarkStyle"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintStart_toEndOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toTopOf="@id/tv_visited_at_selection_title" />
+
+                <TextView
+                    android:id="@+id/tv_visited_at"
+                    style="@style/BackgroundedTextStyle"
+                    android:layout_marginTop="8dp"
+                    android:onClick="@{() -> staccatoUpdateHandler.onVisitedAtSelectionClicked()}"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at_selection_title"
+                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+
+                <TextView
                     android:id="@+id/tv_memory_selection_title"
                     style="@style/SubTitleStyle"
                     android:layout_marginTop="40dp"
                     android:text="@string/staccato_creation_memory_selection"
-                    app:layout_constraintStart_toStartOf="@id/tv_photo_title"
-                    app:layout_constraintTop_toBottomOf="@id/constraint_current_location" />
+                    app:layout_constraintStart_toStartOf="@id/tv_visited_at_selection_title"
+                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at" />
 
                 <TextView
-                    android:id="@+id/tv_staccato_update_required_mark_third"
+                    android:id="@+id/tv_staccato_creation_required_mark_third"
                     style="@style/RequiredMarkStyle"
                     app:layout_constraintBottom_toBottomOf="@id/tv_memory_selection_title"
                     app:layout_constraintStart_toEndOf="@id/tv_memory_selection_title"
@@ -230,34 +256,9 @@
                     android:text="@{viewModel.selectedMemory.memoryTitle}"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection_title" />
-
-                <TextView
-                    android:id="@+id/tv_select_memory_title"
-                    style="@style/SubTitleStyle"
-                    android:layout_marginTop="40dp"
-                    android:text="@string/all_visited_at"
-                    app:layout_constraintStart_toStartOf="@id/tv_memory_selection_title"
-                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection" />
-
-                <TextView
-                    android:id="@+id/tv_staccato_update_required_mark_fourth"
-                    style="@style/RequiredMarkStyle"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_select_memory_title"
-                    app:layout_constraintStart_toEndOf="@id/tv_select_memory_title"
-                    app:layout_constraintTop_toTopOf="@id/tv_select_memory_title" />
-
-                <TextView
-                    android:id="@+id/tv_visited_at"
-                    style="@style/BackgroundedTextStyle"
-                    android:layout_marginTop="8dp"
-                    android:background="@drawable/shape_button_gray1_5dp"
-                    android:onClick="@{() -> staccatoUpdateHandler.onVisitedAtSelectionClicked()}"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_select_memory_title"
-                    bind:dateTimeWithAmPm="@{viewModel.selectedVisitedAt}"
-                    bind:memoryCandidates="@{viewModel.memoryCandidates}" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection_title"
+                    bind:memoryCandidates="@{viewModel.memoryCandidates}"
+                    bind:selectedMemory="@{viewModel.selectedMemory}" />
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_staccato_update_done"
@@ -270,7 +271,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_visited_at"
+                    app:layout_constraintTop_toBottomOf="@id/tv_memory_selection"
                     bind:staccatoAddress="@{viewModel.address}"
                     bind:staccatoMemory="@{viewModel.selectedMemory}"
                     bind:staccatoPhotos="@{viewModel.currentPhotos}"

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_memory_visited_at_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_memory_visited_at_selection.xml
@@ -23,7 +23,7 @@
         <TextView
             android:id="@+id/tv_select_memory_title"
             style="@style/SubTitleStyle"
-            android:text="@string/staccato_creation_memory_selection_hint"
+            android:text="@string/staccato_creation_no_memory_in_this_date"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
@@ -34,7 +34,7 @@
             android:layout_height="wrap_content"
             android:layout_marginVertical="50dp"
             android:gravity="center"
-            android:text="@string/staccato_creation_no_memory_hint"
+            android:text="@string/staccato_creation_no_memory"
             app:layout_constraintBottom_toTopOf="@id/btn_memory_visited_at_confirm"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/fragment_visited_at_selection.xml
@@ -23,20 +23,6 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/tv_memory_is_empty"
-            style="@style/Typography.Body2"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginVertical="50dp"
-            android:gravity="center"
-            android:text="@string/staccato_creation_unselected_memory"
-            app:layout_constraintBottom_toTopOf="@id/btn_visited_at_confirm"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/tv_visited_at_title"
-            bind:isMemoryEmpty="@{years}" />
-
         <NumberPicker
             android:id="@+id/picker_year"
             android:layout_width="0dp"

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -119,8 +119,8 @@
     <string name="staccato_creation_empty_address">"장소를 선택하면 상세 주소가 나타나요"</string>
     <string name="staccato_creation_address">상세 주소</string>
     <string name="staccato_creation_memory_selection">추억 선택</string>
-    <string name="staccato_creation_memory_selection_hint">추억을 선택해 주세요</string>
-    <string name="staccato_creation_no_memory_hint">스타카토를 남길 수 있는 추억이 없어요</string>
+    <string name="staccato_creation_no_memory_in_this_date">선택하신 날짜에는 추억이 없어요</string>
+    <string name="staccato_creation_no_memory">스타카토를 남길 수 있는 추억이 없어요</string>
     <string name="staccato_creation_unselected_memory">추억을 먼저 선택해 주세요</string>
     <string name="staccato_creation_toolbar_subtitle">기억하고 싶은 순간을 남겨 보세요!</string>
     <string name="staccato_creation_toolbar_title">스타카토 기록하기</string>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -121,7 +121,6 @@
     <string name="staccato_creation_memory_selection">추억 선택</string>
     <string name="staccato_creation_no_memory_in_this_date">선택하신 날짜에는 추억이 없어요</string>
     <string name="staccato_creation_no_memory">스타카토를 남길 수 있는 추억이 없어요</string>
-    <string name="staccato_creation_unselected_memory">추억을 먼저 선택해 주세요</string>
     <string name="staccato_creation_toolbar_subtitle">기억하고 싶은 순간을 남겨 보세요!</string>
     <string name="staccato_creation_toolbar_title">스타카토 기록하기</string>
     <string name="staccato_creation_not_found_address">주소를 찾지 못했습니다</string>

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/CalendarFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/CalendarFixture.kt
@@ -1,0 +1,31 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+
+val december10thTo20thCalendar =
+    DateCalendar.of(
+        2024,
+        12,
+        LocalDate.of(2024, 12, 10),
+        LocalDate.of(2024, 12, 20),
+    )
+
+val december1stTo15thMonthCalendar =
+    MonthCalendar.of(
+        year = 2024,
+        periodStart = LocalDate.of(2024, 6, 1),
+        periodEnd = LocalDate.of(2024, 12, 15),
+    )
+
+val aprilToAugustCalendar =
+    MonthCalendar.of(
+        2024,
+        LocalDate.of(2024, 4, 1),
+        LocalDate.of(2024, 8, 1),
+    )
+
+val juneDateCalendar =
+    DateCalendar.of(
+        2024,
+        6,
+    )

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/DateCalendarTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/DateCalendarTest.kt
@@ -1,0 +1,90 @@
+package com.on.staccato.domain.model
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(JUnitParamsRunner::class)
+class DateCalendarTest {
+    @Test
+    fun `기간의 시작과 끝을 정하지 않으면 2024년 2월의 모든 일을 반환한다`() {
+        // 2024년은 윤년이라 2월이 29일까지 있다
+        val expected = (1..29).toList()
+        val actual = DateCalendar.of(2024, 2).availableDates
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `기간의 시작과 끝을 정하지 않으면 2025년 2월의 모든 일을 반환한다`() {
+        // 2025년은 2월 28일까지 있다
+        val expected = (1..28).toList()
+        val actual = DateCalendar.of(2025, 2).availableDates
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `기간의 시작과 끝이 정해져 있으면 기간 안에 속하는 일들을 반환한다`() {
+        // given
+        val startDate = LocalDate.of(2023, 2, 1)
+        val endDate = LocalDate.of(2025, 12, 31)
+
+        // when
+        val expected = (1..28).toList()
+        val actual = DateCalendar.of(2023, 2, startDate, endDate).availableDates
+
+        // then
+        assertEquals(expected, actual)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `날짜가 기간을 벗어나면 예외를 반환한다`() {
+        val periodStart = LocalDate.of(2023, 12, 1)
+        val periodEnd = LocalDate.of(2024, 1, 10)
+        DateCalendar.of(2024, 2, periodStart, periodEnd)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `기간의 시작이 끝보다 늦으면 예외를 반환한다`() {
+        val start = LocalDate.of(2024, 2, 2)
+        val end = LocalDate.of(2024, 2, 1)
+        DateCalendar.of(2024, 2, start, end)
+    }
+
+    @Test
+    @Parameters(method = "dateParametersFrom10to20")
+    fun `범위 안에 있다면 해당 날짜를 그대로 반환한다`(date: Int) {
+        val actual = december10thTo20thCalendar.getClosestDate(date)
+        assertEquals(date, actual)
+    }
+
+    @Test
+    @Parameters(method = "dateParametersSmallerThan10")
+    fun `범위보다 작으면 가장 첫번째 날짜를 반환한다`(date: Int) {
+        // given
+        val firstDate = 10
+
+        // then
+        val actual = december10thTo20thCalendar.getClosestDate(date)
+        assertEquals(firstDate, actual)
+    }
+
+    @Test
+    @Parameters(method = "dateParametersGraterThan20")
+    fun `범위보다 크면 가장 마지막 날짜를 반환한다`(date: Int) {
+        // given
+        val lastDate = 20
+
+        // then
+        val actual = december10thTo20thCalendar.getClosestDate(date)
+        assertEquals(lastDate, actual)
+    }
+
+    private fun dateParametersFrom10to20(): List<Int> = listOf(10, 15, 20)
+
+    private fun dateParametersSmallerThan10(): List<Int> = listOf(1, 5, 9)
+
+    private fun dateParametersGraterThan20(): List<Int> = listOf(21, 25, 30)
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -11,7 +11,7 @@ internal val startDateOf2025 = LocalDate.of(2025, 1, 1)
 
 internal const val TARGET_MEMORY_ID = 4L
 
-internal val newMemoryCandidate =
+internal val memoryCandidateWithId1 =
     makeTestMemoryCandidate(
         memoryId = 1L,
         startAt = endDateOf2023,
@@ -29,7 +29,7 @@ val dummyMemoryCandidates =
     MemoryCandidates(
         memoryCandidate =
             listOf(
-                newMemoryCandidate,
+                memoryCandidateWithId1,
                 makeTestMemoryCandidate(memoryId = 2L, startAt = startDateOf2024, endAt = middleDateOf2024),
                 makeTestMemoryCandidate(memoryId = 3L, startAt = middleDateOf2024, endAt = endDateOf2024),
                 targetMemoryCandidate,

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -10,7 +10,7 @@ internal val yearStart2025 = LocalDate.of(2025, 1, 1)
 
 internal const val TARGET_MEMORY_ID = 4L
 
-internal val firstMemoryCandidate =
+internal val newMemoryCandidate =
     makeTestMemoryCandidate(
         memoryId = 1L,
         startAt = yearEnd2023,
@@ -28,11 +28,30 @@ val dummyMemoryCandidates =
     MemoryCandidates(
         memoryCandidate =
             listOf(
-                firstMemoryCandidate,
+                newMemoryCandidate,
                 makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearMiddle2024),
                 makeTestMemoryCandidate(memoryId = 3L, startAt = yearMiddle2024, endAt = yearEnd2024),
                 targetMemoryCandidate,
             ),
+    )
+
+internal const val TARGET_STACCATO_ID = 4L
+
+internal val targetStaccato =
+    Staccato(
+        staccatoId = TARGET_STACCATO_ID,
+        staccatoTitle = "테스트용 스타카토",
+        placeName = "Elmer Moon",
+        address = "nunc",
+        latitude = 8.9,
+        longitude = 10.11,
+        staccatoImageUrls = listOf(),
+        memoryId = targetMemoryCandidate.memoryId,
+        memoryTitle = targetMemoryCandidate.memoryTitle,
+        visitedAt = yearEnd2024.atTime(12, 0),
+        startAt = targetMemoryCandidate.startAt,
+        endAt = targetMemoryCandidate.endAt,
+        feeling = Feeling.EXCITED,
     )
 
 internal fun makeTestMemoryCandidate(

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -1,6 +1,7 @@
 package com.on.staccato.domain.model
 
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 internal val yearEnd2023 = LocalDate.of(2023, 12, 31)
 internal val yearStart2024 = LocalDate.of(2024, 1, 1)
@@ -37,23 +38,6 @@ val dummyMemoryCandidates =
 
 internal const val TARGET_STACCATO_ID = 4L
 
-internal val targetStaccato =
-    Staccato(
-        staccatoId = TARGET_STACCATO_ID,
-        staccatoTitle = "테스트용 스타카토",
-        placeName = "Elmer Moon",
-        address = "nunc",
-        latitude = 8.9,
-        longitude = 10.11,
-        staccatoImageUrls = listOf(),
-        memoryId = targetMemoryCandidate.memoryId,
-        memoryTitle = targetMemoryCandidate.memoryTitle,
-        visitedAt = yearEnd2024.atTime(12, 0),
-        startAt = targetMemoryCandidate.startAt,
-        endAt = targetMemoryCandidate.endAt,
-        feeling = Feeling.EXCITED,
-    )
-
 internal fun makeTestMemoryCandidate(
     memoryId: Long = 1L,
     memoryTitle: String = "임시 카테고리",
@@ -64,4 +48,31 @@ internal fun makeTestMemoryCandidate(
     memoryTitle = memoryTitle,
     startAt = startAt,
     endAt = endAt,
+)
+
+internal fun makeTestStaccato(
+    staccatoId: Long = 1L,
+    staccatoTitle: String = "test",
+    placeName: String = "test",
+    address: String = "test",
+    latitude: Double = 1.1,
+    longitude: Double = 1.1,
+    staccatoImageUrls: List<String> = emptyList(),
+    visitedAt: LocalDateTime,
+    memoryCandidate: MemoryCandidate,
+    feeling: Feeling = Feeling.EXCITED,
+) = Staccato(
+    staccatoId = staccatoId,
+    staccatoTitle = staccatoTitle,
+    placeName = placeName,
+    address = address,
+    latitude = latitude,
+    longitude = longitude,
+    staccatoImageUrls = staccatoImageUrls,
+    memoryId = memoryCandidate.memoryId,
+    memoryTitle = memoryCandidate.memoryTitle,
+    visitedAt = visitedAt,
+    startAt = memoryCandidate.startAt,
+    endAt = memoryCandidate.endAt,
+    feeling = feeling,
 )

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -3,26 +3,26 @@ package com.on.staccato.domain.model
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-internal val yearEnd2023 = LocalDate.of(2023, 12, 31)
-internal val yearStart2024 = LocalDate.of(2024, 1, 1)
-internal val yearMiddle2024 = LocalDate.of(2024, 7, 1)
-internal val yearEnd2024 = LocalDate.of(2024, 12, 31)
-internal val yearStart2025 = LocalDate.of(2025, 1, 1)
+internal val endDateOf2023 = LocalDate.of(2023, 12, 31)
+internal val startDateOf2024 = LocalDate.of(2024, 1, 1)
+internal val middleDateOf2024 = LocalDate.of(2024, 7, 1)
+internal val endDateOf2024 = LocalDate.of(2024, 12, 31)
+internal val startDateOf2025 = LocalDate.of(2025, 1, 1)
 
 internal const val TARGET_MEMORY_ID = 4L
 
 internal val newMemoryCandidate =
     makeTestMemoryCandidate(
         memoryId = 1L,
-        startAt = yearEnd2023,
-        endAt = yearStart2024,
+        startAt = endDateOf2023,
+        endAt = startDateOf2024,
     )
 
 internal val targetMemoryCandidate =
     makeTestMemoryCandidate(
         memoryId = TARGET_MEMORY_ID,
-        startAt = yearEnd2024,
-        endAt = yearStart2025,
+        startAt = endDateOf2024,
+        endAt = startDateOf2025,
     )
 
 val dummyMemoryCandidates =
@@ -30,8 +30,8 @@ val dummyMemoryCandidates =
         memoryCandidate =
             listOf(
                 newMemoryCandidate,
-                makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearMiddle2024),
-                makeTestMemoryCandidate(memoryId = 3L, startAt = yearMiddle2024, endAt = yearEnd2024),
+                makeTestMemoryCandidate(memoryId = 2L, startAt = startDateOf2024, endAt = middleDateOf2024),
+                makeTestMemoryCandidate(memoryId = 3L, startAt = middleDateOf2024, endAt = endDateOf2024),
                 targetMemoryCandidate,
             ),
     )

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateFixture.kt
@@ -1,0 +1,48 @@
+package com.on.staccato.domain.model
+
+import java.time.LocalDate
+
+internal val yearEnd2023 = LocalDate.of(2023, 12, 31)
+internal val yearStart2024 = LocalDate.of(2024, 1, 1)
+internal val yearMiddle2024 = LocalDate.of(2024, 7, 1)
+internal val yearEnd2024 = LocalDate.of(2024, 12, 31)
+internal val yearStart2025 = LocalDate.of(2025, 1, 1)
+
+internal const val TARGET_MEMORY_ID = 4L
+
+internal val firstMemoryCandidate =
+    makeTestMemoryCandidate(
+        memoryId = 1L,
+        startAt = yearEnd2023,
+        endAt = yearStart2024,
+    )
+
+internal val targetMemoryCandidate =
+    makeTestMemoryCandidate(
+        memoryId = TARGET_MEMORY_ID,
+        startAt = yearEnd2024,
+        endAt = yearStart2025,
+    )
+
+val dummyMemoryCandidates =
+    MemoryCandidates(
+        memoryCandidate =
+            listOf(
+                firstMemoryCandidate,
+                makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearMiddle2024),
+                makeTestMemoryCandidate(memoryId = 3L, startAt = yearMiddle2024, endAt = yearEnd2024),
+                targetMemoryCandidate,
+            ),
+    )
+
+internal fun makeTestMemoryCandidate(
+    memoryId: Long = 1L,
+    memoryTitle: String = "임시 카테고리",
+    startAt: LocalDate? = null,
+    endAt: LocalDate? = null,
+) = MemoryCandidate(
+    memoryId = memoryId,
+    memoryTitle = memoryTitle,
+    startAt = startAt,
+    endAt = endAt,
+)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -99,40 +99,42 @@ class MemoryCandidateTest {
 
     // 아래부터 getClosestDateTime 테스트
     @Test
-    fun `2024년 중 2023년 마지막 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+    fun `현재 시간이 startAt과 endAt의 범위 내일 때 현재 시간을 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearMiddle2024.atTime(13, 30)
 
         // when & then
-        val actual = category.getClosestDateTime(yearEnd2023.atTime(12, 0))
-        val expected = yearStart2024.atTime(0, 0)
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+
+        assertEquals(currentLocalDateTime, actual)
+    }
+
+    @Test
+    fun `현재 시간이 startAt보다 과거일 때 startAt의 정오를 반환`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearEnd2023.atTime(13, 30)
+
+        // when & then
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+        val expected = yearStart2024.atTime(12, 0)
 
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `2024년 중 2024년 7월 1일 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+    fun `현재 시간이 endAt보다 미래일 때 endAt의 정오를 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val currentLocalDateTime = yearStart2025.atTime(13, 30)
 
         // when & then
-        val actual = category.getClosestDateTime(yearMiddle2024.atTime(12, 0))
-        val expected = yearMiddle2024.atTime(12, 0)
-
-        assertEquals(expected, actual)
-    }
-
-    @Test
-    fun `2024년 중 2025년 첫번째 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
-        // given
-        val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-
-        // when & then
-        val actual = category.getClosestDateTime(yearStart2025.atTime(12, 0))
-        val expected = yearEnd2024.atTime(0, 0)
+        val actual = category.getClosestDateTime(currentLocalDateTime)
+        val expected = yearEnd2024.atTime(12, 0)
 
         assertEquals(expected, actual)
     }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -1,130 +1,120 @@
 package com.on.staccato.domain.model
 
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
 
+@RunWith(JUnitParamsRunner::class)
 class MemoryCandidateTest {
-    // 아래부터 isDateWithinPeriod 테스트
     @Test
-    fun `특정 날짜가 startAt과 endAt 사이에 포함되면 true 반환`() {
+    @Parameters(method = "validLocalDateParameters")
+    fun `타겟 날짜가 기간 내면 true를 반환`(targetLocalDate: LocalDate) {
+        // given
         val category =
             makeTestMemoryCandidate(
                 startAt = yearStart2024,
                 endAt = yearEnd2024,
             )
-
-        val actual = category.isDateWithinPeriod(yearMiddle2024)
+        // when
+        val actual = category.isDateWithinPeriod(targetLocalDate)
+        // then
         assertTrue(actual)
     }
 
     @Test
-    fun `특정 날짜와 startAt이 같으면 true 반환`() {
+    fun `타겟 날짜가 기간보다 과거라면 false를 반환`() {
+        // given
         val category =
             makeTestMemoryCandidate(
                 startAt = yearStart2024,
                 endAt = yearEnd2024,
             )
-
-        val actual = category.isDateWithinPeriod(yearStart2024)
-        assertTrue(actual)
-    }
-
-    @Test
-    fun `특정 날짜와 endAt이 같으면 true 반환`() {
-        val category =
-            makeTestMemoryCandidate(
-                startAt = yearStart2024,
-                endAt = yearEnd2024,
-            )
-
-        val actual = category.isDateWithinPeriod(yearEnd2024)
-        assertTrue(actual)
-    }
-
-    @Test
-    fun `특정 날짜가 startAt 이전이면 false 반환`() {
-        val category =
-            makeTestMemoryCandidate(
-                startAt = yearStart2024,
-                endAt = yearEnd2024,
-            )
-
-        val actual = category.isDateWithinPeriod(yearEnd2023)
+        val targetLocalDate = yearEnd2023
+        // when
+        val actual = category.isDateWithinPeriod(targetLocalDate)
+        // then
         assertFalse(actual)
     }
 
     @Test
-    fun `특정 날짜가 endAt 이후면 false 반환`() {
+    fun `타겟 날짜가 기간보다 미래라면 false를 반환`() {
+        // given
         val category =
             makeTestMemoryCandidate(
                 startAt = yearStart2024,
                 endAt = yearEnd2024,
             )
-
-        val actual = category.isDateWithinPeriod(yearStart2025)
+        val targetLocalDate = yearStart2025
+        // when
+        val actual = category.isDateWithinPeriod(targetLocalDate)
+        // then
         assertFalse(actual)
     }
 
     @Test
-    fun `startAt과 endAt이 null이면 모든 날짜에 true 반환`() {
+    @Parameters(method = "localDateParameters")
+    fun `기간 없는 카테고리는 모든 날짜에 true를 반환`(date: LocalDate) {
         // given
         val categoryWithoutPeriod =
             makeTestMemoryCandidate(
                 startAt = null,
                 endAt = null,
             )
-
-        // when & then
-        val actual1 = categoryWithoutPeriod.isDateWithinPeriod(yearEnd2023)
-        val actual2 = categoryWithoutPeriod.isDateWithinPeriod(yearMiddle2024)
-        val actual3 = categoryWithoutPeriod.isDateWithinPeriod(yearStart2025)
-
-        assertTrue(actual1)
-        assertTrue(actual2)
-        assertTrue(actual3)
-    }
-
-    // 아래부터 getClosestDateTime 테스트
-    @Test
-    fun `현재 시간이 startAt과 endAt의 범위 내일 때 현재 시간을 반환`() {
-        // given
-        val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val currentLocalDateTime = yearMiddle2024.atTime(13, 30)
-
-        // when & then
-        val actual = category.getClosestDateTime(currentLocalDateTime)
-
-        assertEquals(currentLocalDateTime, actual)
+        // when
+        val actual = categoryWithoutPeriod.isDateWithinPeriod(date)
+        // then
+        assertTrue(actual)
     }
 
     @Test
-    fun `현재 시간이 startAt보다 과거일 때 startAt의 정오를 반환`() {
+    fun `타겟 일시가 기간 범위 내면 그대로 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val currentLocalDateTime = yearEnd2023.atTime(13, 30)
+        val targetLocalDateTime = yearMiddle2024.atTime(13, 30)
+        // when
+        val actual = category.getClosestDateTime(targetLocalDateTime)
+        // then
+        assertEquals(targetLocalDateTime, actual)
+    }
 
-        // when & then
-        val actual = category.getClosestDateTime(currentLocalDateTime)
+    @Test
+    fun `타겟 일시가 기간보다 과거라면 시작일의 정오를 반환`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+        val targetLocalDateTime = yearEnd2023.atTime(13, 30)
+        // when
+        val actual = category.getClosestDateTime(targetLocalDateTime)
         val expected = yearStart2024.atTime(12, 0)
-
+        // then
         assertEquals(expected, actual)
     }
 
     @Test
-    fun `현재 시간이 endAt보다 미래일 때 endAt의 정오를 반환`() {
+    fun `타겟 일시가 기간보다 미래라면 종료일의 정오를 반환`() {
         // given
         val category =
             makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val currentLocalDateTime = yearStart2025.atTime(13, 30)
-
-        // when & then
-        val actual = category.getClosestDateTime(currentLocalDateTime)
+        val targetLocalDateTime = yearStart2025.atTime(13, 30)
+        // when
+        val actual = category.getClosestDateTime(targetLocalDateTime)
         val expected = yearEnd2024.atTime(12, 0)
-
+        // then
         assertEquals(expected, actual)
     }
+
+    private fun validLocalDateParameters(): List<LocalDate> = listOf(yearStart2024, yearMiddle2024, yearEnd2024)
+
+    private fun localDateParameters(): List<LocalDate> =
+        listOf(
+            LocalDate.now(),
+            LocalDate.now().minusYears(10),
+            LocalDate.now().plusYears(10),
+        )
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -1,6 +1,8 @@
 package com.on.staccato.domain.model
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class MemoryCandidateTest {
@@ -14,9 +16,7 @@ class MemoryCandidateTest {
             )
 
         val actual = category.isDateWithinPeriod(yearMiddle2024)
-        val expected = true
-
-        assertEquals(expected, actual)
+        assertTrue(actual)
     }
 
     @Test
@@ -28,9 +28,7 @@ class MemoryCandidateTest {
             )
 
         val actual = category.isDateWithinPeriod(yearStart2024)
-        val expected = true
-
-        assertEquals(expected, actual)
+        assertTrue(actual)
     }
 
     @Test
@@ -42,9 +40,7 @@ class MemoryCandidateTest {
             )
 
         val actual = category.isDateWithinPeriod(yearEnd2024)
-        val expected = true
-
-        assertEquals(expected, actual)
+        assertTrue(actual)
     }
 
     @Test
@@ -56,9 +52,7 @@ class MemoryCandidateTest {
             )
 
         val actual = category.isDateWithinPeriod(yearEnd2023)
-        val expected = false
-
-        assertEquals(expected, actual)
+        assertFalse(actual)
     }
 
     @Test
@@ -70,9 +64,7 @@ class MemoryCandidateTest {
             )
 
         val actual = category.isDateWithinPeriod(yearStart2025)
-        val expected = false
-
-        assertEquals(expected, actual)
+        assertFalse(actual)
     }
 
     @Test
@@ -86,15 +78,12 @@ class MemoryCandidateTest {
 
         // when & then
         val actual1 = categoryWithoutPeriod.isDateWithinPeriod(yearEnd2023)
-        val expected1 = true
         val actual2 = categoryWithoutPeriod.isDateWithinPeriod(yearMiddle2024)
-        val expected2 = true
         val actual3 = categoryWithoutPeriod.isDateWithinPeriod(yearStart2025)
-        val expected3 = true
 
-        assertEquals(expected1, actual1)
-        assertEquals(expected2, actual2)
-        assertEquals(expected3, actual3)
+        assertTrue(actual1)
+        assertTrue(actual2)
+        assertTrue(actual3)
     }
 
     // 아래부터 getClosestDateTime 테스트

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -17,8 +17,8 @@ class MemoryCandidateTest {
         // given
         val category =
             makeTestMemoryCandidate(
-                startAt = yearStart2024,
-                endAt = yearEnd2024,
+                startAt = startDateOf2024,
+                endAt = endDateOf2024,
             )
         // when
         val actual = category.isDateWithinPeriod(targetLocalDate)
@@ -31,10 +31,10 @@ class MemoryCandidateTest {
         // given
         val category =
             makeTestMemoryCandidate(
-                startAt = yearStart2024,
-                endAt = yearEnd2024,
+                startAt = startDateOf2024,
+                endAt = endDateOf2024,
             )
-        val targetLocalDate = yearEnd2023
+        val targetLocalDate = endDateOf2023
         // when
         val actual = category.isDateWithinPeriod(targetLocalDate)
         // then
@@ -46,10 +46,10 @@ class MemoryCandidateTest {
         // given
         val category =
             makeTestMemoryCandidate(
-                startAt = yearStart2024,
-                endAt = yearEnd2024,
+                startAt = startDateOf2024,
+                endAt = endDateOf2024,
             )
-        val targetLocalDate = yearStart2025
+        val targetLocalDate = startDateOf2025
         // when
         val actual = category.isDateWithinPeriod(targetLocalDate)
         // then
@@ -75,8 +75,8 @@ class MemoryCandidateTest {
     fun `타겟 일시가 기간 범위 내면 그대로 반환`() {
         // given
         val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val targetLocalDateTime = yearMiddle2024.atTime(13, 30)
+            makeTestMemoryCandidate(memoryId = 2L, startAt = startDateOf2024, endAt = endDateOf2024)
+        val targetLocalDateTime = middleDateOf2024.atTime(13, 30)
         // when
         val actual = category.getClosestDateTime(targetLocalDateTime)
         // then
@@ -87,11 +87,11 @@ class MemoryCandidateTest {
     fun `타겟 일시가 기간보다 과거라면 시작일의 정오를 반환`() {
         // given
         val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val targetLocalDateTime = yearEnd2023.atTime(13, 30)
+            makeTestMemoryCandidate(memoryId = 2L, startAt = startDateOf2024, endAt = endDateOf2024)
+        val targetLocalDateTime = endDateOf2023.atTime(13, 30)
         // when
         val actual = category.getClosestDateTime(targetLocalDateTime)
-        val expected = yearStart2024.atTime(12, 0)
+        val expected = startDateOf2024.atTime(12, 0)
         // then
         assertEquals(expected, actual)
     }
@@ -100,16 +100,16 @@ class MemoryCandidateTest {
     fun `타겟 일시가 기간보다 미래라면 종료일의 정오를 반환`() {
         // given
         val category =
-            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
-        val targetLocalDateTime = yearStart2025.atTime(13, 30)
+            makeTestMemoryCandidate(memoryId = 2L, startAt = startDateOf2024, endAt = endDateOf2024)
+        val targetLocalDateTime = startDateOf2025.atTime(13, 30)
         // when
         val actual = category.getClosestDateTime(targetLocalDateTime)
-        val expected = yearEnd2024.atTime(12, 0)
+        val expected = endDateOf2024.atTime(12, 0)
         // then
         assertEquals(expected, actual)
     }
 
-    private fun validLocalDateParameters(): List<LocalDate> = listOf(yearStart2024, yearMiddle2024, yearEnd2024)
+    private fun validLocalDateParameters(): List<LocalDate> = listOf(startDateOf2024, middleDateOf2024, endDateOf2024)
 
     private fun localDateParameters(): List<LocalDate> =
         listOf(

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -4,6 +4,7 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class MemoryCandidateTest {
+    // 아래부터 isDateWithinPeriod 테스트
     @Test
     fun `특정 날짜가 startAt과 endAt 사이에 포함되면 true 반환`() {
         val category =
@@ -94,5 +95,45 @@ class MemoryCandidateTest {
         assertEquals(expected1, actual1)
         assertEquals(expected2, actual2)
         assertEquals(expected3, actual3)
+    }
+
+    // 아래부터 getClosestDateTime 테스트
+    @Test
+    fun `2024년 중 2023년 마지막 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearEnd2023.atTime(12, 0))
+        val expected = yearStart2024.atTime(0, 0)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `2024년 중 2024년 7월 1일 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearMiddle2024.atTime(12, 0))
+        val expected = yearMiddle2024.atTime(12, 0)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `2024년 중 2025년 첫번째 날 12시와 가장 가까운 날짜 및 시간을 반환한다`() {
+        // given
+        val category =
+            makeTestMemoryCandidate(memoryId = 2L, startAt = yearStart2024, endAt = yearEnd2024)
+
+        // when & then
+        val actual = category.getClosestDateTime(yearStart2025.atTime(12, 0))
+        val expected = yearEnd2024.atTime(0, 0)
+
+        assertEquals(expected, actual)
     }
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidateTest.kt
@@ -1,0 +1,98 @@
+package com.on.staccato.domain.model
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class MemoryCandidateTest {
+    @Test
+    fun `특정 날짜가 startAt과 endAt 사이에 포함되면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearMiddle2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜와 startAt이 같으면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearStart2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜와 endAt이 같으면 true 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearEnd2024)
+        val expected = true
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜가 startAt 이전이면 false 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearEnd2023)
+        val expected = false
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `특정 날짜가 endAt 이후면 false 반환`() {
+        val category =
+            makeTestMemoryCandidate(
+                startAt = yearStart2024,
+                endAt = yearEnd2024,
+            )
+
+        val actual = category.isDateWithinPeriod(yearStart2025)
+        val expected = false
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `startAt과 endAt이 null이면 모든 날짜에 true 반환`() {
+        // given
+        val categoryWithoutPeriod =
+            makeTestMemoryCandidate(
+                startAt = null,
+                endAt = null,
+            )
+
+        // when & then
+        val actual1 = categoryWithoutPeriod.isDateWithinPeriod(yearEnd2023)
+        val expected1 = true
+        val actual2 = categoryWithoutPeriod.isDateWithinPeriod(yearMiddle2024)
+        val expected2 = true
+        val actual3 = categoryWithoutPeriod.isDateWithinPeriod(yearStart2025)
+        val expected3 = true
+
+        assertEquals(expected1, actual1)
+        assertEquals(expected2, actual2)
+        assertEquals(expected3, actual3)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -2,6 +2,7 @@ package com.on.staccato.domain.model
 
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -11,7 +12,7 @@ import java.time.LocalDate
 class MemoryCandidatesTest {
     @Test
     @Parameters(method = "parameters")
-    fun `getValidMemoryCandidate는 date를 포함하는 후보만 필터링`(date: LocalDate) {
+    fun `date를 포함하는 후보들을 필터링해 반환`(date: LocalDate) {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
@@ -19,8 +20,21 @@ class MemoryCandidatesTest {
         val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
 
         // then
-        val actual = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
-        assertTrue(actual)
+        val isEveryCandidatesContainDate = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        assertTrue(isEveryCandidatesContainDate)
+    }
+
+    @Test
+    fun `아이디가 정확히 일치하는 memoryCandidate를 찾아 반환`() {
+        // given
+        val memoryCandidates = dummyMemoryCandidates
+
+        // when
+        val actual = memoryCandidates.getValidMemoryCandidate(TARGET_MEMORY_ID)
+        val expected = listOf(targetMemoryCandidate)
+
+        // then
+        assertEquals(expected, actual)
     }
 
     private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -18,40 +18,69 @@ class MemoryCandidatesTest {
         val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val filteredCandidates = categoryCandidates.filterCandidatesBy(date)
+        val filteredCandidates = categoryCandidates.filterBy(date)
 
         // then
-        val isEveryCandidatesContainDate = filteredCandidates.all { it.isDateWithinPeriod(date) }
+        val isEveryCandidatesContainDate = filteredCandidates.memoryCandidate.all { it.isDateWithinPeriod(date) }
         assertTrue(isEveryCandidatesContainDate)
     }
 
     @Test
-    fun `아이디가 일치하는 카테고리를 찾아 반환`() {
+    @Parameters(method = "existentCategoryIds")
+    fun `findBy는 아이디가 일치하는 카테고리를 찾아 반환`(categoryId: Long) {
         // given
         val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = categoryCandidates.findCandidatesBy(TARGET_MEMORY_ID)
-        val expected = targetMemoryCandidate
+        val actual = categoryCandidates.findBy(categoryId)
 
         // then
-        assertEquals(expected, actual)
+        assertEquals(categoryId, actual?.memoryId)
     }
 
     @Test
     @Parameters(method = "nonExistentCategoryIds")
-    fun `아이디가 일치하는 카테고리가 없으면 null을 반환`(categoryId: Long) {
+    fun `findBy는 일치하는 아이디가 없으면 null을 반환`(categoryId: Long) {
         // given
         val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = categoryCandidates.findCandidatesBy(categoryId)
+        val actual = categoryCandidates.findBy(categoryId)
 
         // then
         assertNull(actual)
     }
 
+    @Test
+    @Parameters(method = "existentCategoryIds")
+    fun `findByIdOrFirst는 아이디가 일치하는 카테고리를 찾아 반환`(categoryId: Long) {
+        // given
+        val categoryCandidates = dummyMemoryCandidates
+
+        // when
+        val actual = categoryCandidates.findByIdOrFirst(categoryId)
+
+        // then
+        assertEquals(categoryId, actual?.memoryId)
+    }
+
+    @Test
+    @Parameters(method = "nonExistentCategoryIds")
+    fun `findByIdOrFirst는일치하는 아이디가 없으면 첫번째 카테고리를 반환`(categoryId: Long) {
+        // given
+        val categoryCandidates = dummyMemoryCandidates
+
+        // when
+        val actual = categoryCandidates.findByIdOrFirst(categoryId)
+        val expected = memoryCandidateWithId1
+
+        // then
+        assertEquals(expected, actual)
+    }
+
     private fun parameters(): List<LocalDate> = listOf(endDateOf2023, startDateOf2024, middleDateOf2024, endDateOf2024, startDateOf2025)
 
     private fun nonExistentCategoryIds(): List<Long> = listOf(80L, 999L, 1000L, 1234L)
+
+    private fun existentCategoryIds(): List<Long> = listOf(1L, 2L, 3L, 4L)
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -18,10 +18,10 @@ class MemoryCandidatesTest {
         val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = categoryCandidates.filterCandidatesBy(date)
+        val filteredCandidates = categoryCandidates.filterCandidatesBy(date)
 
         // then
-        val isEveryCandidatesContainDate = actual.all { it.isDateWithinPeriod(date) }
+        val isEveryCandidatesContainDate = filteredCandidates.all { it.isDateWithinPeriod(date) }
         assertTrue(isEveryCandidatesContainDate)
     }
 

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -1,0 +1,27 @@
+package com.on.staccato.domain.model
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(JUnitParamsRunner::class)
+class MemoryCandidatesTest {
+    @Test
+    @Parameters(method = "parameters")
+    fun `getValidMemoryCandidate는 date를 포함하는 후보만 필터링`(date: LocalDate) {
+        // given
+        val memoryCandidates = dummyMemoryCandidates
+
+        // when
+        val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
+
+        // then
+        val actual = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        assertTrue(actual)
+    }
+
+    private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -12,25 +12,25 @@ import java.time.LocalDate
 class MemoryCandidatesTest {
     @Test
     @Parameters(method = "parameters")
-    fun `date를 포함하는 후보들을 필터링해 반환`(date: LocalDate) {
+    fun `date를 포함하는 후보들을 필터링 하여 반환`(date: LocalDate) {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
         // when
-        val selectableMemoryCandidate = memoryCandidates.getValidMemoryCandidate(date)
+        val actual = memoryCandidates.filterCandidatesBy(date)
 
         // then
-        val isEveryCandidatesContainDate = selectableMemoryCandidate.all { it.isDateWithinPeriod(date) }
+        val isEveryCandidatesContainDate = actual.all { it.isDateWithinPeriod(date) }
         assertTrue(isEveryCandidatesContainDate)
     }
 
     @Test
-    fun `아이디가 정확히 일치하는 memoryCandidate를 찾아 반환`() {
+    fun `아이디가 일치하는 memoryCandidate를 찾아 반환`() {
         // given
         val memoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = memoryCandidates.getValidMemoryCandidate(TARGET_MEMORY_ID)
+        val actual = memoryCandidates.filterCandidatesBy(TARGET_MEMORY_ID)
         val expected = listOf(targetMemoryCandidate)
 
         // then

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -3,6 +3,7 @@ package com.on.staccato.domain.model
 import junitparams.JUnitParamsRunner
 import junitparams.Parameters
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -12,12 +13,12 @@ import java.time.LocalDate
 class MemoryCandidatesTest {
     @Test
     @Parameters(method = "parameters")
-    fun `date를 포함하는 후보들을 필터링 하여 반환`(date: LocalDate) {
+    fun `날짜를 포함하는 카테고리들을 필터링 하여 반환`(date: LocalDate) {
         // given
-        val memoryCandidates = dummyMemoryCandidates
+        val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = memoryCandidates.filterCandidatesBy(date)
+        val actual = categoryCandidates.filterCandidatesBy(date)
 
         // then
         val isEveryCandidatesContainDate = actual.all { it.isDateWithinPeriod(date) }
@@ -25,17 +26,32 @@ class MemoryCandidatesTest {
     }
 
     @Test
-    fun `아이디가 일치하는 memoryCandidate를 찾아 반환`() {
+    fun `아이디가 일치하는 카테고리를 찾아 반환`() {
         // given
-        val memoryCandidates = dummyMemoryCandidates
+        val categoryCandidates = dummyMemoryCandidates
 
         // when
-        val actual = memoryCandidates.filterCandidatesBy(TARGET_MEMORY_ID)
-        val expected = listOf(targetMemoryCandidate)
+        val actual = categoryCandidates.findCandidatesBy(TARGET_MEMORY_ID)
+        val expected = targetMemoryCandidate
 
         // then
         assertEquals(expected, actual)
     }
 
+    @Test
+    @Parameters(method = "nonExistentCategoryIds")
+    fun `아이디가 일치하는 카테고리가 없으면 null을 반환`(categoryId: Long) {
+        // given
+        val categoryCandidates = dummyMemoryCandidates
+
+        // when
+        val actual = categoryCandidates.findCandidatesBy(categoryId)
+
+        // then
+        assertNull(actual)
+    }
+
     private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)
+
+    private fun nonExistentCategoryIds(): List<Long> = listOf(80L, 999L, 1000L, 1234L)
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MemoryCandidatesTest.kt
@@ -51,7 +51,7 @@ class MemoryCandidatesTest {
         assertNull(actual)
     }
 
-    private fun parameters(): List<LocalDate> = listOf(yearEnd2023, yearStart2024, yearMiddle2024, yearEnd2024, yearStart2025)
+    private fun parameters(): List<LocalDate> = listOf(endDateOf2023, startDateOf2024, middleDateOf2024, endDateOf2024, startDateOf2025)
 
     private fun nonExistentCategoryIds(): List<Long> = listOf(80L, 999L, 1000L, 1234L)
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MonthCalendarTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/MonthCalendarTest.kt
@@ -1,0 +1,100 @@
+package com.on.staccato.domain.model
+
+import junitparams.JUnitParamsRunner
+import junitparams.Parameters
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+
+@RunWith(JUnitParamsRunner::class)
+class MonthCalendarTest {
+    @Test
+    fun `기간의 시작과 끝을 정하지 않으면 2024년의 모든 월을 반환한다`() {
+        val monthCalendarOf2024 = MonthCalendar.of(year = 2024)
+        val actual = monthCalendarOf2024.getAvailableMonths()
+        val expected = (1..12).toList()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `기간의 시작과 끝이 정해져 있으면 기간 안에 속하는 월들을 반환한다`() {
+        val allMonthsOf2024Calendar =
+            MonthCalendar.of(
+                year = 2024,
+                periodStart = LocalDate.of(2024, 1, 1),
+                periodEnd = LocalDate.of(2025, 6, 1),
+            )
+        val actual = allMonthsOf2024Calendar.getAvailableMonths()
+        val expected = (1..12).toList()
+        assertEquals(expected, actual)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `날짜가 기간을 벗어나면 예외를 반환한다`() {
+        val periodStart = LocalDate.of(2023, 12, 1)
+        val periodEnd = LocalDate.of(2024, 1, 10)
+        MonthCalendar.of(2025, periodStart, periodEnd)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `기간의 시작이 끝보다 늦으면 예외를 반환한다`() {
+        val periodStart = LocalDate.of(2024, 2, 2)
+        val periodEnd = LocalDate.of(2024, 2, 1)
+        MonthCalendar.of(2024, periodStart, periodEnd)
+    }
+
+    @Test
+    fun `달력에서 특정 달에 해당하는 일들을 반환한다`() {
+        val december = 12
+        val actual = december1stTo15thMonthCalendar.getAvailableDates(december)
+        val expected = (1..15).toList()
+
+        assertEquals(expected, actual)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `달력에 특정 달이 없으면 예외를 던진다`() {
+        val january = 1
+        december1stTo15thMonthCalendar.getAvailableDates(january)
+    }
+
+    @Test
+    @Parameters(method = "monthParametersFrom4to8")
+    fun `4월부터 8월 사이라면 해당 월을 그대로 반환한다`(targetMonth: Int) {
+        val actual = aprilToAugustCalendar.getClosestMonth(targetMonth)
+
+        assertEquals(targetMonth, actual)
+    }
+
+    @Test
+    @Parameters(method = "monthParametersSmallerThan4")
+    fun `범위보다 작으면 가장 첫번째 월을 반환한다`(targetMonth: Int) {
+        val firstMonth = 4
+        val actual = aprilToAugustCalendar.getClosestMonth(targetMonth)
+
+        assertEquals(firstMonth, actual)
+    }
+
+    @Test
+    @Parameters(method = "monthParametersGraterThan8")
+    fun `범위보다 크면 가장 마지막 월을 반환한다`(targetMonth: Int) {
+        val lastMonth = 8
+        val actual = aprilToAugustCalendar.getClosestMonth(targetMonth)
+
+        assertEquals(lastMonth, actual)
+    }
+
+    @Test
+    fun `입력된 월의 DateCalendar를 반환한다`() {
+        val actual = aprilToAugustCalendar.findDateCalendar(6)
+        val expected = juneDateCalendar
+        assertEquals(expected, actual)
+    }
+
+    private fun monthParametersFrom4to8(): List<Int> = listOf(4, 5, 6, 7, 8)
+
+    private fun monthParametersSmallerThan4(): List<Int> = listOf(1, 2, 3)
+
+    private fun monthParametersGraterThan8(): List<Int> = listOf(9, 10, 11, 12)
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
@@ -75,13 +75,13 @@ class YearCalendarTest {
     }
 
     @Test
-    fun `기간을 지정하지 않으면 현재 날짜 기준으로 앞뒤 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
+    fun `방문일이 주어지면 해당 날짜를 기준 앞,뒤로 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
         // given
-        val now = LocalDateTime.of(2025, 1, 3, 16, 0)
-        val expectedYearRange = (now.minusYears(10).year..now.plusYears(10).year).toList()
+        val visitedAt = LocalDate.of(2025, 1, 7)
+        val expectedYearRange = (visitedAt.minusYears(10).year..visitedAt.plusYears(10).year).toList()
 
         // when
-        val yearCalendar = YearCalendar.of()
+        val yearCalendar = YearCalendar.from(visitedAt)
 
         // then
         assertEquals(expectedYearRange, yearCalendar.getAvailableYears())
@@ -96,6 +96,20 @@ class YearCalendarTest {
 
         // when
         val yearCalendar = YearCalendar.of(periodStart, periodEnd)
+
+        // then
+        assertEquals(expectedYearRange, yearCalendar.getAvailableYears())
+    }
+
+    @Test
+    fun `시작일과 종료일을 지정하지 않으면 현재 날짜를 기준으로 앞,뒤로 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
+        // given
+        val now = LocalDate.of(2025, 1, 1)
+        val expectedYearRange = (now.minusYears(10).year..now.plusYears(10).year).toList()
+
+        // when
+        val yearCalendar = YearCalendar.of()
+        println(yearCalendar.getAvailableYears())
 
         // then
         assertEquals(expectedYearRange, yearCalendar.getAvailableYears())

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
@@ -1,0 +1,148 @@
+package com.on.staccato.domain.model
+
+import junitparams.JUnitParamsRunner
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@RunWith(JUnitParamsRunner::class)
+class YearCalendarTest {
+    @Test
+    fun `기간의 시작일과 종료일 사이에 해당하는 달력을 반환한다`() {
+        // given
+        val startYear = 2024
+        val startMonth = 12
+        val startDate = 1
+        val start = LocalDate.of(startYear, startMonth, startDate)
+        val end = start.plusYears(1)
+
+        // when
+        val actualCalendar = YearCalendar.of(start, end)
+
+        // then
+        assertEquals(startYear, actualCalendar.selectedYear)
+        assertEquals(startMonth, actualCalendar.selectedMonth)
+        assertEquals(startDate, actualCalendar.selectedDate)
+
+        val defaultHour = 12
+        val defaultMinute = 0
+        val dateTime =
+            LocalDateTime.of(startYear, startMonth, startDate, defaultHour, defaultMinute)
+        assertEquals(defaultHour, actualCalendar.selectedHour)
+        assertEquals(dateTime, actualCalendar.selectedDateTime)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun `기간의 시작일이 종료일보다 늦으면 예외가 발생한다`() {
+        // given
+        val periodStart = LocalDate.of(2024, 12, 31)
+        val periodEnd = LocalDate.of(2024, 1, 1)
+        // when & then
+        YearCalendar.of(periodStart, periodEnd)
+    }
+
+    @Test
+    fun `달력의 모든 년도를 반환한다`() {
+        val periodStart = LocalDate.of(2023, 2, 2)
+        val periodEnd = LocalDate.of(2025, 2, 1)
+        val calendar = YearCalendar.of(periodStart, periodEnd)
+
+        val actual = calendar.getAvailableYears()
+        val expected = (2023..2025).toList()
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `선택된 년도의 월을 반환한다`() {
+        // given
+        val startYear = 2023
+        val startMonth = 5
+        val periodStart = LocalDate.of(startYear, startMonth, 2)
+        val periodEnd = LocalDate.of(2025, 6, 1)
+        val actualCalendar = YearCalendar.of(periodStart, periodEnd)
+
+        // when
+        val actualMonths = actualCalendar.getAvailableMonths()
+        val expectedMonths = (startMonth..12).toList()
+        assertEquals(startYear, actualCalendar.selectedYear)
+        assertEquals(expectedMonths, actualMonths)
+
+        // then
+        assertEquals(startYear, actualCalendar.selectedYear)
+        assertEquals(expectedMonths, actualMonths)
+    }
+
+    @Test
+    fun `기간을 지정하지 않으면 현재 날짜 기준으로 앞뒤 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
+        // given
+        val now = LocalDateTime.of(2025, 1, 3, 16, 0)
+        val expectedYearRange = (now.minusYears(10).year..now.plusYears(10).year).toList()
+
+        // when
+        val yearCalendar = YearCalendar.of()
+
+        // then
+        assertEquals(expectedYearRange, yearCalendar.getAvailableYears())
+    }
+
+    @Test
+    fun `시작일과 종료일이 주어지면 해당 기간의 연도 범위를 가진 YearCalendar가 생성된다`() {
+        // given
+        val periodStart = LocalDate.of(2023, 1, 1)
+        val periodEnd = LocalDate.of(2025, 12, 31)
+        val expectedYearRange = (2023..2025).toList()
+
+        // when
+        val yearCalendar = YearCalendar.of(periodStart, periodEnd)
+
+        // then
+        assertEquals(expectedYearRange, yearCalendar.getAvailableYears())
+    }
+
+    @Test
+    fun `선택된 연도를 변경하면 해당 연도의 사용 가능한 월 목록을 반환한다`() {
+        // given
+        val periodStart = LocalDate.of(2024, 4, 1)
+        val periodEnd = LocalDate.of(2024, 8, 30)
+        val yearCalendar = YearCalendar.of(periodStart, periodEnd)
+
+        // when
+        yearCalendar.changeSelectedYear(2024)
+
+        // then
+        assertEquals((4..8).toList(), yearCalendar.getAvailableMonths())
+    }
+
+    @Test
+    fun `선택된 연월을 변경하면 해당 월의 사용 가능한 일자 목록을 반환한다`() {
+        // given
+        val periodStart = LocalDate.of(2024, 4, 15)
+        val periodEnd = LocalDate.of(2025, 5, 15)
+        val yearCalendar = YearCalendar.of(periodStart, periodEnd)
+
+        // when
+        yearCalendar.changeSelectedYear(2024)
+        yearCalendar.changeSelectedMonth(4)
+        yearCalendar.changeSelectedDate(15)
+        yearCalendar.changeSelectedHour(20)
+
+        // then
+        assertEquals((15..30).toList(), yearCalendar.getAvailableDates())
+        assertEquals(LocalDateTime.of(2024, 4, 15, 20, 0), yearCalendar.selectedDateTime)
+    }
+
+    @Test
+    fun `initSelectedDateTime으로 날짜를 초기화할 수 있다`() {
+        // given
+        val yearCalendar = YearCalendar.of()
+        val initDateTime = LocalDateTime.of(2024, 5, 15, 14, 0)
+
+        // when
+        yearCalendar.initSelectedDateTime(initDateTime)
+
+        // then
+        assertEquals(initDateTime, yearCalendar.selectedDateTime)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
@@ -75,10 +75,10 @@ class YearCalendarTest {
     }
 
     @Test
-    fun `방문일이 주어지면 해당 날짜를 기준 앞,뒤로 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
+    fun `방문일이 주어지면 해당 날짜를 기준 앞,뒤로 100년씩의 범위를 가진 YearCalendar가 생성된다`() {
         // given
         val visitedAt = LocalDate.of(2025, 1, 7)
-        val expectedYearRange = (visitedAt.minusYears(10).year..visitedAt.plusYears(10).year).toList()
+        val expectedYearRange = (visitedAt.minusYears(100).year..visitedAt.plusYears(100).year).toList()
 
         // when
         val yearCalendar = YearCalendar.from(visitedAt)
@@ -102,10 +102,10 @@ class YearCalendarTest {
     }
 
     @Test
-    fun `시작일과 종료일을 지정하지 않으면 현재 날짜를 기준으로 앞,뒤로 10년씩의 범위를 가진 YearCalendar가 생성된다`() {
+    fun `시작일과 종료일을 지정하지 않으면 현재 날짜를 기준으로 앞,뒤로 100년씩의 범위를 가진 YearCalendar가 생성된다`() {
         // given
         val now = LocalDate.of(2025, 1, 1)
-        val expectedYearRange = (now.minusYears(10).year..now.plusYears(10).year).toList()
+        val expectedYearRange = (now.minusYears(100).year..now.plusYears(100).year).toList()
 
         // when
         val yearCalendar = YearCalendar.of()

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/LiveDataTestUtil.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/LiveDataTestUtil.kt
@@ -1,0 +1,33 @@
+package com.on.staccato.presentation
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer =
+        object : Observer<T> {
+            override fun onChanged(value: T) {
+                data = value
+                latch.countDown()
+                this@getOrAwaitValue.removeObserver(this)
+            }
+        }
+
+    this.observeForever(observer)
+
+    // Don't wait indefinitely if the LiveData is not set.
+    if (!latch.await(time, timeUnit)) {
+        throw TimeoutException("LiveData value was never set.")
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/MainDispatcherRule.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/MainDispatcherRule.kt
@@ -1,0 +1,21 @@
+package com.on.staccato.presentation
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -5,11 +5,11 @@ import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
 import com.on.staccato.domain.model.TARGET_MEMORY_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.endDateOf2023
+import com.on.staccato.domain.model.middleDateOf2024
 import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.startDateOf2024
 import com.on.staccato.domain.model.targetMemoryCandidate
-import com.on.staccato.domain.model.yearEnd2023
-import com.on.staccato.domain.model.yearMiddle2024
-import com.on.staccato.domain.model.yearStart2024
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.MainDispatcherRule
@@ -75,7 +75,7 @@ class StaccatoCreationViewModelTest {
             advanceUntilIdle()
 
             // when
-            val currentLocalDate = yearMiddle2024.atStartOfDay()
+            val currentLocalDate = middleDateOf2024.atStartOfDay()
             viewModel.initMemoryAndVisitedAt(0L, currentLocalDate)
 
             // then
@@ -83,8 +83,8 @@ class StaccatoCreationViewModelTest {
             val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
             val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
 
-            val selectableMemories = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024)
-            val selectedMemory = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024).first()
+            val selectableMemories = dummyMemoryCandidates.filterCandidatesBy(middleDateOf2024)
+            val selectedMemory = dummyMemoryCandidates.filterCandidatesBy(middleDateOf2024).first()
 
             assertEquals(currentLocalDate, actualVisitedAt)
             assertEquals(selectableMemories, actualMemories)
@@ -99,7 +99,7 @@ class StaccatoCreationViewModelTest {
             advanceUntilIdle()
 
             // when
-            val currentVisitedAt = yearMiddle2024.atStartOfDay()
+            val currentVisitedAt = middleDateOf2024.atStartOfDay()
             viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, currentVisitedAt)
 
             // then
@@ -122,11 +122,11 @@ class StaccatoCreationViewModelTest {
             // given
             viewModel.fetchMemoryCandidates()
 
-            val oldLocalDate = yearStart2024.atStartOfDay()
+            val oldLocalDate = startDateOf2024.atStartOfDay()
             viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, oldLocalDate)
 
             // when
-            val newLocalDate = yearEnd2023.atStartOfDay()
+            val newLocalDate = endDateOf2023.atStartOfDay()
             viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.on.staccato.presentation.staccatocreation.viewmodel
 
-import android.os.Looper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
@@ -13,33 +12,27 @@ import com.on.staccato.domain.model.yearMiddle2024
 import com.on.staccato.domain.model.yearStart2024
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.MainDispatcherRule
 import com.on.staccato.presentation.getOrAwaitValue
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.util.concurrent.Executors
 
 @RunWith(JUnit4::class)
 class StaccatoCreationViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @MockK
     private lateinit var timelineRepository: TimelineRepository
@@ -53,25 +46,9 @@ class StaccatoCreationViewModelTest {
     @InjectMockKs
     private lateinit var viewModel: StaccatoCreationViewModel
 
-    private val dispatcher =
-        Executors
-            .newSingleThreadExecutor()
-            .asCoroutineDispatcher()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        dispatcher.close()
     }
 
     @Test

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -142,7 +142,7 @@ class StaccatoCreationViewModelTest {
 
             // when
             val newLocalDate = yearEnd2023.atStartOfDay()
-            viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+            viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then
             val expectedMemories = listOf(newMemoryCandidate)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -3,11 +3,12 @@ package com.on.staccato.presentation.staccatocreation.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.MemoryCandidates
 import com.on.staccato.domain.model.TARGET_MEMORY_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
 import com.on.staccato.domain.model.endDateOf2023
+import com.on.staccato.domain.model.memoryCandidateWithId1
 import com.on.staccato.domain.model.middleDateOf2024
-import com.on.staccato.domain.model.newMemoryCandidate
 import com.on.staccato.domain.model.startDateOf2024
 import com.on.staccato.domain.model.targetMemoryCandidate
 import com.on.staccato.domain.repository.StaccatoRepository
@@ -68,7 +69,7 @@ class StaccatoCreationViewModelTest {
         }
 
     @Test
-    fun `카테고리 ID가 0L일 때는 현재 날짜를 기준으로 일시와 카테고리 후보를 정한다`() =
+    fun `카테고리 ID가 0L일 때는 현재 날짜에서 선택 가능한 카테고리 후보 중 첫번째를 선택한다`() =
         runTest {
             // given
             viewModel.fetchMemoryCandidates()
@@ -80,19 +81,19 @@ class StaccatoCreationViewModelTest {
 
             // then
             val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
-            val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
-            val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+            val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
 
-            val selectableMemories = dummyMemoryCandidates.filterCandidatesBy(middleDateOf2024)
-            val selectedMemory = dummyMemoryCandidates.filterCandidatesBy(middleDateOf2024).first()
+            val selectableMemories = dummyMemoryCandidates.filterBy(middleDateOf2024)
+            val selectedMemory = selectableMemories.findByIdOrFirst(null)
 
             assertEquals(currentLocalDate, actualVisitedAt)
-            assertEquals(selectableMemories, actualMemories)
-            assertEquals(selectedMemory, actualMemory)
+            assertEquals(selectableMemories, actualSelectableMemories)
+            assertEquals(selectedMemory, actualSelectedMemory)
         }
 
     @Test
-    fun `카테고리 ID가 0L이 아닐 때는 특정 카테고리로 고정, 현재와 가장 가까운 일시를 선택한다`() =
+    fun `카테고리 ID가 0L이 아닐 때는 id로 카테고리를 선택하고, 현재와 가장 가까운 일시를 선택한다`() =
         runTest {
             // given
             viewModel.fetchMemoryCandidates()
@@ -104,16 +105,16 @@ class StaccatoCreationViewModelTest {
 
             // then
             val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
-            val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
-            val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+            val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
 
             val closestVisitedAt = targetMemoryCandidate.getClosestDateTime(currentVisitedAt)
-            val fixedMemories = listOf(targetMemoryCandidate)
-            val fixedMemory = targetMemoryCandidate
+            val fixedSelectableMemories = MemoryCandidates.from(targetMemoryCandidate)
+            val fixedSelectedMemory = targetMemoryCandidate
 
             assertEquals(closestVisitedAt, actualVisitedAt)
-            assertEquals(fixedMemories, actualMemories)
-            assertEquals(fixedMemory, actualMemory)
+            assertEquals(fixedSelectableMemories, actualSelectableMemories)
+            assertEquals(fixedSelectedMemory, actualSelectedMemory)
         }
 
     @Test
@@ -130,14 +131,14 @@ class StaccatoCreationViewModelTest {
             viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then
-            val expectedMemories = listOf(newMemoryCandidate)
-            val expectedMemory = newMemoryCandidate
+            val expectedSelectableMemories = MemoryCandidates.from(memoryCandidateWithId1)
+            val expectedSelectedMemory = memoryCandidateWithId1
 
-            val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
-            val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+            val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
 
-            assertEquals(expectedMemories, actualMemories)
-            assertEquals(expectedMemory, actualMemory)
+            assertEquals(expectedSelectableMemories, actualSelectableMemories)
+            assertEquals(expectedSelectedMemory, actualSelectedMemory)
         }
 
     private fun givenMemoryCandidatesReturnsSuccessWithDummyData() {

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
 @RunWith(JUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
 class StaccatoCreationViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -51,22 +52,17 @@ class StaccatoCreationViewModelTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
+        givenMemoryCandidatesReturnsSuccessWithDummyData()
     }
 
     @Test
     fun `viewModel 초기화 시 카테고리 후보를 불러온다`() =
         runTest {
-            // given
-            coEvery { timelineRepository.getMemoryCandidates() } returns
-                ResponseResult.Success(
-                    dummyMemoryCandidates,
-                )
-
             // when
             viewModel.fetchMemoryCandidates()
             advanceUntilIdle()
 
-            // when & then
+            // then
             val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
             assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
         }
@@ -75,10 +71,6 @@ class StaccatoCreationViewModelTest {
     fun `카테고리 ID가 0L일 때는 현재 날짜를 기준으로 일시와 카테고리 후보를 정한다`() =
         runTest {
             // given
-            coEvery { timelineRepository.getMemoryCandidates() } returns
-                ResponseResult.Success(
-                    dummyMemoryCandidates,
-                )
             viewModel.fetchMemoryCandidates()
             advanceUntilIdle()
 
@@ -99,15 +91,10 @@ class StaccatoCreationViewModelTest {
             assertEquals(selectedMemory, actualMemory)
         }
 
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun `카테고리 ID가 0L이 아닐 때는 특정 카테고리로 고정, 현재와 가장 가까운 일시를 선택한다`() =
         runTest {
             // given
-            coEvery { timelineRepository.getMemoryCandidates() } returns
-                ResponseResult.Success(
-                    dummyMemoryCandidates,
-                )
             viewModel.fetchMemoryCandidates()
             advanceUntilIdle()
 
@@ -133,8 +120,6 @@ class StaccatoCreationViewModelTest {
     fun `카테고리 ID가 0L일 때는 일시가 바뀌면 memoryCandidate도 바뀐다`() =
         runTest {
             // given
-            coEvery { timelineRepository.getMemoryCandidates() } returns
-                ResponseResult.Success(dummyMemoryCandidates)
             viewModel.fetchMemoryCandidates()
 
             val oldLocalDate = yearStart2024.atStartOfDay()
@@ -154,4 +139,11 @@ class StaccatoCreationViewModelTest {
             assertEquals(expectedMemories, actualMemories)
             assertEquals(expectedMemory, actualMemory)
         }
+
+    private fun givenMemoryCandidatesReturnsSuccessWithDummyData() {
+        coEvery { timelineRepository.getMemoryCandidates() } returns
+            ResponseResult.Success(
+                dummyMemoryCandidates,
+            )
+    }
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -128,7 +128,7 @@ class StaccatoCreationViewModelTest {
 
             // when
             val newLocalDate = endDateOf2023.atStartOfDay()
-            viewModel.setMemoryCandidateBy(newLocalDate)
+            viewModel.updateMemorySelectionBy(newLocalDate)
 
             // then
             val expectedSelectableMemories = MemoryCandidates.from(memoryCandidateWithId1)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -1,0 +1,176 @@
+package com.on.staccato.presentation.staccatocreation.viewmodel
+
+import android.os.Looper
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.on.staccato.data.ResponseResult
+import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.TARGET_MEMORY_ID
+import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.targetMemoryCandidate
+import com.on.staccato.domain.model.yearEnd2023
+import com.on.staccato.domain.model.yearMiddle2024
+import com.on.staccato.domain.model.yearStart2024
+import com.on.staccato.domain.repository.StaccatoRepository
+import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.getOrAwaitValue
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.concurrent.Executors
+
+@RunWith(JUnit4::class)
+class StaccatoCreationViewModelTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var timelineRepository: TimelineRepository
+
+    @MockK
+    private lateinit var staccatoRepository: StaccatoRepository
+
+    @MockK
+    private lateinit var imageRepository: ImageDefaultRepository
+
+    @InjectMockKs
+    private lateinit var viewModel: StaccatoCreationViewModel
+
+    private val dispatcher =
+        Executors
+            .newSingleThreadExecutor()
+            .asCoroutineDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() } returns mockk(relaxed = true)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        dispatcher.close()
+    }
+
+    @Test
+    fun `viewModel 초기화 시 카테고리 후보를 불러온다`() =
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+
+            // when
+            viewModel.fetchMemoryCandidates()
+
+            // when & then
+            val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+            assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+        }
+
+    @Test
+    fun `카테고리 ID가 0L일 때는 현재 날짜를 기준으로 일시와 카테고리 후보를 정한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        // when
+        val currentLocalDate = yearMiddle2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(0L, currentLocalDate)
+
+        // then
+        val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        val selectableMemories = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024)
+        val selectedMemory = dummyMemoryCandidates.filterCandidatesBy(yearMiddle2024).first()
+
+        assertEquals(currentLocalDate, actualVisitedAt)
+        assertEquals(selectableMemories, actualMemories)
+        assertEquals(selectedMemory, actualMemory)
+    }
+
+    @Test
+    fun `카테고리 ID가 0L이 아닐 때는 특정 카테고리로 고정, 현재와 가장 가까운 일시를 선택한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        // when
+        val currentVisitedAt = yearMiddle2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, currentVisitedAt)
+
+        // then
+        val actualVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        val closestVisitedAt = targetMemoryCandidate.getClosestDateTime(currentVisitedAt)
+        val fixedMemories = listOf(targetMemoryCandidate)
+        val fixedMemory = targetMemoryCandidate
+
+        assertEquals(closestVisitedAt, actualVisitedAt)
+        assertEquals(fixedMemories, actualMemories)
+        assertEquals(fixedMemory, actualMemory)
+    }
+
+    @Test
+    fun `카테고리 ID가 0L일 때는 일시가 바뀌면 memoryCandidate도 바뀐다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            viewModel.fetchMemoryCandidates()
+        }
+        val oldLocalDate = yearStart2024.atStartOfDay()
+        viewModel.initMemoryAndVisitedAt(TARGET_MEMORY_ID, oldLocalDate)
+
+        // when
+        val newLocalDate = yearEnd2023.atStartOfDay()
+        viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+
+        // then
+        val expectedMemories = listOf(newMemoryCandidate)
+        val expectedMemory = newMemoryCandidate
+
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        assertEquals(expectedMemories, actualMemories)
+        assertEquals(expectedMemory, actualMemory)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -118,7 +118,7 @@ class StaccatoUpdateViewModelTest {
 
             // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
             val newLocalDate = yearEnd2023.atStartOfDay() // 수정 후 방문 날짜
-            viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+            viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
             val expectedMemories = listOf(newMemoryCandidate)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -1,6 +1,5 @@
 package com.on.staccato.presentation.staccatoupdate.viewmodel
 
-import android.os.Looper
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
@@ -13,30 +12,24 @@ import com.on.staccato.domain.model.targetStaccato
 import com.on.staccato.domain.model.yearEnd2023
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.MainDispatcherRule
 import com.on.staccato.presentation.getOrAwaitValue
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.asCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.After
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-import java.util.concurrent.Executors
 
 class StaccatoUpdateViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
 
     @MockK
     private lateinit var timelineRepository: TimelineRepository
@@ -50,25 +43,9 @@ class StaccatoUpdateViewModelTest {
     @InjectMockKs
     private lateinit var viewModel: StaccatoUpdateViewModel
 
-    private val dispatcher =
-        Executors
-            .newSingleThreadExecutor()
-            .asCoroutineDispatcher()
-
-    @OptIn(ExperimentalCoroutinesApi::class)
     @Before
     fun setUp() {
         MockKAnnotations.init(this)
-        mockkStatic(Looper::class)
-        every { Looper.getMainLooper() } returns mockk(relaxed = true)
-        Dispatchers.setMain(dispatcher)
-    }
-
-    @OptIn(ExperimentalCoroutinesApi::class)
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        dispatcher.close()
     }
 
     @Test
@@ -95,7 +72,8 @@ class StaccatoUpdateViewModelTest {
         Assert.assertEquals(targetStaccato.address, actualAddress)
 
         // 일시 선택을 위한 값 검사
-        val expectedSelectableMemories = dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+        val expectedSelectableMemories =
+            dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
         val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
         Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
 

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -6,11 +6,11 @@ import com.on.staccato.data.image.ImageDefaultRepository
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.model.TARGET_STACCATO_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.endDateOf2023
+import com.on.staccato.domain.model.endDateOf2024
 import com.on.staccato.domain.model.makeTestStaccato
 import com.on.staccato.domain.model.newMemoryCandidate
 import com.on.staccato.domain.model.targetMemoryCandidate
-import com.on.staccato.domain.model.yearEnd2023
-import com.on.staccato.domain.model.yearEnd2024
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.MainDispatcherRule
@@ -95,7 +95,7 @@ class StaccatoUpdateViewModelTest {
             advanceUntilIdle()
 
             // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
-            val newLocalDate = yearEnd2023.atStartOfDay() // 수정 후 방문 날짜
+            val newLocalDate = endDateOf2023.atStartOfDay() // 수정 후 방문 날짜
             viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
@@ -114,7 +114,7 @@ class StaccatoUpdateViewModelTest {
             makeTestStaccato(
                 staccatoId = TARGET_STACCATO_ID,
                 memoryCandidate = targetMemoryCandidate,
-                visitedAt = yearEnd2024.atTime(12, 0),
+                visitedAt = endDateOf2024.atTime(12, 0),
             )
         setupRepositoriesWithDummyData(targetStaccato)
         return targetStaccato

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -1,0 +1,139 @@
+package com.on.staccato.presentation.staccatoupdate.viewmodel
+
+import android.os.Looper
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.on.staccato.data.ResponseResult
+import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.TARGET_MEMORY_ID
+import com.on.staccato.domain.model.TARGET_STACCATO_ID
+import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.targetMemoryCandidate
+import com.on.staccato.domain.model.targetStaccato
+import com.on.staccato.domain.model.yearEnd2023
+import com.on.staccato.domain.repository.StaccatoRepository
+import com.on.staccato.domain.repository.TimelineRepository
+import com.on.staccato.presentation.getOrAwaitValue
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.Executors
+
+class StaccatoUpdateViewModelTest {
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @MockK
+    private lateinit var timelineRepository: TimelineRepository
+
+    @MockK
+    private lateinit var staccatoRepository: StaccatoRepository
+
+    @MockK
+    private lateinit var imageRepository: ImageDefaultRepository
+
+    @InjectMockKs
+    private lateinit var viewModel: StaccatoUpdateViewModel
+
+    private val dispatcher =
+        Executors
+            .newSingleThreadExecutor()
+            .asCoroutineDispatcher()
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this)
+        mockkStatic(Looper::class)
+        every { Looper.getMainLooper() } returns mockk(relaxed = true)
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        dispatcher.close()
+    }
+
+    @Test
+    fun `수정하려는 스타카토와 추억 후보를 불러와 스타카토, 일시 및 추억 선택 값을 초기화 한다`() {
+        runTest {
+            // given
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+                ResponseResult.Success(targetStaccato)
+
+            // when
+            viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+        }
+
+        // then
+        // 스타카토 관련 값 검사
+        val actualPlaceName = viewModel.placeName.getOrAwaitValue()
+        val actualAddress = viewModel.address.getOrAwaitValue()
+
+        Assert.assertEquals(targetStaccato.placeName, actualPlaceName)
+        Assert.assertEquals(targetStaccato.address, actualAddress)
+
+        // 일시 선택을 위한 값 검사
+        val expectedSelectableMemories = dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+        val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+        Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
+
+        // 추억 선택을 위한 값 검사
+        val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+        val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
+        val actualSelectedVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+
+        Assert.assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+        Assert.assertEquals(targetMemoryCandidate, actualSelectedMemory)
+        Assert.assertEquals(targetStaccato.visitedAt, actualSelectedVisitedAt)
+    }
+
+    @Test
+    fun `일시가 바뀌면 그에 따라 선택 가능 카테고리, 선택된 카테고리를 업데이트 한다`() {
+        // given
+        runTest {
+            coEvery { timelineRepository.getMemoryCandidates() } returns
+                ResponseResult.Success(
+                    dummyMemoryCandidates,
+                )
+            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+                ResponseResult.Success(targetStaccato)
+            viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+        }
+
+        // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
+        val newLocalDate = yearEnd2023.atStartOfDay()
+        viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+
+        // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
+        val expectedMemories = listOf(newMemoryCandidate)
+        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+
+        val expectedMemory = newMemoryCandidate
+        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+        Assert.assertEquals(expectedMemories, actualMemories)
+        Assert.assertEquals(expectedMemory, actualMemory)
+    }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -71,13 +71,14 @@ class StaccatoUpdateViewModelTest {
             assertEquals(targetStaccato.address, actualAddress)
 
             // 추억 선택을 위한 데이터 검사
+            val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
             val expectedSelectableMemories =
                 dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
-            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
-            val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
             val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
-            assertEquals(expectedSelectableMemories, actualSelectableMemories)
+
             assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+            assertEquals(expectedSelectableMemories, actualSelectableMemories)
             assertEquals(targetMemoryCandidate, actualSelectedMemory)
 
             // 일시 선택을 위한 데이터 검사

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -3,13 +3,14 @@ package com.on.staccato.presentation.staccatoupdate.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.domain.model.MemoryCandidates
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.model.TARGET_STACCATO_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
 import com.on.staccato.domain.model.endDateOf2023
 import com.on.staccato.domain.model.endDateOf2024
 import com.on.staccato.domain.model.makeTestStaccato
-import com.on.staccato.domain.model.newMemoryCandidate
+import com.on.staccato.domain.model.memoryCandidateWithId1
 import com.on.staccato.domain.model.targetMemoryCandidate
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
@@ -74,7 +75,7 @@ class StaccatoUpdateViewModelTest {
             val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
             val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
             val expectedSelectableMemories =
-                dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+                dummyMemoryCandidates.filterBy(targetStaccato.visitedAt.toLocalDate())
             val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
 
             assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
@@ -100,14 +101,14 @@ class StaccatoUpdateViewModelTest {
             viewModel.setMemoryCandidateBy(newLocalDate)
 
             // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
-            val expectedMemories = listOf(newMemoryCandidate)
-            val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+            val expectedSelectableMemories = MemoryCandidates.from(memoryCandidateWithId1)
+            val actualSelectedMemories = viewModel.selectableMemories.getOrAwaitValue()
 
-            val expectedMemory = newMemoryCandidate
-            val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+            val expectedSelectableMemory = memoryCandidateWithId1
+            val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
 
-            assertEquals(expectedMemories, actualMemories)
-            assertEquals(expectedMemory, actualMemory)
+            assertEquals(expectedSelectableMemories, actualSelectedMemories)
+            assertEquals(expectedSelectableMemory, actualSelectedMemory)
         }
 
     private fun givenTargetStaccatoWithRepositorySetup(): Staccato {

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -6,10 +6,11 @@ import com.on.staccato.data.image.ImageDefaultRepository
 import com.on.staccato.domain.model.TARGET_MEMORY_ID
 import com.on.staccato.domain.model.TARGET_STACCATO_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
+import com.on.staccato.domain.model.makeTestStaccato
 import com.on.staccato.domain.model.newMemoryCandidate
 import com.on.staccato.domain.model.targetMemoryCandidate
-import com.on.staccato.domain.model.targetStaccato
 import com.on.staccato.domain.model.yearEnd2023
+import com.on.staccato.domain.model.yearEnd2024
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.MainDispatcherRule
@@ -18,12 +19,15 @@ import io.mockk.MockKAnnotations
 import io.mockk.coEvery
 import io.mockk.impl.annotations.InjectMockKs
 import io.mockk.impl.annotations.MockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class StaccatoUpdateViewModelTest {
     @get:Rule
     var instantTaskExecutorRule = InstantTaskExecutorRule()
@@ -49,69 +53,82 @@ class StaccatoUpdateViewModelTest {
     }
 
     @Test
-    fun `수정하려는 스타카토와 추억 후보를 불러와 스타카토, 일시 및 추억 선택 값을 초기화 한다`() {
+    fun `수정하려는 스타카토, 추억 후보를 불러온 뒤 뷰모델의 스타카토, 일시 및 추억 관련 데이터를 초기화 한다`() =
         runTest {
-            // given
+            // given : 뷰모델 메서드 반환값 지정
+            val targetStaccato =
+                makeTestStaccato(
+                    staccatoId = TARGET_STACCATO_ID,
+                    memoryCandidate = targetMemoryCandidate,
+                    visitedAt = yearEnd2024.atTime(12, 0),
+                )
+
             coEvery { timelineRepository.getMemoryCandidates() } returns
                 ResponseResult.Success(
                     dummyMemoryCandidates,
                 )
-            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+            coEvery { staccatoRepository.getStaccato(TARGET_STACCATO_ID) } returns
                 ResponseResult.Success(targetStaccato)
 
-            // when
+            // when : TARGET_STACCATO_ID에 맞는 스타카토를 불러온다.
             viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+            advanceUntilIdle()
+
+            // then : 뷰모델의 LiveData가 초기화 된다.
+            // 스타카토 관련 데이터 검사
+            val actualPlaceName = viewModel.placeName.getOrAwaitValue()
+            val actualAddress = viewModel.address.getOrAwaitValue()
+
+            Assert.assertEquals(targetStaccato.placeName, actualPlaceName)
+            Assert.assertEquals(targetStaccato.address, actualAddress)
+
+            // 추억 선택을 위한 데이터 검사
+            val expectedSelectableMemories =
+                dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
+            val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
+            val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
+            val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
+            Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
+            Assert.assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
+            Assert.assertEquals(targetMemoryCandidate, actualSelectedMemory)
+
+            // 일시 선택을 위한 데이터 검사
+            val actualSelectedVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
+            Assert.assertEquals(targetStaccato.visitedAt, actualSelectedVisitedAt)
         }
-
-        // then
-        // 스타카토 관련 값 검사
-        val actualPlaceName = viewModel.placeName.getOrAwaitValue()
-        val actualAddress = viewModel.address.getOrAwaitValue()
-
-        Assert.assertEquals(targetStaccato.placeName, actualPlaceName)
-        Assert.assertEquals(targetStaccato.address, actualAddress)
-
-        // 일시 선택을 위한 값 검사
-        val expectedSelectableMemories =
-            dummyMemoryCandidates.filterCandidatesBy(targetStaccato.visitedAt.toLocalDate())
-        val actualSelectableMemories = viewModel.selectableMemories.getOrAwaitValue()
-        Assert.assertEquals(expectedSelectableMemories, actualSelectableMemories)
-
-        // 추억 선택을 위한 값 검사
-        val actualMemoryCandidates = viewModel.memoryCandidates.getOrAwaitValue()
-        val actualSelectedMemory = viewModel.selectedMemory.getOrAwaitValue()
-        val actualSelectedVisitedAt = viewModel.selectedVisitedAt.getOrAwaitValue()
-
-        Assert.assertEquals(dummyMemoryCandidates, actualMemoryCandidates)
-        Assert.assertEquals(targetMemoryCandidate, actualSelectedMemory)
-        Assert.assertEquals(targetStaccato.visitedAt, actualSelectedVisitedAt)
-    }
 
     @Test
-    fun `일시가 바뀌면 그에 따라 선택 가능 카테고리, 선택된 카테고리를 업데이트 한다`() {
-        // given
+    fun `일시가 바뀌면 그에 따라 선택 가능 카테고리, 선택된 카테고리를 업데이트 한다`() =
         runTest {
+            // given : 뷰모델을 초기화 한다
+            val targetStaccato =
+                makeTestStaccato(
+                    staccatoId = TARGET_STACCATO_ID,
+                    memoryCandidate = targetMemoryCandidate,
+                    visitedAt = yearEnd2024.atTime(12, 0),
+                )
             coEvery { timelineRepository.getMemoryCandidates() } returns
                 ResponseResult.Success(
                     dummyMemoryCandidates,
                 )
-            coEvery { staccatoRepository.getStaccato(TARGET_MEMORY_ID) } returns
+            coEvery { staccatoRepository.getStaccato(TARGET_STACCATO_ID) } returns
                 ResponseResult.Success(targetStaccato)
+
             viewModel.fetchTargetData(staccatoId = TARGET_STACCATO_ID)
+            advanceUntilIdle()
+
+            // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
+            val newLocalDate = yearEnd2023.atStartOfDay() // 수정 후 방문 날짜
+            viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
+
+            // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
+            val expectedMemories = listOf(newMemoryCandidate)
+            val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
+
+            val expectedMemory = newMemoryCandidate
+            val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
+
+            Assert.assertEquals(expectedMemories, actualMemories)
+            Assert.assertEquals(expectedMemory, actualMemory)
         }
-
-        // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
-        val newLocalDate = yearEnd2023.atStartOfDay()
-        viewModel.setMemoryCandidateByVisitedAt(newLocalDate)
-
-        // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
-        val expectedMemories = listOf(newMemoryCandidate)
-        val actualMemories = viewModel.selectableMemories.getOrAwaitValue()
-
-        val expectedMemory = newMemoryCandidate
-        val actualMemory = viewModel.selectedMemory.getOrAwaitValue()
-
-        Assert.assertEquals(expectedMemories, actualMemories)
-        Assert.assertEquals(expectedMemory, actualMemory)
-    }
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -3,7 +3,6 @@ package com.on.staccato.presentation.staccatoupdate.viewmodel
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import com.on.staccato.data.ResponseResult
 import com.on.staccato.data.image.ImageDefaultRepository
-import com.on.staccato.domain.model.TARGET_MEMORY_ID
 import com.on.staccato.domain.model.TARGET_STACCATO_ID
 import com.on.staccato.domain.model.dummyMemoryCandidates
 import com.on.staccato.domain.model.makeTestStaccato

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -98,7 +98,7 @@ class StaccatoUpdateViewModelTest {
 
             // when : 현재 선택된 카테고리 범위 밖의 날짜로 바뀌면
             val newLocalDate = endDateOf2023.atStartOfDay() // 수정 후 방문 날짜
-            viewModel.setMemoryCandidateBy(newLocalDate)
+            viewModel.updateMemorySelectionBy(newLocalDate)
 
             // then : 바뀐 날짜 기준으로 유효한 값을 업데이트한다
             val expectedSelectableMemories = MemoryCandidates.from(memoryCandidateWithId1)

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ converterScalars = "2.9.0"
 dotsindicator = "5.0"
 hiltAndroid = "2.51.1"
 archTestingVersion = "2.2.0"
+junitparams = "1.1.0"
 kotlin = "1.9.0"
 ktlint = "12.1.0"
 coreKtx = "1.13.1"
@@ -48,6 +49,7 @@ dotsindicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dotsindi
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+junitparams = { module = "pl.pragmatists:JUnitParams",version.ref = "junitparams" }
 androidx-arch-core = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTestingVersion" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ agp = "8.3.0"
 converterScalars = "2.9.0"
 dotsindicator = "5.0"
 hiltAndroid = "2.51.1"
+archTestingVersion = "2.2.0"
 kotlin = "1.9.0"
 ktlint = "12.1.0"
 coreKtx = "1.13.1"
@@ -20,6 +21,7 @@ playServicesLocation = "21.3.0"
 retrofit = "2.11.0"
 retrofit-serialization-converter = "1.0.0"
 kotlinx-serialization-json = "1.6.3"
+kotlinx-coroutines-test = "1.8.1"
 okhttp-logging-interceptor = "4.12.0"
 mockk = "1.13.11"
 lifecycle = "2.8.3"
@@ -46,6 +48,7 @@ dotsindicator = { module = "com.tbuonomo:dotsindicator", version.ref = "dotsindi
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hiltAndroid" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hiltAndroid" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
+androidx-arch-core = { group = "androidx.arch.core", name = "core-testing", version.ref = "archTestingVersion" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
@@ -60,6 +63,7 @@ play-services-location = { module = "com.google.android.gms:play-services-locati
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-serialization-converter" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -62,7 +62,8 @@ retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = 
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
-mockk-agent = { group = "io.mockk", name = "mockk-agent", version.ref = "mockk" }
+mockk-agent = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 lifecycle-livedata = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }


### PR DESCRIPTION
## ⭐️ Issue Number
- #564 

## 🚩 Summary
스타카토 생성/수정 화면의 카테고리, 일시 관련 로직에 아래의 작업들을 수행했습니다.
- [x] 카테고리, 일시 선택 순서 변경
- [x] 카테고리, 일시 선택 코드 리팩터링
- [x] 카테고리, 일시 선택 로직 테스트 추가

### 리팩터링 내용 정리
#### 생성 화면

1. `fetchMemoryCandidates()`로 사용자의 모든 추억을 불러와 `_memoryCandidates`를 업데이트 합니다.
2. 이 때 `_memoryCandidates`는 최초 한 번 업데이트된 후엔 변하지 않습니다.
3. `memoryCandidates.observe` 람다에서 `initMemoryAndVisitedAt()`를 수행하여 일시, 추억의 초기값을 세팅합니다.
    1. 메인 화면에서 생성 (memoryId == 0L)
        - **일시** 먼저 초기화 → `LocalDateTime.now()` (선택 가능한 일시 범위는 selectedVisitedAt ±10년)
        - 일시를 기준으로 **추억**을 초기화 → `updateMemoryCandidateAndVisitedAt()`
        - 일시가 바뀌면 추억을 다시 세팅
    2. 추억 화면에서 생성 (memoryId를 알고 있는 경우)
        - **추억** 먼저 초기화 → memoryId가 일치하는 추억으로 고정
        - 추억을 기준으로 **일시**를 초기화 → 추억 기간 안에서 'LocalDate.now()'와 가장 인접한 날짜 선택 (`MemoryCandidate`의 `getClosestDateTime()` 참고)
        - 선택 가능한 일시 범위는 추억 기간으로 세팅

#### 수정 화면
1. 사용자의 모든 추억을 불러옵니다. (`fetchMemoryCandidates()`)
2. 수정 대상인 스타카토의 정보를 불러옵니다. (`fetchStaccatoBy()`)
3. 불러온 스타카토 정보로 추억, 일시를 초기화 합니다.
4. 일시가 바뀌면 추억을 다시 세팅합니다.

## 🛠️ Technical Concerns

### 스타카토 생성/수정 ViewModel 테스트

MVVM 구조의 뷰모델 내부 LiveData 값을 테스트하기 위해 아래 Rule을 설정하고 getOrAwaitValue를 추가했습니다.

```kotlin
    @get:Rule
    var instantTaskExecutorRule = InstantTaskExecutorRule()

    @get:Rule
    val mainDispatcherRule = MainDispatcherRule()
```

또한 mockK의 coEvery와 coroutines.test의 runTest를 사용했습니다.

## 🙂 To Reviewer