### PR TITLE
fix: 코드 난독화 설정으로 인한 제네릭 타입 소거 에러 해결 #637

### DIFF
--- a/android/Staccato_AN/app/proguard-rules.pro
+++ b/android/Staccato_AN/app/proguard-rules.pro
@@ -14,8 +14,10 @@
 
 # Uncomment this to preserve the line number information for
 # debugging stack traces.
--keepattributes SourceFile,LineNumberTable
+-keepattributes SourceFile,LineNumberTable,Signature
 
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 -renamesourcefileattribute SourceFile
+
+-keepnames, allowobfuscation class com.on.staccato.data.ApiResult


### PR DESCRIPTION
## ⭐️ Issue Number
- #637 

<br>

## 🚩 Summary
### 코드 난독화 관련 에러 해결
- 코드 난독화 설정으로, 제네릭 타입 Signature가 소거되어 제네릭 타입을 확인할 수 없는 런타임 에러 발생.
  - 에러 발생 시점: CallAdapter 반환에 필요한 리턴 타입을 타입 캐스팅 할 때(ApiResultCallAdapterFactory)

- proguard-rules.pro에서 Signature를 소거 대상에서 제외시키는 규칙을 설정하여 문제 해결

<br>

## 🛠️ Technical Concerns

<br>

## 🙂 To Reviewer

<br>

## 📋 To Do
