### PR TITLE
fix: LogBack appender xml 수정 #590

### DIFF
--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -13,7 +13,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/error/error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>15</maxHistory>
+            <maxHistory>365</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
         </rollingPolicy>
     </appender>

--- a/backend/src/main/resources/error-appender.xml
+++ b/backend/src/main/resources/error-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./logs/error/error-${BY_DATE}.log</file>
+        <file>./logs/error/error.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -13,7 +13,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/info/info-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>15</maxHistory>
+            <maxHistory>365</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
         </rollingPolicy>
     </appender>

--- a/backend/src/main/resources/info-appender.xml
+++ b/backend/src/main/resources/info-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./logs/info/info-${BY_DATE}.log</file>
+        <file>./logs/info/info.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>

--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <configuration>
-    <timestamp key="BY_DATE" datePattern="yyyy-MM-dd"/>
     <springProfile name="dev">
         <include resource="console-appender.xml"/>
         <root level="info">

--- a/backend/src/main/resources/warn-appender.xml
+++ b/backend/src/main/resources/warn-appender.xml
@@ -1,6 +1,6 @@
 <included>
     <appender name="WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>./logs/warn/warn-${BY_DATE}.log</file>
+        <file>./logs/warn/warn.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>

--- a/backend/src/main/resources/warn-appender.xml
+++ b/backend/src/main/resources/warn-appender.xml
@@ -13,7 +13,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>./logs/warn/warn-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>10MB</maxFileSize>
-            <maxHistory>15</maxHistory>
+            <maxHistory>365</maxHistory>
             <totalSizeCap>3GB</totalSizeCap>
         </rollingPolicy>
     </appender>


### PR DESCRIPTION
## ⭐️ Issue Number
- #590 

## 🚩 Summary
- 로그 저장 기간을 15일에서 365일(1년)으로 변경했습니다.
   - `<totalSizeCap>3GB</totalSizeCap>` 설정 때문에 전체 로그파일의 크기가 3GB를 넘어가면 오래된 로그부터 자동으로 삭제됩니다. 따라서 로그 저장 기간이 길어도 용량 문제가 생기지 않습니다.
- 오늘 일자의 로그를 임시로 저장하는 파일의 이름을 `info.log` `warn.log` `error.log`로 변경했습니다.