### PR TITLE
refactor: 스타카토 양방향 연관관계 끊기 #547

### DIFF
--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -21,6 +21,7 @@ import com.staccato.memory.service.dto.response.MemoryNameResponses;
 import com.staccato.memory.service.dto.response.MemoryResponses;
 import com.staccato.memory.service.dto.response.MomentResponse;
 import com.staccato.moment.domain.Moment;
+import com.staccato.moment.domain.MomentImage;
 import com.staccato.moment.repository.MomentImageRepository;
 import com.staccato.moment.repository.MomentRepository;
 import lombok.RequiredArgsConstructor;
@@ -85,10 +86,9 @@ public class MemoryService {
     }
 
     private String getMomentThumbnail(Moment moment) {
-        if (moment.hasImage()) {
-            return moment.getThumbnailUrl();
-        }
-        return null;
+        return momentImageRepository.findFirstByMomentIdOrderByIdAsc(moment.getId())
+                .map(MomentImage::getImageUrl)
+                .orElse(null);
     }
 
     @Transactional

--- a/backend/src/main/java/com/staccato/moment/domain/Moment.java
+++ b/backend/src/main/java/com/staccato/moment/domain/Moment.java
@@ -43,8 +43,6 @@ public class Moment extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memory_id", nullable = false)
     private Memory memory;
-    @Embedded
-    private MomentImages momentImages = new MomentImages();
 
     @Builder
     public Moment(
@@ -54,14 +52,12 @@ public class Moment extends BaseEntity {
             @NonNull String address,
             @NonNull BigDecimal latitude,
             @NonNull BigDecimal longitude,
-            @NonNull MomentImages momentImages,
             @NonNull Memory memory
     ) {
         validateIsWithinMemoryDuration(visitedAt, memory);
         this.visitedAt = visitedAt.truncatedTo(ChronoUnit.SECONDS);
         this.title = title.trim();
         this.spot = new Spot(placeName, address, latitude, longitude);
-        this.momentImages.addAll(momentImages, this);
         this.memory = memory;
     }
 
@@ -71,25 +67,11 @@ public class Moment extends BaseEntity {
         }
     }
 
-    public void update(String title, MomentImages newMomentImages) {
-        this.title = title;
-        this.momentImages.update(newMomentImages, this);
-    }
-
     public void update(Moment updatedMoment) {
         this.visitedAt = updatedMoment.getVisitedAt();
         this.title = updatedMoment.getTitle();
         this.spot = updatedMoment.getSpot();
-        this.momentImages.update(updatedMoment.momentImages, this);
         this.memory = updatedMoment.getMemory();
-    }
-
-    public String getThumbnailUrl() {
-        return momentImages.getImages().get(0).getImageUrl();
-    }
-
-    public boolean hasImage() {
-        return momentImages.isNotEmpty();
     }
 
     public void changeFeeling(Feeling feeling) {

--- a/backend/src/main/java/com/staccato/moment/domain/MomentImage.java
+++ b/backend/src/main/java/com/staccato/moment/domain/MomentImage.java
@@ -9,7 +9,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,12 +27,10 @@ public class MomentImage {
     @JoinColumn(name = "moment_id", nullable = false)
     private Moment moment;
 
-    @Builder
-    public MomentImage(@Nonnull String imageUrl) {
-        this.imageUrl = imageUrl;
-    }
 
-    protected void belongTo(Moment moment) {
+    @Builder
+    public MomentImage(@Nonnull String imageUrl, Moment moment) {
+        this.imageUrl = imageUrl;
         this.moment = moment;
     }
 }

--- a/backend/src/main/java/com/staccato/moment/domain/MomentImages.java
+++ b/backend/src/main/java/com/staccato/moment/domain/MomentImages.java
@@ -1,53 +1,42 @@
 package com.staccato.moment.domain;
 
-import java.util.ArrayList;
 import java.util.List;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Embeddable;
-import jakarta.persistence.OneToMany;
 import com.staccato.exception.StaccatoException;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Embeddable
-@Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MomentImages {
+public record MomentImages(List<MomentImage> images) {
     private static final int MAX_COUNT = 5;
-    @OneToMany(mappedBy = "moment", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MomentImage> images = new ArrayList<>();
 
-    public MomentImages(List<String> addedImages) {
-        validateNumberOfImages(addedImages);
-        this.images.addAll(addedImages.stream()
-                .map(MomentImage::new)
-                .toList());
+    public MomentImages {
+        validateNumberOfImages(images);
     }
 
-    private void validateNumberOfImages(List<String> addedImages) {
+    public static MomentImages of(List<String> imageUrls, Moment moment) {
+        List<MomentImage> images = imageUrls.stream()
+                .map(imageUrl -> new MomentImage(imageUrl, moment))
+                .toList();
+        return new MomentImages(images);
+    }
+
+    private <T> void validateNumberOfImages(List<T> addedImages) {
         if (addedImages.size() > MAX_COUNT) {
             throw new StaccatoException("사진은 5장을 초과할 수 없습니다.");
         }
     }
 
-    protected void addAll(MomentImages newMomentImages, Moment moment) {
-        newMomentImages.images.forEach(image -> {
-            this.images.add(image);
-            image.belongTo(moment);
-        });
+    public List<MomentImage> findValuesNotPresentIn(MomentImages targetMomentImages) {
+        return this.images.stream()
+                .filter(image -> !targetMomentImages.contains(image))
+                .toList();
     }
 
-    protected void update(MomentImages momentImages, Moment moment) {
-        removeExistsImages(new ArrayList<>(images));
-        addAll(momentImages, moment);
+    private boolean contains(MomentImage momentImage) {
+        return this.images.stream()
+                .anyMatch(image -> image.getImageUrl().equals(momentImage.getImageUrl()));
     }
 
-    private void removeExistsImages(List<MomentImage> originalImages) {
-        originalImages.forEach(this.images::remove);
-    }
-
-    public boolean isNotEmpty() {
-        return !images.isEmpty();
+    public List<String> getUrls() {
+        return images.stream()
+                .map(MomentImage::getImageUrl)
+                .toList();
     }
 }

--- a/backend/src/main/java/com/staccato/moment/repository/MomentImageRepository.java
+++ b/backend/src/main/java/com/staccato/moment/repository/MomentImageRepository.java
@@ -9,9 +9,15 @@ import org.springframework.data.repository.query.Param;
 import com.staccato.moment.domain.MomentImage;
 
 public interface MomentImageRepository extends JpaRepository<MomentImage, Long> {
-    Optional<MomentImage> findFirstByMomentId(long momentId);
-
     @Modifying
     @Query("DELETE FROM MomentImage mi WHERE mi.moment.id In :momentIds")
     void deleteAllByMomentIdInBatch(@Param("momentIds") List<Long> momentIds);
+
+    @Modifying
+    @Query("DELETE FROM MomentImage mi WHERE mi.id In :ids")
+    void deleteAllByIdInBatch(@Param("ids") List<Long> ids);
+
+    List<MomentImage> findAllByMomentId(long momentId);
+
+    Optional<MomentImage> findFirstByMomentIdOrderByIdAsc(long momentId);
 }

--- a/backend/src/main/java/com/staccato/moment/service/dto/request/MomentRequest.java
+++ b/backend/src/main/java/com/staccato/moment/service/dto/request/MomentRequest.java
@@ -4,18 +4,14 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import org.springframework.format.annotation.DateTimeFormat;
-
 import com.staccato.memory.domain.Memory;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.domain.MomentImages;
-
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -65,7 +61,10 @@ public record MomentRequest(
                 .longitude(longitude)
                 .address(address)
                 .memory(memory)
-                .momentImages(new MomentImages(momentImageUrls))
                 .build();
+    }
+
+    public MomentImages toMomentImages(Moment moment) {
+        return MomentImages.of(momentImageUrls, moment);
     }
 }

--- a/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
+++ b/backend/src/main/java/com/staccato/moment/service/dto/response/MomentDetailResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.moment.domain.Moment;
-import com.staccato.moment.domain.MomentImage;
+import com.staccato.moment.domain.MomentImages;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -41,7 +41,7 @@ public record MomentDetailResponse(
         @Schema(example = "-0.12712788587027796")
         BigDecimal longitude
 ) {
-    public MomentDetailResponse(Moment moment) {
+    public MomentDetailResponse(Moment moment, MomentImages momentImages) {
         this(
                 moment.getId(),
                 moment.getMemory().getId(),
@@ -49,7 +49,7 @@ public record MomentDetailResponse(
                 moment.getMemory().getTerm().getStartAt(),
                 moment.getMemory().getTerm().getEndAt(),
                 moment.getTitle(),
-                moment.getMomentImages().getImages().stream().map(MomentImage::getImageUrl).toList(),
+                momentImages.getUrls(),
                 moment.getVisitedAt(),
                 moment.getFeeling().getValue(),
                 moment.getSpot().getPlaceName(),

--- a/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/moment/MomentFixture.java
@@ -2,10 +2,8 @@ package com.staccato.fixture.moment;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.List;
 import com.staccato.memory.domain.Memory;
 import com.staccato.moment.domain.Moment;
-import com.staccato.moment.domain.MomentImages;
 
 public class MomentFixture {
     private static final BigDecimal latitude = new BigDecimal("37.77490000000000");
@@ -20,7 +18,6 @@ public class MomentFixture {
                 .address("address")
                 .placeName("placeName")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
                 .build();
     }
 
@@ -33,20 +30,6 @@ public class MomentFixture {
                 .placeName("placeName")
                 .address("address")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
-                .build();
-    }
-
-    public static Moment createWithImages(Memory memory, LocalDateTime visitedAt, MomentImages momentImages) {
-        return Moment.builder()
-                .visitedAt(visitedAt)
-                .title("staccatoTitle")
-                .latitude(latitude)
-                .longitude(longitude)
-                .placeName("placeName")
-                .address("address")
-                .memory(memory)
-                .momentImages(momentImages)
                 .build();
     }
 }

--- a/backend/src/test/java/com/staccato/moment/domain/MomentTest.java
+++ b/backend/src/test/java/com/staccato/moment/domain/MomentTest.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,7 +37,6 @@ class MomentTest {
                 .longitude(BigDecimal.ONE)
                 .address("address")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
                 .build()).doesNotThrowAnyException();
     }
 
@@ -59,7 +57,6 @@ class MomentTest {
                 .longitude(BigDecimal.ONE)
                 .address("address")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
                 .build()).doesNotThrowAnyException();
     }
 
@@ -80,7 +77,6 @@ class MomentTest {
                 .placeName("placeName")
                 .address("address")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
                 .build();
 
         // then
@@ -107,7 +103,6 @@ class MomentTest {
                 .longitude(BigDecimal.ONE)
                 .address("address")
                 .memory(memory)
-                .momentImages(new MomentImages(List.of()))
                 .build()).isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("추억에 포함되지 않는 날짜입니다.");
     }

--- a/backend/src/test/java/com/staccato/moment/repository/MomentImageRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/moment/repository/MomentImageRepositoryTest.java
@@ -3,8 +3,7 @@ package com.staccato.moment.repository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +13,7 @@ import com.staccato.fixture.moment.MomentFixture;
 import com.staccato.memory.domain.Memory;
 import com.staccato.memory.repository.MemoryRepository;
 import com.staccato.moment.domain.Moment;
-import com.staccato.moment.domain.MomentImages;
+import com.staccato.moment.domain.MomentImage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -27,31 +26,82 @@ class MomentImageRepositoryTest {
     private MemoryRepository memoryRepository;
     @Autowired
     private MomentImageRepository momentImageRepository;
-    @PersistenceContext
-    private EntityManager em;
 
     @DisplayName("특정 스타카토의 id 여러개를 가지고 있는 모든 스타카토 이미지들을 삭제한다.")
     @Test
     void deleteAllByMomentIdInBatch() {
         // given
         Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
-        Moment moment1 = momentRepository.save(MomentFixture
-                .createWithImages(memory, LocalDateTime.of(2023, 12, 31, 22, 20), new MomentImages(List.of("url1", "url2"))));
-        Moment moment2 = momentRepository.save(MomentFixture
-                .createWithImages(memory, LocalDateTime.of(2023, 12, 31, 22, 20), new MomentImages(List.of("url1", "url2"))));
+        Moment moment1 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+        Moment moment2 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+        List<MomentImage> momentImages1 = List.of(new MomentImage("url1", moment1), new MomentImage("url2", moment1));
+        List<MomentImage> momentImages2 = List.of(new MomentImage("url1", moment2), new MomentImage("url2", moment2));
+        momentImageRepository.saveAll(momentImages1);
+        momentImageRepository.saveAll(momentImages2);
 
         // when
         momentImageRepository.deleteAllByMomentIdInBatch(List.of(moment1.getId(), moment2.getId()));
-        em.flush();
-        em.clear();
 
         // then
         assertAll(
                 () -> assertThat(momentImageRepository.findAll()).isEqualTo(List.of()),
-                () -> assertThat(momentRepository.findById(moment1.getId()).get().getMomentImages()
-                        .isNotEmpty()).isFalse(),
-                () -> assertThat(momentRepository.findById(moment2.getId()).get().getMomentImages()
-                        .isNotEmpty()).isFalse()
+                () -> assertThat(momentImageRepository.findAllByMomentId(moment1.getId()).size()).isEqualTo(0),
+                () -> assertThat(momentImageRepository.findAllByMomentId(moment2.getId()).size()).isEqualTo(0)
         );
+    }
+
+    @DisplayName("특정 스타카토 이미지들을 배치 삭제한다.")
+    @Test
+    void deleteAllByIdInBatch() {
+        // given
+        Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
+        Moment moment = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+
+        MomentImage momentImage1 = new MomentImage("url1", moment);
+        MomentImage momentImage2 = new MomentImage("url2", moment);
+        MomentImage momentImage3 = new MomentImage("url3", moment);
+        momentImageRepository.saveAll(List.of(momentImage1, momentImage2, momentImage3));
+
+        // when
+        momentImageRepository.deleteAllByIdInBatch(List.of(momentImage1.getId(), momentImage2.getId(), momentImage3.getId()));
+
+        // then
+        assertThat(momentImageRepository.findAll()).isEmpty();
+    }
+
+    @DisplayName("특정 스타카토의 모든 스타카토 이미지를 조회한다.")
+    @Test
+    void findAllByMomentId() {
+        // given
+        Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
+        Moment moment = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+
+        List<MomentImage> momentImages = List.of(new MomentImage("url1", moment), new MomentImage("url2", moment), new MomentImage("url3", moment));
+        momentImageRepository.saveAll(momentImages);
+
+        // when
+        List<MomentImage> retrievedImages = momentImageRepository.findAllByMomentId(moment.getId());
+
+        // then
+        assertThat(retrievedImages).hasSize(3)
+                .extracting(MomentImage::getImageUrl)
+                .containsExactlyInAnyOrder("url1", "url2", "url3");
+    }
+
+    @DisplayName("특정 스타카토의 이미지 중 가장 작은 ID 값을 가진 이미지를 조회한다.")
+    @Test
+    void findFirstByMomentIdOrderByIdAsc() {
+        // given
+        Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
+        Moment moment = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+
+        List<MomentImage> momentImages = List.of(new MomentImage("url1", moment), new MomentImage("url2", moment), new MomentImage("url3", moment));
+        momentImageRepository.saveAll(momentImages);
+
+        // when
+        Optional<MomentImage> image = momentImageRepository.findFirstByMomentIdOrderByIdAsc(moment.getId());
+
+        // then
+        assertThat(image.get().getImageUrl()).isEqualTo("url1");
     }
 }

--- a/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/moment/repository/MomentRepositoryTest.java
@@ -19,7 +19,7 @@ import com.staccato.memory.domain.MemoryMember;
 import com.staccato.memory.repository.MemoryMemberRepository;
 import com.staccato.memory.repository.MemoryRepository;
 import com.staccato.moment.domain.Moment;
-import com.staccato.moment.domain.MomentImages;
+import com.staccato.moment.domain.MomentImage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -34,6 +34,8 @@ class MomentRepositoryTest {
     private MemoryRepository memoryRepository;
     @Autowired
     private MemoryMemberRepository memoryMemberRepository;
+    @Autowired
+    private MomentImageRepository momentImageRepository;
     @PersistenceContext
     private EntityManager entityManager;
 
@@ -102,9 +104,14 @@ class MomentRepositoryTest {
         Memory memory = memoryRepository.save(MemoryFixture.create(LocalDate.of(2023, 12, 31), LocalDate.of(2024, 1, 10)));
         memoryMemberRepository.save(new MemoryMember(member, memory));
 
-        Moment moment1 = momentRepository.save(MomentFixture.createWithImages(memory, LocalDateTime.of(2023, 12, 31, 22, 20), new MomentImages(List.of("image1", "image2"))));
-        Moment moment2 = momentRepository.save(MomentFixture.createWithImages(memory, LocalDateTime.of(2024, 1, 1, 22, 20), new MomentImages(List.of("image1", "image2"))));
+        Moment moment1 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2023, 12, 31, 22, 20)));
+        Moment moment2 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2024, 1, 1, 22, 20)));
         Moment moment3 = momentRepository.save(MomentFixture.create(memory, LocalDateTime.of(2024, 1, 10, 23, 21)));
+
+        List<MomentImage> momentImages1 = List.of(new MomentImage("url1", moment1), new MomentImage("url2", moment1));
+        List<MomentImage> momentImages2 = List.of(new MomentImage("url1", moment2), new MomentImage("url2", moment2));
+        momentImageRepository.saveAll(momentImages1);
+        momentImageRepository.saveAll(momentImages2);
 
         // when
         List<Moment> moments = momentRepository.findAllByMemoryIdOrdered(memory.getId());


### PR DESCRIPTION
## ⭐️ Issue Number
- #547 

## 🚩 Summary
**기존에 Moment와 MomentImage의 양방향 연관관계를 끊음**

- `Moment`와 `MomentImage`의 양방향 연관관계를 끊음으로써 부모 엔티티에서 자식 엔티티의 생성을 관리했던 로직이 `Service`에 위치하게 되었습니다.
  ![service](https://github.com/user-attachments/assets/a864ef2d-5259-4e70-825c-2530aadc99c2)

- 그로인해 MomentImageRepository에 쿼리 메서드와 BulkDelete(JPQL Query)가 추가되었습니다.

- Moment 단위테스트를 실행할 때 MomentImage에 관한 설정사항이 제외되었습니다.
  ![test](https://github.com/user-attachments/assets/651cd78c-30ba-4200-9038-ebde88ce2b47)

양방향 연관관계를 끊는것의 목적은 아래 2가지가 존재하였습니다.
- Cascade 설정과 양방향 연관관계에서 발생하는 연관관계 주인 설정 문제, 엔티티 상태 동기화 문제(양쪽 필드 갱신), 직렬화 시 순환 참조 등의 다양한 이슈를 피하기 위해
- 단방향 관계나 최소한의 관계 매핑만 유지하게 되어, 도메인 모델의 단순화와 유지보수성 향상에 기여하기 위해


---
## 현재 PR에는 BulkInsert관련 커밋은 올라가있지 않은 상태입니다. 의견 나눈 후 적용할지 정하려고 합니다!

---

### 추가로 양방향 연관관계를 끊는 것에서 더 나아가 
기존에는 영속 전이 상태를 통해 아래와 같이 새롭게 들어온 `MomentImage`에 대해 각 객체 별 `Insert` 쿼리가 하나씩 나가는 문제가 있었습니다.
![insert](https://github.com/user-attachments/assets/60cd7a2d-51bf-4aa6-bfae-48878ad0a86c)

이를 `BulkInsert`로 해결하고자 하였고,
저희는 현재 기본키 생성 전략중 IDENTITY 전략을 사용하고 있는 상태입니다. 
영속성 컨텍스트 내부에 엔티티를 식별할때 엔티티 타입과 PK값으로 식별하지만, IDENTITY전략의 경우 DB에 **`Insert`** 한 후 PK 확인이 가능하기 때문에 Hibernate는 insert batching을 지원하지 않는 상태였습니다.
- `jdbc` or `Native SQL`을 이용해야 하는 상황 
  - `Native SQL`은 모든 디비에 반영이 될 수 없기에 지양

[참고자료](https://docs.jboss.org/hibernate/orm/4.1/manual/en-US/html/ch15.html)


따라서 새롭게 JdbcTemplate을 통해 `BatchUpdate`하는 방향으로 구성해 보았습니다.
![bulkinsertcode](https://github.com/user-attachments/assets/5b48351c-f2de-4c85-a1e9-6d670d94c2fa)

**BulkInsert 로그**
![bulkinsert](https://github.com/user-attachments/assets/8d590877-f852-4a0d-8fe7-4d92495ed5a1)


## 🛠️ Technical Concerns

### BulkInsert가 정말 필요한가?
저희의 IDENTITY 전략에서는 jdbcTemplate을 통해 새롭게 BulkInsert하는 과정이 필요했습니다.
이를 위해서 새롭게 `BulkInsert` 전용 클래스가 필요해졌고, 그로 인해 아래와 같은 다이어그램 형식이 되었습니다.
![qeurydiagram](https://github.com/user-attachments/assets/9dad0bc0-942a-4b97-8b6e-9b603ec72398)

- 저희는 아무리 많아도 한번에 최대 5개의 이미지만을 저장할 수 있기에, 하나의 요청당 최대(이미지 5개 저장)로 줄일 수 있는 쿼리는 4개(기존 5개 나가던 쿼리를 1개로)로 제한됩니다. -> 성능상 이점 미미
- 1차캐시를 이용하지 못하기에 아래와 같이 Entity의 id를 가지고 오고 싶다면 다시 DB를 조회해야 하는 문제가 있습니다 -> 번거롭고, 휴먼에러 가능성 높아짐

> 저장된 Entity의 id를 바로 조회하게 된다면 NullPointerException이 발생하게 된다.
![bulkinsert_d](https://github.com/user-attachments/assets/0d47d02d-1d8a-45c2-8731-22274f7df53c)

> id값을 직접 넣어준다면 테스트 통과
![bulkinsert-dd](https://github.com/user-attachments/assets/fe814d85-1608-450b-b994-bb57a1d43867)

**BulkInsert의 도입이 정말 필요할까 얘기 나눠보고 싶습니다!**

## 🙂 To Reviewer
- [x] @linirini 
- [ ] @BurningFalls 

## 📋 To Do
- BulkInsert를 도입할것인지 아닐지 결정하기!
