### PR TITLE
fix: 이미지 순서 수정 시 반영 안되는 문제 #650

### DIFF
--- a/backend/src/main/java/com/staccato/memory/service/MemoryService.java
+++ b/backend/src/main/java/com/staccato/memory/service/MemoryService.java
@@ -89,7 +89,7 @@ public class MemoryService {
 
     private String getMomentThumbnail(Moment moment) {
         if (moment.hasImage()) {
-            return moment.getThumbnailUrl();
+            return moment.thumbnailUrl();
         }
         return null;
     }

--- a/backend/src/main/java/com/staccato/moment/domain/Moment.java
+++ b/backend/src/main/java/com/staccato/moment/domain/Moment.java
@@ -3,6 +3,7 @@ package com.staccato.moment.domain;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -99,5 +100,9 @@ public class Moment extends BaseEntity {
     @PreRemove
     public void touchForWrite() {
         memory.setUpdatedAt(LocalDateTime.now());
+    }
+
+    public List<MomentImage> existingImages() {
+        return momentImages.getImages();
     }
 }

--- a/backend/src/main/java/com/staccato/moment/domain/Moment.java
+++ b/backend/src/main/java/com/staccato/moment/domain/Moment.java
@@ -83,7 +83,7 @@ public class Moment extends BaseEntity {
         this.memory = newMoment.getMemory();
     }
 
-    public String getThumbnailUrl() {
+    public String thumbnailUrl() {
         return momentImages.getImages().get(0).getImageUrl();
     }
 

--- a/backend/src/main/java/com/staccato/moment/domain/MomentImages.java
+++ b/backend/src/main/java/com/staccato/moment/domain/MomentImages.java
@@ -42,32 +42,8 @@ public class MomentImages {
         return !images.isEmpty();
     }
 
-    public List<MomentImage> findImagesNotPresentIn(MomentImages targetMomentImages) {
-        return images.stream()
-                .filter(image -> !targetMomentImages.contains(image))
-                .toList();
-    }
-
     protected void update(MomentImages newMomentImages, Moment moment) {
-        removeExistImages(newMomentImages);
-        saveNewImages(newMomentImages, moment);
-    }
-
-    private void removeExistImages(MomentImages newMomentImages) {
-        List<MomentImage> momentImages = findImagesNotPresentIn(newMomentImages);
-        images.removeAll(momentImages);
-    }
-
-    private void saveNewImages(MomentImages newMomentImages, Moment moment) {
-        List<MomentImage> momentImages = newMomentImages.findImagesNotPresentIn(this);
-        momentImages.forEach(image -> {
-            this.images.add(image);
-            image.belongTo(moment);
-        });
-    }
-
-    private boolean contains(MomentImage momentImage) {
-        return this.images.stream()
-                .anyMatch(image -> image.isSame(momentImage));
+        images.clear();
+        addAll(newMomentImages, moment);
     }
 }

--- a/backend/src/main/java/com/staccato/moment/service/MomentService.java
+++ b/backend/src/main/java/com/staccato/moment/service/MomentService.java
@@ -13,7 +13,6 @@ import com.staccato.memory.repository.MemoryRepository;
 import com.staccato.moment.domain.Feeling;
 import com.staccato.moment.domain.Moment;
 import com.staccato.moment.domain.MomentImage;
-import com.staccato.moment.domain.MomentImages;
 import com.staccato.moment.repository.MomentImageRepository;
 import com.staccato.moment.repository.MomentRepository;
 import com.staccato.moment.service.dto.request.FeelingRequest;
@@ -70,14 +69,12 @@ public class MomentService {
         validateMemoryOwner(targetMemory, member);
 
         Moment newMoment = momentRequest.toMoment(targetMemory);
-        MomentImages originMomentImages = moment.getMomentImages();
-        List<MomentImage> images = originMomentImages.findImagesNotPresentIn(newMoment.getMomentImages());
-        removeImages(images);
-
+        List<MomentImage> existingImages = moment.existingImages();
+        removeExistingImages(existingImages);
         moment.update(newMoment);
     }
 
-    private void removeImages(List<MomentImage> images) {
+    private void removeExistingImages(List<MomentImage> images) {
         List<Long> ids = images.stream()
                 .map(MomentImage::getId)
                 .toList();

--- a/backend/src/test/java/com/staccato/moment/domain/MomentImagesTest.java
+++ b/backend/src/test/java/com/staccato/moment/domain/MomentImagesTest.java
@@ -50,14 +50,14 @@ class MomentImagesTest {
                 .hasMessage("사진은 5장을 초과할 수 없습니다.");
     }
 
-    @DisplayName("사진들을 추가할 때 기존 사진이 포함되지 않은 경우 삭제 후 추가한다.")
+    @DisplayName("사진들의 순서를 변경할 때 기존 사진이 포함되지 않은 경우 삭제 후 추가한다.")
     @Test
     void update() {
         // given
         Memory memory = Memory.builder().title("Sample Memory").startAt(LocalDate.now().minusDays(1))
                 .endAt(LocalDate.now().plusDays(1)).build();
-        MomentImages existingImages = new MomentImages(List.of("picture1", "picture3"));
-        MomentImages updatedImages = new MomentImages(List.of("picture1", "picture4"));
+        MomentImages existingImages = new MomentImages(List.of("picture1", "picture3", "picture2"));
+        MomentImages updatedImages = new MomentImages(List.of("picture1", "picture4", "picture3"));
 
         // when
         existingImages.update(updatedImages, MomentFixture.create(memory, LocalDateTime.now()));
@@ -65,29 +65,8 @@ class MomentImagesTest {
         // then
         List<String> images = existingImages.getImages().stream().map(MomentImage::getImageUrl).toList();
         assertAll(
-                () -> assertThat(images).containsAll(List.of("picture1", "picture4")),
-                () -> assertThat(images.size()).isEqualTo(2)
-        );
-    }
-
-    @DisplayName("포함되지 않는 사진들을 선별할 수 있다.")
-    @Test
-    void findImagesNotPresentIn() {
-        // given
-        MomentImages existingImages = new MomentImages(List.of("picture1", "picture3"));
-        MomentImages newImages = new MomentImages(List.of("picture1", "picture4"));
-
-        // when
-        List<MomentImage> remainingExistingImages = existingImages.findImagesNotPresentIn(newImages);
-        List<MomentImage> remainingNewImages = newImages.findImagesNotPresentIn(existingImages);
-
-        // then
-        assertAll(
-
-                () -> assertThat(remainingExistingImages.size()).isEqualTo(1),
-                () -> assertThat(remainingNewImages.size()).isEqualTo(1),
-                () -> assertThat(remainingExistingImages.get(0).getImageUrl()).isEqualTo("picture3"),
-                () -> assertThat(remainingNewImages.get(0).getImageUrl()).isEqualTo("picture4")
+                () -> assertThat(images).containsExactlyElementsOf(List.of("picture1", "picture4", "picture3")),
+                () -> assertThat(images.size()).isEqualTo(3)
         );
     }
 }

--- a/backend/src/test/java/com/staccato/moment/domain/MomentImagesTest.java
+++ b/backend/src/test/java/com/staccato/moment/domain/MomentImagesTest.java
@@ -20,6 +20,16 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class MomentImagesTest {
+    static Stream<Arguments> provideUpdateData() {
+        return Stream.of(
+                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of()),
+                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture4")),
+                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture3", "picture2")),
+                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture3", "picture1", "picture2")),
+                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture1", "picture2", "picture4", "picture3"))
+        );
+    }
+
     @DisplayName("생성하려는 사진의 갯수가 0장 이상, 5장 이하이면 생성에 성공한다.")
     @ParameterizedTest
     @ValueSource(ints = {0, 5})
@@ -68,15 +78,5 @@ class MomentImagesTest {
 
         // then
         assertThat(images).containsExactlyElementsOf(updatedImageNames);
-    }
-
-    static Stream<Arguments> provideUpdateData() {
-        return Stream.of(
-                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of()),
-                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture4")),
-                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture3", "picture2")),
-                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture3", "picture1", "picture2")),
-                Arguments.of(List.of("picture1", "picture2", "picture3"), List.of("picture1", "picture2", "picture4", "picture3"))
-        );
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #650 

## 🚩 Summary
- 스타카토 수정 시 기존 이미지에 대한 순서 변경이 적용 안되는 이슈를 해결하였습니다.
- 기존 로직보다 쿼리수는 더 나가겠지만, 전체 이미지가 5개로 제한되는 상황이므로 크리티컬하지 않다고 판단하였습니다.

## 🛠️ Technical Concerns
- 이미지의 순서를 부여하는 칼럼을 새롭게 구성하는 방식 또한 고려해보았는데, 새롭게 칼럼을 추가해서 관리하는 것보다 최대 5개의 이미지로 제한되므로 전체 삭제 후 전체 갱신으로 구성하였습니다.

## 🙂 To Reviewer


## 📋 To Do

