### PR TITLE
feat: 기록 시점이 과거 / 현재 / 미래인지 비즈니스 매트릭 구성 #611

### DIFF
--- a/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
@@ -1,0 +1,63 @@
+package com.staccato.config.log;
+
+
+import java.time.LocalDateTime;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import com.staccato.member.domain.Member;
+import com.staccato.moment.service.MomentService;
+import com.staccato.moment.service.dto.request.MomentRequest;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class CreateMomentMetricsAspect {
+    private static final long TIME_THRESHOLD_MINUTES = 30;
+
+    private final MeterRegistry meterRegistry;
+
+    @Pointcut("execution(public * com.staccato.moment.service.MomentService.createMoment(..)) && args(momentRequest, member)")
+    public void createMomentPointcut(MomentRequest momentRequest, Member member) {
+    }
+
+    @AfterReturning(pointcut = "createMomentPointcut(momentRequest, member)", returning = "result")
+    public void afterSuccessfulCreateMoment(MomentRequest momentRequest, Member member, Object result) {
+        LocalDateTime visitedAt = momentRequest.visitedAt();
+        LocalDateTime now = LocalDateTime.now();
+        if (!isPastDateTime(visitedAt, now) && !isFutureDateTime(visitedAt, now)) {
+            recordCounter("now");
+            return;
+        }
+        checkViewPoint(visitedAt, now);
+    }
+
+    private void checkViewPoint(LocalDateTime visitedAt, LocalDateTime now) {
+        if (isPastDateTime(visitedAt, now)) {
+            recordCounter("past");
+            return;
+        }
+        recordCounter("future");
+    }
+
+    private boolean isFutureDateTime(LocalDateTime visitedAt, LocalDateTime now) {
+        return visitedAt.isAfter(now.plusMinutes(TIME_THRESHOLD_MINUTES));
+    }
+
+    private boolean isPastDateTime(LocalDateTime visitedAt, LocalDateTime now) {
+        return visitedAt.isBefore(now.minusMinutes(TIME_THRESHOLD_MINUTES));
+    }
+
+    private void recordCounter(String viewPoint) {
+        Counter.builder("staccato_record_viewpoint")
+                .tag("class", MomentService.class.getName())
+                .tag("method", "createMoment")
+                .tag("viewPoint", viewPoint)
+                .description("counts different view points for Staccato Record")
+                .register(meterRegistry).increment();
+    }
+}

--- a/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
@@ -1,12 +1,11 @@
 package com.staccato.config.log;
 
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
-import com.staccato.member.domain.Member;
 import com.staccato.moment.service.MomentService;
 import com.staccato.moment.service.dto.request.MomentRequest;
 import io.micrometer.core.instrument.Counter;
@@ -17,39 +16,34 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class CreateMomentMetricsAspect {
-    private static final long TIME_THRESHOLD_MINUTES = 30;
 
     private final MeterRegistry meterRegistry;
 
-    @Pointcut("execution(public * com.staccato.moment.service.MomentService.createMoment(..)) && args(momentRequest, member)")
-    public void createMomentPointcut(MomentRequest momentRequest, Member member) {
+    @Pointcut("execution(public * com.staccato.moment.service.MomentService.createMoment(..)) && args(momentRequest)")
+    public void createMomentPointcut(MomentRequest momentRequest) {
     }
 
-    @AfterReturning(pointcut = "createMomentPointcut(momentRequest, member)", returning = "result")
-    public void afterSuccessfulCreateMoment(MomentRequest momentRequest, Member member, Object result) {
-        LocalDateTime visitedAt = momentRequest.visitedAt();
-        LocalDateTime now = LocalDateTime.now();
-        if (!isPastDateTime(visitedAt, now) && !isFutureDateTime(visitedAt, now)) {
-            recordCounter("now");
-            return;
-        }
-        checkViewPoint(visitedAt, now);
-    }
-
-    private void checkViewPoint(LocalDateTime visitedAt, LocalDateTime now) {
-        if (isPastDateTime(visitedAt, now)) {
+    @AfterReturning(pointcut = "createMomentPointcut(momentRequest)")
+    public void afterSuccessfulCreateMoment(MomentRequest momentRequest) {
+        LocalDate visitedAt = momentRequest.visitedAt().toLocalDate();
+        LocalDate now = LocalDate.now();
+        if (isPastDate(visitedAt, now)) {
             recordCounter("past");
             return;
         }
-        recordCounter("future");
+        if (isFutureDate(visitedAt, now)) {
+            recordCounter("future");
+            return;
+        }
+        recordCounter("now");
     }
 
-    private boolean isFutureDateTime(LocalDateTime visitedAt, LocalDateTime now) {
-        return visitedAt.isAfter(now.plusMinutes(TIME_THRESHOLD_MINUTES));
+    private boolean isPastDate(LocalDate visitedAt, LocalDate now) {
+        return visitedAt.isBefore(now);
     }
 
-    private boolean isPastDateTime(LocalDateTime visitedAt, LocalDateTime now) {
-        return visitedAt.isBefore(now.minusMinutes(TIME_THRESHOLD_MINUTES));
+    private boolean isFutureDate(LocalDate visitedAt, LocalDate now) {
+        return visitedAt.isAfter(now);
     }
 
     private void recordCounter(String viewPoint) {

--- a/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/CreateMomentMetricsAspect.java
@@ -6,6 +6,7 @@ import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
+import com.staccato.member.domain.Member;
 import com.staccato.moment.service.MomentService;
 import com.staccato.moment.service.dto.request.MomentRequest;
 import io.micrometer.core.instrument.Counter;
@@ -19,12 +20,12 @@ public class CreateMomentMetricsAspect {
 
     private final MeterRegistry meterRegistry;
 
-    @Pointcut("execution(public * com.staccato.moment.service.MomentService.createMoment(..)) && args(momentRequest)")
-    public void createMomentPointcut(MomentRequest momentRequest) {
+    @Pointcut("execution(public * com.staccato.moment.service.MomentService.createMoment(..)) && args(momentRequest, member)")
+    public void createMomentPointcut(MomentRequest momentRequest, Member member) {
     }
 
-    @AfterReturning(pointcut = "createMomentPointcut(momentRequest)")
-    public void afterSuccessfulCreateMoment(MomentRequest momentRequest) {
+    @AfterReturning(pointcut = "createMomentPointcut(momentRequest, member)", returning = "result")
+    public void afterSuccessfulCreateMoment(MomentRequest momentRequest, Member member, Object result) {
         LocalDate visitedAt = momentRequest.visitedAt().toLocalDate();
         LocalDate now = LocalDate.now();
         if (isPastDate(visitedAt, now)) {

--- a/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
@@ -1,0 +1,131 @@
+package com.staccato.config.log;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.staccato.ServiceSliceTest;
+import com.staccato.fixture.Member.MemberFixture;
+import com.staccato.fixture.memory.MemoryFixture;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+import com.staccato.memory.domain.Memory;
+import com.staccato.memory.repository.MemoryRepository;
+import com.staccato.moment.service.MomentService;
+import com.staccato.moment.service.dto.request.MomentRequest;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+class CreateMomentMetricsAspectTest extends ServiceSliceTest {
+
+    @Autowired
+    private MemoryRepository memoryRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MomentService momentService;
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    static class TestCase {
+        String description;
+        LocalDateTime visitedAt;
+        double expectedPast;
+        double expectedNow;
+        double expectedFuture;
+
+        public TestCase(String description, LocalDateTime visitedAt, double expectedPast, double expectedNow, double expectedFuture) {
+            this.description = description;
+            this.visitedAt = visitedAt;
+            this.expectedPast = expectedPast;
+            this.expectedNow = expectedNow;
+            this.expectedFuture = expectedFuture;
+        }
+    }
+
+    /**
+     * 동적 테스트 시나리오
+     * 1. 첫 번째 호출: 과거 요청 → 누적: past:1, now:0, future:0
+     * 2. 두 번째 호출: 현재 요청 → 누적: past:1, now:1, future:0
+     * 3. 세 번째 호출: 미래 요청 → 누적: past:1, now:1, future:1
+     * 4. 네 번째 호출: 미래 요청 → 누적: past:1, now:1, future:2
+     */
+    @DisplayName("기록되는 시점을 매트릭을 통해 표현 할 수 있습니다.")
+    @TestFactory
+    Stream<DynamicTest> createMomentMetricsAspect() {
+        Member member = saveMember();
+        Memory memory = saveMemory(member);
+        LocalDateTime now = LocalDateTime.now();
+
+        registerMetrics(memory, member, now);
+
+        List<TestCase> testCases = List.of(
+                new TestCase("과거 기록 Counter를 매트릭에 추가합니다.", now.minusDays(5), 2.0, 1.0, 1.0),
+                new TestCase("현재 기록 Counter를 매트릭에 추가합니다.", now, 2.0, 2.0, 1.0),
+                new TestCase("미래 기록 Counter를 매트릭에 추가합니다.", now.plusDays(1), 2.0, 2.0, 2.0),
+                new TestCase("미래 기록 Counter를 매트릭에 추가합니다.", now.plusDays(2), 2.0, 2.0, 3.0)
+        );
+
+        return testCases.stream().map(tc ->
+                dynamicTest(tc.description, () -> {
+                    MomentRequest momentRequest = createRequest(memory.getId(), tc.visitedAt);
+                    momentService.createMoment(momentRequest, member);
+
+                    double pastCount = meterRegistry.get("staccato_record_viewpoint")
+                            .tag("viewPoint", "past")
+                            .counter().count();
+                    double nowCount = meterRegistry.get("staccato_record_viewpoint")
+                            .tag("viewPoint", "now")
+                            .counter().count();
+                    double futureCount = meterRegistry.get("staccato_record_viewpoint")
+                            .tag("viewPoint", "future")
+                            .counter().count();
+
+                    assertAll(
+                            () -> assertThat(tc.expectedPast).isEqualTo(pastCount),
+                            () -> assertThat(tc.expectedNow).isEqualTo(nowCount),
+                            () -> assertThat(tc.expectedFuture).isEqualTo(futureCount)
+                    );
+                })
+        );
+    }
+
+    private Member saveMember() {
+        return memberRepository.save(MemberFixture.create());
+    }
+
+    private Memory saveMemory(Member member) {
+        Memory memory = MemoryFixture.create(LocalDate.now().minusDays(50), LocalDate.now().plusDays(50));
+        memory.addMemoryMember(member);
+        return memoryRepository.save(memory);
+    }
+
+    private MomentRequest createRequest(Long memoryId, LocalDateTime localDateTime) {
+        return new MomentRequest(
+                "staccatoTitle",
+                "placeName",
+                "address",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                localDateTime,
+                memoryId,
+                List.of());
+    }
+
+    private void registerMetrics(Memory memory, Member member, LocalDateTime now) {
+        MomentRequest pastRequest = createRequest(memory.getId(), now.minusDays(1));
+        MomentRequest nowRequest = createRequest(memory.getId(), now);
+        MomentRequest futureRequest = createRequest(memory.getId(), now.plusDays(1));
+        momentService.createMoment(pastRequest, member);
+        momentService.createMoment(nowRequest, member);
+        momentService.createMoment(futureRequest, member);
+    }
+}

--- a/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
@@ -51,13 +51,6 @@ class CreateMomentMetricsAspectTest extends ServiceSliceTest {
         }
     }
 
-    /**
-     * 동적 테스트 시나리오
-     * 1. 첫 번째 호출: 과거 요청 → 누적: past:1, now:0, future:0
-     * 2. 두 번째 호출: 현재 요청 → 누적: past:1, now:1, future:0
-     * 3. 세 번째 호출: 미래 요청 → 누적: past:1, now:1, future:1
-     * 4. 네 번째 호출: 미래 요청 → 누적: past:1, now:1, future:2
-     */
     @DisplayName("기록되는 시점을 매트릭을 통해 표현 할 수 있습니다.")
     @TestFactory
     Stream<DynamicTest> createMomentMetricsAspect() {

--- a/backend/src/test/java/com/staccato/fixture/memory/MemoryFixture.java
+++ b/backend/src/test/java/com/staccato/fixture/memory/MemoryFixture.java
@@ -5,6 +5,14 @@ import com.staccato.member.domain.Member;
 import com.staccato.memory.domain.Memory;
 
 public class MemoryFixture {
+    public static Memory create() {
+        return Memory.builder()
+                .thumbnailUrl("https://example.com/memorys/geumohrm.jpg")
+                .title("title")
+                .description("친구들과 함께한 여름 휴가 추억")
+                .build();
+    }
+
     public static Memory create(String title) {
         return Memory.builder()
                 .thumbnailUrl("https://example.com/memorys/geumohrm.jpg")


### PR DESCRIPTION
## ⭐️ Issue Number
- #611]

## 🚩 Summary
- 코드를 단순히 Service 로직에 넣으면 매트릭을 관리하는 로직이 핵심 비즈니스 개발 로직에 침투하는 이유 때문에 AOP를 적용하기로 하였습니다.
공통된 관심사의 분리라는 뜻과는 조금 다르게 하나의 메서드에 대한 적용이여서 AOP 적용이 고민되었지만, 아래 2가지 이유로 인해 Service layer에 AOP를 적용하게 되었습니다.

- 생성로직이 정상 수행된 경우에만 매트릭이 기록되어야 한다. 따라서 컨트롤러가 아닌 Service에 적용하여야 한다.
- 비즈니스 로직에 매트릭 기록 로직이 침범하는 것은 옳지 않다.

`staccato` 생성 `api` 한번 호출하고 난 뒤에 `metrics`이 생기게 됩니다.
![image](https://github.com/user-attachments/assets/45e5513b-da21-40df-9952-2c6efcf61d4f)

`local`에서 정상동작함을 확인했습니다.
![image](https://github.com/user-attachments/assets/f5751631-4431-47e8-802e-3869711f9f2d)


## 🛠️ Technical Concerns
시간에 따라 분기처리되는 과정으로 인해 제공되는 `@Counted` 를 사용하지 못하고 `Counter Builder`를 통해 구성하게 되었습니다.

## 🙂 To Reviewer


## 📋 To Do
