### PR TITLE
fix: 사진 첨부를 길게 터치할 시 액티비티가 종료되는 버그 (스타카토 생성/수정 화면) #588

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/StaccatoCreationActivity.kt
@@ -15,7 +15,6 @@ import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -34,7 +33,6 @@ import com.on.staccato.presentation.main.viewmodel.SharedViewModel
 import com.on.staccato.presentation.memory.MemoryFragment.Companion.MEMORY_ID_KEY
 import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.STACCATO_ID_KEY
 import com.on.staccato.presentation.staccatocreation.adapter.AttachedPhotoItemTouchHelperCallback
-import com.on.staccato.presentation.staccatocreation.adapter.ItemDragListener
 import com.on.staccato.presentation.staccatocreation.adapter.PhotoAttachAdapter
 import com.on.staccato.presentation.staccatocreation.dialog.MemorySelectionFragment
 import com.on.staccato.presentation.staccatocreation.dialog.VisitedAtSelectionFragment
@@ -241,18 +239,7 @@ class StaccatoCreationActivity :
 
     private fun initAdapter() {
         photoAttachAdapter =
-            PhotoAttachAdapter(
-                object : ItemDragListener {
-                    override fun onStartDrag(viewHolder: RecyclerView.ViewHolder) {
-                        itemTouchHelper.startDrag(viewHolder)
-                    }
-
-                    override fun onStopDrag(list: List<AttachedPhotoUiModel>) {
-                        viewModel.setUrisWithNewOrder(list)
-                    }
-                },
-                viewModel,
-            )
+            PhotoAttachAdapter(viewModel) { viewModel.setUrisWithNewOrder(it) }
         binding.rvPhotoAttach.adapter = photoAttachAdapter
     }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -47,8 +47,8 @@ class AttachedPhotoItemTouchHelperCallback(
         super.onSelectedChanged(viewHolder, actionState)
         when (actionState) {
             ItemTouchHelper.ACTION_STATE_DRAG -> {
-                if (viewHolder != null) {
-                    (viewHolder as PhotoAttachViewHolder.AttachedPhotoViewHolder).startMoving()
+                if (viewHolder is PhotoAttachViewHolder.AttachedPhotoViewHolder) {
+                    viewHolder.startMoving()
                 }
             }
 
@@ -62,7 +62,9 @@ class AttachedPhotoItemTouchHelperCallback(
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder,
     ) {
-        (viewHolder as PhotoAttachViewHolder.AttachedPhotoViewHolder).stopMoving()
+        if (viewHolder is PhotoAttachViewHolder.AttachedPhotoViewHolder) {
+            viewHolder.stopMoving()
+        }
     }
 
     override fun onSwiped(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -14,10 +14,14 @@ class AttachedPhotoItemTouchHelperCallback(
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder,
     ): Int {
-        return makeFlag(
-            ItemTouchHelper.ACTION_STATE_DRAG,
-            ItemTouchHelper.DOWN or ItemTouchHelper.UP or ItemTouchHelper.START or ItemTouchHelper.END,
-        )
+        return if (viewHolder is PhotoAttachViewHolder.AttachedPhotoViewHolder) {
+            makeFlag(
+                ItemTouchHelper.ACTION_STATE_DRAG,
+                ItemTouchHelper.DOWN or ItemTouchHelper.UP or ItemTouchHelper.START or ItemTouchHelper.END,
+            )
+        } else {
+            ItemTouchHelper.ACTION_STATE_IDLE
+        }
     }
 
     override fun onMove(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -44,7 +44,6 @@ class AttachedPhotoItemTouchHelperCallback(
         viewHolder: RecyclerView.ViewHolder?,
         actionState: Int,
     ) {
-        super.onSelectedChanged(viewHolder, actionState)
         when (actionState) {
             ItemTouchHelper.ACTION_STATE_DRAG -> {
                 if (viewHolder is PhotoAttachViewHolder.AttachedPhotoViewHolder) {
@@ -56,6 +55,7 @@ class AttachedPhotoItemTouchHelperCallback(
                 moveListener.onStopDrag()
             }
         }
+        super.onSelectedChanged(viewHolder, actionState)
     }
 
     override fun clearView(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/AttachedPhotoItemTouchHelperCallback.kt
@@ -6,10 +6,6 @@ import androidx.recyclerview.widget.RecyclerView
 class AttachedPhotoItemTouchHelperCallback(
     private val moveListener: ItemMoveListener,
 ) : ItemTouchHelper.Callback() {
-    override fun isLongPressDragEnabled(): Boolean {
-        return true
-    }
-
     override fun getMovementFlags(
         recyclerView: RecyclerView,
         viewHolder: RecyclerView.ViewHolder,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/ItemDragListener.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/ItemDragListener.kt
@@ -1,10 +1,7 @@
 package com.on.staccato.presentation.staccatocreation.adapter
 
-import androidx.recyclerview.widget.RecyclerView
 import com.on.staccato.presentation.staccatocreation.model.AttachedPhotoUiModel
 
-interface ItemDragListener {
-    fun onStartDrag(viewHolder: RecyclerView.ViewHolder)
-
+fun interface ItemDragListener {
     fun onStopDrag(list: List<AttachedPhotoUiModel>)
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/PhotoAttachAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/adapter/PhotoAttachAdapter.kt
@@ -10,8 +10,8 @@ import com.on.staccato.presentation.common.AttachedPhotoHandler
 import com.on.staccato.presentation.staccatocreation.model.AttachedPhotoUiModel
 
 class PhotoAttachAdapter(
-    private val dragListener: ItemDragListener,
     private val attachedPhotoHandler: AttachedPhotoHandler,
+    private val dragListener: ItemDragListener,
 ) :
     ItemMoveListener, ListAdapter<AttachedPhotoUiModel, PhotoAttachViewHolder>(diffUtil) {
     init {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/StaccatoUpdateActivity.kt
@@ -15,7 +15,6 @@ import androidx.annotation.RequiresApi
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.ItemTouchHelper
-import androidx.recyclerview.widget.RecyclerView
 import com.google.android.gms.location.FusedLocationProviderClient
 import com.google.android.gms.location.LocationServices
 import com.google.android.gms.location.Priority
@@ -37,7 +36,6 @@ import com.on.staccato.presentation.staccato.StaccatoFragment.Companion.STACCATO
 import com.on.staccato.presentation.staccatocreation.CurrentLocationHandler
 import com.on.staccato.presentation.staccatocreation.OnUrisSelectedListener
 import com.on.staccato.presentation.staccatocreation.adapter.AttachedPhotoItemTouchHelperCallback
-import com.on.staccato.presentation.staccatocreation.adapter.ItemDragListener
 import com.on.staccato.presentation.staccatocreation.adapter.PhotoAttachAdapter
 import com.on.staccato.presentation.staccatocreation.dialog.MemorySelectionFragment
 import com.on.staccato.presentation.staccatocreation.dialog.VisitedAtSelectionFragment
@@ -236,18 +234,7 @@ class StaccatoUpdateActivity :
 
     private fun initAdapter() {
         photoAttachAdapter =
-            PhotoAttachAdapter(
-                object : ItemDragListener {
-                    override fun onStartDrag(viewHolder: RecyclerView.ViewHolder) {
-                        itemTouchHelper.startDrag(viewHolder)
-                    }
-
-                    override fun onStopDrag(list: List<AttachedPhotoUiModel>) {
-                        viewModel.setUrisWithNewOrder(list)
-                    }
-                },
-                viewModel,
-            )
+            PhotoAttachAdapter(viewModel) { viewModel.setUrisWithNewOrder(it) }
         binding.rvPhotoAttach.adapter = photoAttachAdapter
     }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #588 

## 🚩 Summary

출시하고 2달 동안 그 누구도 알아채지 못한 버그..
이스터 에그라고 우기고 싶은 버그..
를 발견해서 후딱 고쳐보았습니다.

<img width="287" alt="image" src="https://github.com/user-attachments/assets/a257f74e-abd0-4d69-ae88-f2faa81d2d83" />

위 사진에서 동그라미 친 버튼을 꾹 누르면 액티비티가 종료됩니다.

### 원인

AttachedPhotoItemTouchHelperCallback 클래스에서 타입 캐스팅 예외가 일어나고 있습니다.

```
java.lang.ClassCastException: com.on.staccato.presentation.staccatocreation.adapter.PhotoAttachViewHolder$AddPhotoViewHolder
cannot be cast to
com.on.staccato.presentation.staccatocreation.adapter.PhotoAttachViewHolder$AttachedPhotoViewHolder
```
```kotlin
// AttachedPhotoItemTouchHelperCallback.kt
    override fun onSelectedChanged(
        viewHolder: RecyclerView.ViewHolder?,
        actionState: Int,
    ) {
        super.onSelectedChanged(viewHolder, actionState)
        when (actionState) {
            ItemTouchHelper.ACTION_STATE_DRAG -> {
                if (viewHolder != null) {
                    (viewHolder as PhotoAttachViewHolder.AttachedPhotoViewHolder).startMoving() // -> 해당 라인에서 예외 발생 중
                }
            }

            ItemTouchHelper.ACTION_STATE_IDLE -> {
                moveListener.onStopDrag()
            }
        }
    }
```
터치 동작 시작 시 대상이 사진 첨부 버튼이면 getMovementFlags에서
0(ItemTouchHelper.ACTION_STATE_IDLE)을 반환하도록 수정했습니다.
또한 타입 캐스팅을 위한 `as`를 제거하고, `is`와 if문으로 대체하였습니다.