### PR TITLE
refactor: Actuator 설정 값 변경 #555

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -65,9 +65,8 @@ management:
     web:
       exposure:
         include: info, health, metrics, env, beans, threaddump, loggers, prometheus
-  endpoint:
-    health:
-      show-components: when_authorized
+
+
 
 server:
   tomcat:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -61,9 +61,6 @@ management:
     web:
       exposure:
         include: "*"
-  endpoint:
-    health:
-      show-components: when_authorized
 
 server:
   tomcat:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -90,14 +90,17 @@ image:
 
 management:
   server:
-    port: 8080
+    port: 9292
   endpoints:
     web:
       exposure:
-        include: info, health, metrics, env, beans, threaddump, loggers, prometheus
+        include: info, health, prometheus
+    jmx:
+      exposure:
+        exclude: "*"
   endpoint:
     health:
-      show-components: when_authorized
+      show-components: never
 
 server:
   tomcat:

--- a/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/CreateMomentMetricsAspectTest.java
@@ -3,7 +3,6 @@ package com.staccato.config.log;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
@@ -34,18 +33,18 @@ class CreateMomentMetricsAspectTest extends ServiceSliceTest {
     @Autowired
     private MeterRegistry meterRegistry;
 
-    @DisplayName("기록되는 시점을 매트릭을 통해 표현 할 수 있습니다.")
+    @DisplayName("기록 상의 날짜를 현재를 기준으로 과거 혹은 미래 인지 매트릭을 통해 표현 할 수 있습니다.")
     @TestFactory
-    Stream<DynamicTest> createMomentMetricsAspect() {
+    List<DynamicTest> createMomentMetricsAspect() {
         Member member = saveMember();
         Memory memory = saveMemory(member);
         LocalDateTime now = LocalDateTime.now();
 
-        return Stream.of(
-                dynamicTest("과거, 미래 기록 매트릭을 등록합니다.", () -> {
+        return List.of(
+                dynamicTest("기록 상의 날짜가 과거인 기록과 미래인 기록을 매트릭에 등록합니다.", () -> {
                     // given
-                    MomentRequest pastRequest = createRequest(memory.getId(), now.minusDays(1));
-                    MomentRequest futureRequest = createRequest(memory.getId(), now.plusDays(1));
+                    MomentRequest pastRequest = createRequest(memory.getId(), now.minusDays(2));
+                    MomentRequest futureRequest = createRequest(memory.getId(), now.plusDays(2));
 
                     //when
                     momentService.createMoment(pastRequest, member);
@@ -57,9 +56,9 @@ class CreateMomentMetricsAspectTest extends ServiceSliceTest {
                             () -> assertThat(getFutureCount()).isEqualTo(1.0)
                     );
                 }),
-                dynamicTest("과거 요청 → 누적: past:2, future:1", () -> {
+                dynamicTest("기록 상의 날짜가 과거인 기록 작성 요청 → 누적: past:2.0, future:1.0", () -> {
                     // given
-                    MomentRequest momentRequest = createRequest(memory.getId(), now.minusDays(1));
+                    MomentRequest momentRequest = createRequest(memory.getId(), now.minusDays(3));
 
                     // when
                     momentService.createMoment(momentRequest, member);


### PR DESCRIPTION
## ⭐️ Issue Number
- #555 

## 🚩 Summary
- 아래와 같이 수정하였습니다.

``` java
management:
  server:
    port: 9292
  endpoints:
    web:
      exposure:
        include: info, health, prometheus
    jmx:
      exposure:
        exclude: "*"
  endpoint:
    health:
      show-components: never
```

## 🛠️ Technical Concerns

이슈와 다르게 반영하지 않은 부분은 base url부분인데,
위와 같이 구성하면 기본 애플리케이션 포트(예: 8080)와는 별개로, 관리용 엔드포인트들이 9292번 포트에서 서비스됩니다.
즉, 애플리케이션을 실행하면 일반 웹 요청은 기본 포트에서 처리되고, 관리 요청(health, info, prometheus 등)은 9292번 포트에서 처리됩니다.
따라서 `외부에서의 접근이 가능한가?` 라는 관점으로 봤을 때, base url까지 변경하는 것은 필요하지 않다고 판단하여 수정하지 않았습니다.

## 🙂 To Reviewer


## 📋 To Do
