### PR TITLE
fix: Comment API에서 도메인명 안바뀐 부분 수정 #609

### DIFF
--- a/backend/src/main/java/com/staccato/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/staccato/comment/controller/CommentController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.staccato.comment.controller.docs.CommentControllerDocs;
 import com.staccato.comment.service.CommentService;
 import com.staccato.comment.service.dto.request.CommentRequest;
+import com.staccato.comment.service.dto.request.CommentRequestV2;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 import com.staccato.comment.service.dto.response.CommentResponses;
 import com.staccato.config.auth.LoginMember;
@@ -42,12 +43,38 @@ public class CommentController implements CommentControllerDocs {
                 .build();
     }
 
+    @PostMapping("/v2")
+    public ResponseEntity<Void> createComment(
+            @LoginMember Member member,
+            @Valid @RequestBody CommentRequestV2 commentRequestV2
+    ) {
+        long commentId = commentService.createComment(toCommentRequest(commentRequestV2), member);
+        return ResponseEntity.created(URI.create("/comments/" + commentId))
+                .build();
+    }
+
+    private CommentRequest toCommentRequest(CommentRequestV2 commentRequestV2) {
+        return new CommentRequest(
+                commentRequestV2.staccatoId(),
+                commentRequestV2.content()
+        );
+    }
+
     @GetMapping
     public ResponseEntity<CommentResponses> readCommentsByMomentId(
             @LoginMember Member member,
             @RequestParam @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.") long momentId
     ) {
         CommentResponses commentResponses = commentService.readAllCommentsByMomentId(member, momentId);
+        return ResponseEntity.ok().body(commentResponses);
+    }
+
+    @GetMapping("/v2")
+    public ResponseEntity<CommentResponses> readCommentsByStaccatoId(
+            @LoginMember Member member,
+            @RequestParam @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.") long staccatoId
+    ) {
+        CommentResponses commentResponses = commentService.readAllCommentsByMomentId(member, staccatoId);
         return ResponseEntity.ok().body(commentResponses);
     }
 

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequestV2.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequestV2.java
@@ -1,0 +1,32 @@
+package com.staccato.comment.service.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import com.staccato.comment.domain.Comment;
+import com.staccato.member.domain.Member;
+import com.staccato.moment.domain.Moment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "댓글 생성 시 요청 형식입니다.")
+public record CommentRequestV2(
+        @Schema(example = "1")
+        @NotNull(message = "스타카토를 선택해주세요.")
+        @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.")
+        Long staccatoId,
+        @Schema(example = "예시 댓글 내용")
+        @NotBlank(message = "댓글 내용을 입력해주세요.")
+        @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
+        String content
+) {
+    public Comment toComment(Moment moment, Member member) {
+        return Comment.builder()
+                .content(content)
+                .moment(moment)
+                .member(member)
+                .build();
+    }
+}

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
@@ -1,0 +1,148 @@
+package com.staccato.comment.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import com.staccato.ControllerTest;
+import com.staccato.comment.service.dto.request.CommentRequestV2;
+import com.staccato.comment.service.dto.response.CommentResponse;
+import com.staccato.comment.service.dto.response.CommentResponses;
+import com.staccato.exception.ExceptionResponse;
+import com.staccato.fixture.Member.MemberFixture;
+
+public class CommentControllerV2Test extends ControllerTest {
+    private static final int MAX_CONTENT_LENGTH = 500;
+    private static final long MIN_STACCATO_ID = 1L;
+
+    static Stream<Arguments> invalidCommentCreateRequestProvider() {
+        return Stream.of(
+                Arguments.of(
+                        new CommentRequestV2(null, "예시 댓글 내용"),
+                        "스타카토를 선택해주세요."
+                ),
+                Arguments.of(
+                        new CommentRequestV2(MIN_STACCATO_ID - 1, "예시 댓글 내용"),
+                        "스타카토 식별자는 양수로 이루어져야 합니다."
+                ),
+                Arguments.of(
+                        new CommentRequestV2(MIN_STACCATO_ID, null),
+                        "댓글 내용을 입력해주세요."
+                ),
+                Arguments.of(
+                        new CommentRequestV2(MIN_STACCATO_ID, ""),
+                        "댓글 내용을 입력해주세요."
+                ),
+                Arguments.of(
+                        new CommentRequestV2(MIN_STACCATO_ID, " "),
+                        "댓글 내용을 입력해주세요."
+                ),
+                Arguments.of(
+                        new CommentRequestV2(MIN_STACCATO_ID, "1".repeat(MAX_CONTENT_LENGTH + 1)),
+                        "댓글은 공백 포함 500자 이하로 입력해주세요."
+                )
+        );
+    }
+
+    @DisplayName("댓글 생성 요청/응답에 대한 직렬화/역직렬화에 성공한다.")
+    @Test
+    void createComment() throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
+        String CommentCreateRequest = """
+                {
+                    "staccatoId": 1,
+                    "content": "content"
+                }
+                """;
+        when(commentService.createComment(any(), any())).thenReturn(1L);
+
+        // when & then
+        mockMvc.perform(post("/comments/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(CommentCreateRequest)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/comments/1"));
+    }
+
+    @DisplayName("올바르지 않은 형식으로 정보를 입력하면, 댓글을 생성할 수 없다.")
+    @ParameterizedTest
+    @MethodSource("invalidCommentCreateRequestProvider")
+    void createCommentFail(CommentRequestV2 CommentRequestV2, String expectedMessage) throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
+
+        // when & then
+        mockMvc.perform(post("/comments/v2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(CommentRequestV2))
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
+
+    @DisplayName("댓글을 조회했을 때 응답 직렬화에 성공한다.")
+    @Test
+    void readCommentsBystaccatoId() throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
+        CommentResponse commentResponse = new CommentResponse(1L, 1L, "member", "image.jpg", "내용");
+        CommentResponses commentResponses = new CommentResponses(List.of(commentResponse));
+        when(commentService.readAllCommentsByMomentId(any(), any())).thenReturn(commentResponses);
+        String expectedResponse = """
+                {
+                    "comments": [
+                	        {
+                            "commentId": 1,
+                            "memberId": 1,
+                            "nickname": "member",
+                            "memberImageUrl": "image.jpg",
+                            "content": "내용"
+                        }
+                    ]
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/comments/v2")
+                        .param("staccatoId", "1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedResponse));
+    }
+
+    @DisplayName("스타카토 식별자가 양수가 아닐 경우 댓글 읽기에 실패한다.")
+    @Test
+    void readCommentsBystaccatoIdFail() throws Exception {
+        // given
+        when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "스타카토 식별자는 양수로 이루어져야 합니다.");
+
+        // when & then
+        mockMvc.perform(get("/comments/v2")
+                        .param("staccatoId", "0")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
+    }
+}

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
@@ -85,7 +85,7 @@ public class CommentControllerV2Test extends ControllerTest {
     @DisplayName("올바르지 않은 형식으로 정보를 입력하면, 댓글을 생성할 수 없다.")
     @ParameterizedTest
     @MethodSource("invalidCommentRequestProvider")
-    void createCommentFail(CommentRequestV2 CommentRequestV2, String expectedMessage) throws Exception {
+    void createCommentFail(CommentRequestV2 commentRequestV2, String expectedMessage) throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
@@ -93,7 +93,7 @@ public class CommentControllerV2Test extends ControllerTest {
         // when & then
         mockMvc.perform(post("/comments/v2")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(CommentRequestV2))
+                        .content(objectMapper.writeValueAsString(commentRequestV2))
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().json(objectMapper.writeValueAsString(exceptionResponse)));
@@ -101,7 +101,7 @@ public class CommentControllerV2Test extends ControllerTest {
 
     @DisplayName("댓글을 조회했을 때 응답 직렬화에 성공한다.")
     @Test
-    void readCommentsBystaccatoId() throws Exception {
+    void readCommentsByStaccatoId() throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
         CommentResponse commentResponse = new CommentResponse(1L, 1L, "member", "image.jpg", "내용");
@@ -132,7 +132,7 @@ public class CommentControllerV2Test extends ControllerTest {
 
     @DisplayName("스타카토 식별자가 양수가 아닐 경우 댓글 읽기에 실패한다.")
     @Test
-    void readCommentsBystaccatoIdFail() throws Exception {
+    void readCommentsByStaccatoIdFail() throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "스타카토 식별자는 양수로 이루어져야 합니다.");

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
@@ -31,7 +31,7 @@ public class CommentControllerV2Test extends ControllerTest {
     private static final int MAX_CONTENT_LENGTH = 500;
     private static final long MIN_STACCATO_ID = 1L;
 
-    static Stream<Arguments> invalidCommentCreateRequestProvider() {
+    static Stream<Arguments> invalidCommentRequestProvider() {
         return Stream.of(
                 Arguments.of(
                         new CommentRequestV2(null, "예시 댓글 내용"),
@@ -65,7 +65,7 @@ public class CommentControllerV2Test extends ControllerTest {
     void createComment() throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());
-        String CommentCreateRequest = """
+        String commentRequest = """
                 {
                     "staccatoId": 1,
                     "content": "content"
@@ -76,7 +76,7 @@ public class CommentControllerV2Test extends ControllerTest {
         // when & then
         mockMvc.perform(post("/comments/v2")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(CommentCreateRequest)
+                        .content(commentRequest)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/comments/1"));
@@ -84,7 +84,7 @@ public class CommentControllerV2Test extends ControllerTest {
 
     @DisplayName("올바르지 않은 형식으로 정보를 입력하면, 댓글을 생성할 수 없다.")
     @ParameterizedTest
-    @MethodSource("invalidCommentCreateRequestProvider")
+    @MethodSource("invalidCommentRequestProvider")
     void createCommentFail(CommentRequestV2 CommentRequestV2, String expectedMessage) throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixture.create());


### PR DESCRIPTION
## ⭐️ Issue Number
- #609 

## 🚩 Summary

* `POST /comments`에서 사용하는 `CommentRequest` 내부에 `momentId`가 있음
  -> `staccatoId`를 사용하는 새로운 `CommentRequestV2` Dto 생성
  -> `CommentRequestV2`를 사용하는 `POST /comments/v2` 생성
* `GET /comments`의 `RequestParam`에 `momentId`가 있음
  -> `staccatoId`를 사용하는 `GET /comments/v2` 생성

## 🙂 To Reviewer

* 테스트는 하나의 파일에서 만들려다가 테스트 데이터 구성에 복잡함을 느껴서, 구현의 편리성을 위해 다른 파일로 분리해서 작업했습니다.

## 📋 To Do

* 클라이언트에서 새로운 API 적용 완료 후, 구 버전 API 제거 필요