### PR TITLE
fix: 필터링 API 파싱 오류 수정 #604

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -1,9 +1,7 @@
 name: Backend CI/CD dev
 
 on:
-  push:
-    paths: [ 'backend/**', '.github/**' ]
-    branches: [ "develop-be", "develop" ]
+  workflow_dispatch:
 
 jobs:
   ci:

--- a/.github/workflows/backend-ci-cd-multi-dev.yml
+++ b/.github/workflows/backend-ci-cd-multi-dev.yml
@@ -1,4 +1,4 @@
-name: Backend CI/CD multi prod
+name: Backend CI/CD multi dev
 
 on:
   push:

--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -17,7 +17,7 @@ public record LoginRequest(
         String nickname
 ) {
     public LoginRequest {
-        if (!Objects.isNull(nickname)) {
+        if (Objects.nonNull(nickname)) {
             nickname = nickname.trim();
         }
     }

--- a/backend/src/main/java/com/staccato/memory/service/MemoryFilter.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryFilter.java
@@ -28,6 +28,7 @@ public enum MemoryFilter {
                 .map(name -> MemoryFilter.findByName(name.trim()))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
+                .distinct()
                 .toList();
     }
 

--- a/backend/src/main/java/com/staccato/memory/service/dto/request/MemoryReadRequest.java
+++ b/backend/src/main/java/com/staccato/memory/service/dto/request/MemoryReadRequest.java
@@ -2,6 +2,7 @@ package com.staccato.memory.service.dto.request;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import com.staccato.memory.service.MemoryFilter;
 import com.staccato.memory.service.MemorySort;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,10 +17,17 @@ public record MemoryReadRequest(
     private static final String DELIMITER = ",";
 
     public List<MemoryFilter> getFilters() {
-        List<String> filters = Arrays.stream(this.filters.split(DELIMITER))
+        List<String> filters = parseFilters().stream()
                 .map(String::trim)
                 .toList();
         return MemoryFilter.findAllByName(filters);
+    }
+
+    private List<String> parseFilters() {
+        if (Objects.nonNull(filters)) {
+            return Arrays.stream(filters.split(DELIMITER)).toList();
+        }
+        return List.of();
     }
 
     public MemorySort getSort() {

--- a/backend/src/main/java/com/staccato/memory/service/dto/request/MemoryReadRequest.java
+++ b/backend/src/main/java/com/staccato/memory/service/dto/request/MemoryReadRequest.java
@@ -24,10 +24,10 @@ public record MemoryReadRequest(
     }
 
     private List<String> parseFilters() {
-        if (Objects.nonNull(filters)) {
-            return Arrays.stream(filters.split(DELIMITER)).toList();
+        if (Objects.isNull(filters)) {
+            return List.of();
         }
-        return List.of();
+        return Arrays.stream(filters.split(DELIMITER)).toList();
     }
 
     public MemorySort getSort() {

--- a/backend/src/test/java/com/staccato/memory/service/MemoryFilterTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemoryFilterTest.java
@@ -36,11 +36,24 @@ class MemoryFilterTest extends ServiceSliceTest {
         );
     }
 
-    @DisplayName("필터링명이 주어졌을 때 유효한 MemoryFilter 목록 민 반환한다.")
+    @DisplayName("필터링명이 주어졌을 때 유효한 MemoryFilter 목록만 반환한다.")
     @Test
     void findAllByNameIfOnlyValid() {
         // when
         List<MemoryFilter> result = MemoryFilter.findAllByName(List.of("invalid", "term"));
+
+        // then
+        assertAll(
+                () -> assertThat(result).hasSize(1),
+                () -> assertThat(result.get(0)).isEqualTo(MemoryFilter.TERM)
+        );
+    }
+
+    @DisplayName("필터링명이 중복으로 주어졌을 때 중복 없이 MemoryFilter 목록을 반환한다.")
+    @Test
+    void findAllByNameDistinct() {
+        // when
+        List<MemoryFilter> result = MemoryFilter.findAllByName(List.of("TERM", "term"));
 
         // then
         assertAll(

--- a/backend/src/test/java/com/staccato/memory/service/MemorySortTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/MemorySortTest.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,13 +27,21 @@ public class MemorySortTest extends ServiceSliceTest {
     private MemoryRepository memoryRepository;
 
     @DisplayName("정렬명이 주어졌을 때 대소문자 구분 없이 MemorySort을 반환한다.")
-    @Test
-    void findByNameWithValidSort() {
+    @ParameterizedTest
+    @CsvSource({
+            "UPDATED, UPDATED",
+            "NEWEST, NEWEST",
+            "OLDEST, OLDEST",
+            "updated, UPDATED",
+            "newest, NEWEST",
+            "oldest, OLDEST"
+    })
+    void findByNameWithValidSort(String name, MemorySort sort) {
         // when
-        MemorySort result = MemorySort.findByName("newest");
+        MemorySort result = MemorySort.findByName(name);
 
         // then
-        assertThat(result).isEqualTo(MemorySort.NEWEST);
+        assertThat(result).isEqualTo(sort);
     }
 
     @DisplayName("유효하지 않거나 null인 정렬명이 주어졌을 때 기본값인 UPDATED를 반환한다.")

--- a/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
@@ -1,0 +1,54 @@
+package com.staccato.memory.service.dto.request;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import com.staccato.memory.service.MemoryFilter;
+import com.staccato.memory.service.MemorySort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemoryReadRequestTest {
+    @DisplayName("필터가 주어졌을 때 올바른 MemoryFilter 리스트를 반환한다")
+    @Test
+    void getFiltersWithValidFilters() {
+        // given
+        MemoryReadRequest request = new MemoryReadRequest("TERM, term", "NEWEST");
+
+        // when
+        List<MemoryFilter> filters = request.getFilters();
+
+        // then
+        assertThat(filters).hasSize(1).containsOnly(MemoryFilter.TERM);
+    }
+
+    @DisplayName("필터가 주어지지 않았을 때 빈 리스트를 반환한다")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getFiltersWithNullOrEmptyFilters(String filters) {
+        // given
+        MemoryReadRequest request = new MemoryReadRequest(filters, "NEWEST");
+
+        // when
+        List<MemoryFilter> result = request.getFilters();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @DisplayName("정렬이 주어지지 않았을 때 기본 정렬 기준을 반환한다")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void getSortWithNullOrEmptyFilters(String sort) {
+        // given
+        MemoryReadRequest request = new MemoryReadRequest(null, sort);
+
+        // when
+        MemorySort result = request.getSort();
+
+        // then
+        assertThat(result).isEqualTo(MemorySort.UPDATED);
+    }
+}

--- a/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
@@ -11,7 +11,7 @@ import com.staccato.memory.service.MemorySort;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MemoryReadRequestTest {
-    @DisplayName("필터가 주어졌을 때 올바른 MemoryFilter 리스트를 반환한다")
+    @DisplayName("필터가 주어졌을 때 올바른 필터 목록을 반환한다")
     @Test
     void getFiltersWithValidFilters() {
         // given
@@ -24,7 +24,7 @@ class MemoryReadRequestTest {
         assertThat(filters).hasSize(1).containsOnly(MemoryFilter.TERM);
     }
 
-    @DisplayName("필터가 주어지지 않았을 때 빈 리스트를 반환한다")
+    @DisplayName("필터가 주어지지 않았을 때 빈 목록을 반환한다")
     @ParameterizedTest
     @NullAndEmptySource
     void getFiltersWithNullOrEmptyFilters(String filters) {

--- a/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
+++ b/backend/src/test/java/com/staccato/memory/service/dto/request/MemoryReadRequestTest.java
@@ -24,7 +24,7 @@ class MemoryReadRequestTest {
         assertThat(filters).hasSize(1).containsOnly(MemoryFilter.TERM);
     }
 
-    @DisplayName("필터가 주어지지 않았을 때 빈 목록을 반환한다")
+    @DisplayName("필터가 주어지지 않았을 때 빈 필터 목록을 반환한다")
     @ParameterizedTest
     @NullAndEmptySource
     void getFiltersWithNullOrEmptyFilters(String filters) {


### PR DESCRIPTION
## ⭐️ Issue Number
- #546 
- #604 

## 🚩 Summary
![image](https://github.com/user-attachments/assets/6f7eed5e-3aca-45bc-a03e-b8ab91ccc66c)

- 필터링 API 에서 필터링 조건 없을 때 NPE에 대한 고려를 놓쳤습니다.
- 컨트롤러 단위 테스트와 도메인 단위 테스트로는 잡지 못했어요! dto 내부에 해당 로직이 있기 때문에 dto 단위 테스트가 필요하다고 생각해서 추가했습니다.
- 추가로, 같은 조건값이 들어왔을 때에는 한 번만 카운트 하도록 로직 추가했습니다.

- Dev 서버의 workflow가 2개가 있어서 하나는 비활성화했습니다~

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
