### PR TITLE
feat: 필터링/조건 옵션 로깅 구현 #601

### DIFF
--- a/backend/src/main/java/com/staccato/config/log/ReadAllCategoryMetricsAspect.java
+++ b/backend/src/main/java/com/staccato/config/log/ReadAllCategoryMetricsAspect.java
@@ -1,0 +1,52 @@
+package com.staccato.config.log;
+
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import com.staccato.member.domain.Member;
+import com.staccato.memory.service.MemoryFilter;
+import com.staccato.memory.service.MemoryService;
+import com.staccato.memory.service.MemorySort;
+import com.staccato.memory.service.dto.request.MemoryReadRequest;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ReadAllCategoryMetricsAspect {
+
+    private final MeterRegistry meterRegistry;
+
+    @Pointcut("execution(public * com.staccato.memory.service.MemoryService.readAllMemories(..)) && args(member, memoryReadRequest)")
+    public void createMemoryPointcut(Member member, MemoryReadRequest memoryReadRequest) {
+    }
+
+    @AfterReturning(pointcut = "createMemoryPointcut(member, memoryReadRequest)", returning = "result", argNames = "member,memoryReadRequest,result")
+    public void afterSuccessfulReadMemory(Member member, MemoryReadRequest memoryReadRequest, Object result) {
+        for (MemoryFilter filter : memoryReadRequest.getFilters()) {
+            countFilter(filter);
+        }
+        countSort(memoryReadRequest.getSort());
+    }
+
+    private void countFilter(MemoryFilter filter) {
+        Counter.builder("category_filter_count")
+                .tag("class", MemoryService.class.getName())
+                .tag("method", "readAllMemories")
+                .tag("filter", filter.getName())
+                .description("counts for filter usage of categories")
+                .register(meterRegistry).increment();
+    }
+
+    private void countSort(MemorySort sort) {
+        Counter.builder("category_sort_count")
+                .tag("class", MemoryService.class.getName())
+                .tag("method", "readAllMemories")
+                .tag("sort", sort.getName())
+                .description("counts for sort usage of categories")
+                .register(meterRegistry).increment();
+    }
+}

--- a/backend/src/main/java/com/staccato/memory/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/memory/controller/CategoryController.java
@@ -2,10 +2,8 @@ package com.staccato.memory.controller;
 
 import java.net.URI;
 import java.time.LocalDate;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -26,7 +23,6 @@ import com.staccato.memory.controller.docs.CategoryControllerDocs;
 import com.staccato.memory.service.MemoryService;
 import com.staccato.memory.service.dto.request.CategoryReadRequest;
 import com.staccato.memory.service.dto.request.CategoryRequest;
-import com.staccato.memory.service.dto.request.MemoryReadRequest;
 import com.staccato.memory.service.dto.response.CategoryDetailResponse;
 import com.staccato.memory.service.dto.response.CategoryIdResponse;
 import com.staccato.memory.service.dto.response.CategoryNameResponses;
@@ -35,7 +31,6 @@ import com.staccato.memory.service.dto.response.MemoryDetailResponse;
 import com.staccato.memory.service.dto.response.MemoryIdResponse;
 import com.staccato.memory.service.dto.response.MemoryNameResponses;
 import com.staccato.memory.service.dto.response.MemoryResponses;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -52,7 +47,8 @@ public class CategoryController implements CategoryControllerDocs {
             @LoginMember Member member
     ) {
         MemoryIdResponse memoryIdResponse = memoryService.createMemory(CategoryDtoMapper.toMemoryRequest(categoryRequest), member);
-        return ResponseEntity.created(URI.create("/categories/" + memoryIdResponse.memoryId())).body(CategoryDtoMapper.toCategoryIdResponse(memoryIdResponse));
+        return ResponseEntity.created(URI.create("/categories/" + memoryIdResponse.memoryId()))
+                .body(CategoryDtoMapper.toCategoryIdResponse(memoryIdResponse));
     }
 
     @GetMapping

--- a/backend/src/main/java/com/staccato/memory/service/MemoryFilter.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryFilter.java
@@ -6,9 +6,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import com.staccato.memory.domain.Memory;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum MemoryFilter {
     TERM("term", memoryList ->
             memoryList.stream()

--- a/backend/src/main/java/com/staccato/memory/service/MemorySort.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemorySort.java
@@ -5,9 +5,11 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import com.staccato.memory.domain.Memory;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Getter
 public enum MemorySort {
     UPDATED("UPDATED", memoryList ->
             memoryList.stream()

--- a/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
@@ -1,0 +1,53 @@
+package com.staccato.config.log;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import com.staccato.fixture.Member.MemberFixture;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+import com.staccato.memory.service.MemoryService;
+import com.staccato.memory.service.dto.request.MemoryReadRequest;
+import io.micrometer.core.instrument.MeterRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@SpringBootTest
+public class ReadAllCategoryMetricsAspectTest {
+
+    @Autowired
+    private MemoryService memoryService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @DisplayName("필터와 정렬 조건마다 호출 횟수를 메트릭으로 남긴다.")
+    @Test
+    void testMetricsAfterServiceExecution() {
+        // given
+        Member member = MemberFixture.create();
+        memberRepository.save(member);
+        MemoryReadRequest memoryReadRequest = new MemoryReadRequest("term", "oldest");
+
+        // when
+        memoryService.readAllMemories(member, memoryReadRequest);
+
+        // then
+        double filterCount = meterRegistry.counter("category_filter_count",
+                "class", MemoryService.class.getName(),
+                "method", "readAllMemories",
+                "filter", "term").count();
+        double sortCount = meterRegistry.counter("category_sort_count",
+                "class", MemoryService.class.getName(),
+                "method", "readAllMemories",
+                "sort", "OLDEST").count();
+        assertAll(
+                () -> assertThat(filterCount).isEqualTo(1.0),
+                () -> assertThat(sortCount).isEqualTo(1.0)
+        );
+    }
+}
+

--- a/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
@@ -3,7 +3,7 @@ package com.staccato.config.log;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import com.staccato.ServiceSliceTest;
 import com.staccato.fixture.Member.MemberFixture;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
@@ -14,8 +14,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-@SpringBootTest
-public class ReadAllCategoryMetricsAspectTest {
+public class ReadAllCategoryMetricsAspectTest extends ServiceSliceTest {
 
     @Autowired
     private MemoryService memoryService;


### PR DESCRIPTION
## ⭐️ Issue Number
- #601 

## 🚩 Summary
- AOP를 사용하여 `MemoryService.readAllMemories` 메서드 호출이 성공하였을 때(`@AfterReturning`) 정렬 조건과 필터링 조건에 대한 메트릭을 기록하도록 구현했습니다.
- `Counter`를 활용하여 각 정렬 조건과 필터링 조건의 사용 횟수를 메트릭으로 기록하고 있습니다.
- 관련 테스트 함께 구현했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
