### PR TITLE
fix: 스타카토 조회 API 응답값 매핑 오류 수정 #606

### DIFF
--- a/backend/src/main/java/com/staccato/moment/controller/StaccatoDtoMapper.java
+++ b/backend/src/main/java/com/staccato/moment/controller/StaccatoDtoMapper.java
@@ -48,8 +48,8 @@ public class StaccatoDtoMapper {
 
     public static StaccatoDetailResponse toStaccatoDetailResponse(MomentDetailResponse momentDetailResponse) {
         return new StaccatoDetailResponse(
-                momentDetailResponse.memoryId(),
                 momentDetailResponse.momentId(),
+                momentDetailResponse.memoryId(),
                 momentDetailResponse.memoryTitle(),
                 momentDetailResponse.startAt(),
                 momentDetailResponse.endAt(),


### PR DESCRIPTION
## ⭐️ Issue Number
- #606 

## 🚩 Summary
- 스타카토 조회 API 응답의 스타카토 ID와 카테고리 ID 응답값 매핑이 잘못되어 있어 수정했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer
- StaccatoDtoMapper와 CategoryDtoMapper에 오류가 없는지 체크했습니다. 놓친 부분이 있을지도 모르니 더블 체크 부탁드립니다.
- @hxeyexn @s6m1n @Junyoung-WON 조만간 바뀔 코드라서 테스트가 따로 없습니다. 체크하긴 했지만, 도메인명이 바뀐 API (Category, Staccato)에서 문제가 있는 것 같다면 백엔드 파트도 콜해주세용!

## 📋 To Do
