### PR TITLE
feat: 민감 정보 jasypt 적용 #647

### DIFF
--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   ci:
     runs-on: [ self-hosted, dev ]
-
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-ci-cd-dev.yml
+++ b/.github/workflows/backend-ci-cd-dev.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Docker Image Build
         run: |
-          sudo docker build --platform linux/arm64 -t staccato/staccato:dev -f Dockerfile.dev .
+          sudo docker build --platform linux/arm64 -t staccato/staccato:dev -f Dockerfile.dev --build-arg JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} .
 
       - name: Docker Hub Push
         run: |

--- a/.github/workflows/backend-ci-cd-multi-dev.yml
+++ b/.github/workflows/backend-ci-cd-multi-dev.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Docker Image Build
         run: |
-          sudo docker build --platform linux/arm64 -t staccato/staccato:dev -f Dockerfile.dev .
+          sudo docker build --platform linux/arm64 -t staccato/staccato:dev -f Dockerfile.dev --build-arg JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} .
 
       - name: Docker Hub Push
         run: |

--- a/.github/workflows/backend-ci-cd-multi-dev.yml
+++ b/.github/workflows/backend-ci-cd-multi-dev.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   ci:
     runs-on: [ self-hosted, dev ]
-
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-ci-cd-prod.yml
+++ b/.github/workflows/backend-ci-cd-prod.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
-
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/backend-ci-cd-prod.yml
+++ b/.github/workflows/backend-ci-cd-prod.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Docker Image Build
         run: |
-          sudo docker build --platform linux/arm64 -t staccato/staccato:prod -f Dockerfile.prod .
+          sudo docker build --platform linux/arm64 -t staccato/staccato:prod -f Dockerfile.prod --build-arg JASYPT_ENCRYPTOR_PASSWORD=${{ secrets.JASYPT_PASSWORD }} .
 
       - name: Docker Hub Push
         run: |

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -9,9 +9,9 @@ permissions: write-all
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
+    env:
+      JASYPT_PASSWORD: ${{ secrets.JASYPT_PASSWORD }}
     defaults:
       run:
         shell: bash

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM openjdk:17
 EXPOSE 8080
 ARG JAR_FILE=./build/libs/*-SNAPSHOT.jar
+ARG JASYPT_ENCRYPTOR_PASSWORD
+
 COPY ${JAR_FILE} app.jar
+
 ENTRYPOINT ["java", "-jar","-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=dev","app.jar"]

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,6 +1,8 @@
 FROM openjdk:17
 EXPOSE 8080 8081
 ARG JAR_FILE=./build/libs/*-SNAPSHOT.jar
+ARG JASYPT_ENCRYPTOR_PASSWORD
+
 COPY ${JAR_FILE} app.jar
 
 ENTRYPOINT ["java", "-jar","-Duser.timezone=Asia/Seoul", "-Dspring.profiles.active=prod","app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'

--- a/backend/src/main/java/com/staccato/config/JasyptConfig.java
+++ b/backend/src/main/java/com/staccato/config/JasyptConfig.java
@@ -26,7 +26,7 @@ public class JasyptConfig {
         config.setPoolSize("2");
         config.setProviderName("SunJCE");
         config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
-        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
         config.setStringOutputType("base64");
         encryptor.setConfig(config);
         return encryptor;

--- a/backend/src/main/java/com/staccato/config/JasyptConfig.java
+++ b/backend/src/main/java/com/staccato/config/JasyptConfig.java
@@ -1,0 +1,34 @@
+package com.staccato.config;
+
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Profile({"dev", "prod"})
+@Configuration
+public class JasyptConfig {
+
+    @Value("${jasypt.encryptor.password}")
+    private String password;
+
+    @Bean("jasyptStringEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+
+        config.setPassword(password);
+        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setKeyObtentionIterations("1000");
+        config.setPoolSize("2");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.NoIvGenerator");
+        config.setStringOutputType("base64");
+        encryptor.setConfig(config);
+        return encryptor;
+    }
+}

--- a/backend/src/main/java/com/staccato/config/JasyptConfig.java
+++ b/backend/src/main/java/com/staccato/config/JasyptConfig.java
@@ -22,7 +22,7 @@ public class JasyptConfig {
 
         config.setPassword(password);
         config.setAlgorithm("PBEWithHMACSHA512AndAES_256");
-        config.setKeyObtentionIterations("1000");
+        config.setKeyObtentionIterations("210000");
         config.setPoolSize("2");
         config.setProviderName("SunJCE");
         config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");

--- a/backend/src/main/java/com/staccato/config/JasyptConfig.java
+++ b/backend/src/main/java/com/staccato/config/JasyptConfig.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-@Profile({"dev", "prod"})
+@Profile({"local", "dev", "prod"})
 @Configuration
 public class JasyptConfig {
 

--- a/backend/src/main/java/com/staccato/config/JasyptConfig.java
+++ b/backend/src/main/java/com/staccato/config/JasyptConfig.java
@@ -4,11 +4,11 @@ import org.jasypt.encryption.StringEncryptor;
 import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
-@Profile({"local", "dev", "prod"})
+@ConditionalOnProperty(name = "jasypt.encryptor.password")
 @Configuration
 public class JasyptConfig {
 
@@ -21,7 +21,7 @@ public class JasyptConfig {
         SimpleStringPBEConfig config = new SimpleStringPBEConfig();
 
         config.setPassword(password);
-        config.setAlgorithm("PBEWithMD5AndDES");
+        config.setAlgorithm("PBEWithHMACSHA512AndAES_256");
         config.setKeyObtentionIterations("1000");
         config.setPoolSize("2");
         config.setProviderName("SunJCE");

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -9,9 +9,9 @@ spring:
       mode: always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(Z6HexGUo7PIGVWA2GOFTnKczW8Lz2MD7QIBkNIQLJh2CZf/ctAKg0lHUmfv9pKUHDzd5kUuVsaYNty9uEV3C5e+KyuTq+wLCJ5X1Piq8TaGobJ3hqqCsotKKr+PEi/tUodfxKQgcsBHfVN5fNaGevw8Ed2ryY7BZkaiC9OtN9NE=)
-    username: ENC(qwQULh2q73p3VZxYNssXO0/Y4IvJzBTU)
-    password: ENC(Foce1I2WyNdpbdGLKvSJ7w==)
+    url: ENC(Bhf3aE/YmxUOU46I9KniZFPEqiJzNNpPFWp+BGk2Hyk0GOrhQE1D0h2UEdxpf1TpcmaWScgFDXqEdA7Pj7CK0YWNyfAcUsFc3Tu2tsHJrV9CHF2t8sUGettLn9RVKCQaUXUClz0QHasPmdAjkw+BeVHl+xiZfvqUOFP+7WtJniYsBPM9TvRnfM7DH77ryKVEztXvxNDhRDkS2qyY9XDySQ==)
+    username: ENC(pvX1j0OBUpzxQBzlDxOty1HdBKoufY3UWN3yFwmdbwIWd6yz14FXaAiCVsNkuz3o)
+    password: ENC(LzwPGUo4GEfmf88zBWpfRbAachfEbT4W6JqymJ5KlvvNv+nXP1xydOJPNg9FRV0p)
   jpa:
     database: MYSQL
     show-sql: true
@@ -42,18 +42,18 @@ springdoc:
 security:
   jwt:
     token:
-      secret-key: ENC(rTauTAGby+LR+4Km3UaSJDOq8gCbZzgaMDrO0vpgTHGloohaiWw/XPQK8Cr2/kHfb7xy5Lhc0ctX9LJjdn79aQjgQC7skIeI)
+      secret-key: ENC(AXnLfMTl5wkGHnVtZGEIrJdrNGqJ22n7c2mmpHdyNnCveMMU0wLnZQuPlbK0l7Ooi05C4/6ZZrsGCzSJJYWO8ME1Yyy1IN1ES1uq0RnWU5J8N04ZBp1/bmT2fYbeRbO+)
 cloud:
   aws:
-    access-key: ENC(r3b3pCaGN+E5Tbxj1U+epJy28eby+mg2h5Kl8hy6yuY=)
-    secret-access-key: ENC(O6y2eQtc5gZiULBxWKSVfxl2Op6ipKy5Nzv83/irPf+Rx44OW1omEq4Ofa0kdQmFBbi+gfEcsnY=)
+    access-key: ENC(esOew5zDP7xeUY4rqpHQIWRJvnyh4qC9HHMzFI9Bek4gu65ZxgQOaGT40tXaJ/kLBsPAXM4NIYF7g64+67gfHg==)
+    secret-access-key: ENC(osZssrZ+Z1Mraw1D8Rd0tXOk0VfMj/8uaGeRrH7/pF+PMJQQga6EBCp14HbGE/zwsSKaZ4xyI5tBy6hwSCJFqKPzzgTN4/Y/AQX3bFp6k90=)
     s3:
-      bucket: ENC(dj8hl6vZzv6bqbqPpgzcmjjLwpszT8MS)
-      endpoint: ENC(XrPoJGC5B1EkIaMfcLYZQr5ODGQhLXbSD1jPvh5uALXVGGeK8f89Cwe0RIQ65MQXJ0FGOAXIP6q+5P4An4PNLQ==)
+      bucket: ENC(3G8rZ+nSA+6jQBkeskKXlBcpdJEjr+6CnsK8auvOzMMF9ytS6lqGuJbW+G7emzL2)
+      endpoint: ENC(9yj+jkWlB807kp6umhJIA+osCj4ha/WQcuh8+TTipY3XJNpPs+LswGr4pPPQ5bLQobDzat8PSNZClqvALLpue3PCBxqpUq7Ot3zN02siH+PuFEAqV/izRYpku0bUgK65)
     cloudfront:
-      endpoint: ENC(tX/4xozGxIJmG5WSYYwE/ik1cDTrKe3Qsl1J7QpRgQD9RMDodMvAw6ATDfh7tgPK)
+      endpoint: ENC(LMIPHd+0QQ480lNvi9VTyTjVs/+ok8dpUnZfcNTqrLrlmjAEFV61fh/JmgQmjTBCWW+vlKqWmp3tqnbjjqsxrTI+wl2IGB6O+K/ewjU6TMg=)
     region:
-      static: ENC(yZpFfqqQH/FT+acjy9oSNta/LV6DIuGn)
+      static: ENC(VU25sKaZUPFns2J8GhgAyrioMpwOaWyMa4fBWSzX8LH3zInZc2upgBttgy7EaJWV)
     stack:
       auto: false
 image:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -9,9 +9,9 @@ spring:
       mode: always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
+    url: ENC(Z6HexGUo7PIGVWA2GOFTnKczW8Lz2MD7QIBkNIQLJh2CZf/ctAKg0lHUmfv9pKUHDzd5kUuVsaYNty9uEV3C5e+KyuTq+wLCJ5X1Piq8TaGobJ3hqqCsotKKr+PEi/tUodfxKQgcsBHfVN5fNaGevw8Ed2ryY7BZkaiC9OtN9NE=)
+    username: ENC(qwQULh2q73p3VZxYNssXO0/Y4IvJzBTU)
+    password: ENC(Foce1I2WyNdpbdGLKvSJ7w==)
   jpa:
     database: MYSQL
     show-sql: true
@@ -31,27 +31,32 @@ spring:
     multipart:
       max-file-size: 20MB
       max-request-size: 20MB
+
+jasypt:
+  encryptor:
+    password: ${JASYPT_PASSWORD}
+
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
 security:
   jwt:
     token:
-      secret-key: ${SECRET_KEY}
+      secret-key: ENC(rTauTAGby+LR+4Km3UaSJDOq8gCbZzgaMDrO0vpgTHGloohaiWw/XPQK8Cr2/kHfb7xy5Lhc0ctX9LJjdn79aQjgQC7skIeI)
   admin:
     key: ${ADMIN_KEY}
     token: ${ADMIN_TOKEN}
 cloud:
   aws:
-    access-key: ${AWS_ACCESS_KEY}
-    secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+    access-key: ENC(r3b3pCaGN+E5Tbxj1U+epJy28eby+mg2h5Kl8hy6yuY=)
+    secret-access-key: ENC(O6y2eQtc5gZiULBxWKSVfxl2Op6ipKy5Nzv83/irPf+Rx44OW1omEq4Ofa0kdQmFBbi+gfEcsnY=)
     s3:
-      bucket: ${AWS_S3_BUCKET}
-      endpoint: ${AWS_S3_ENDPOINT}
+      bucket: ENC(dj8hl6vZzv6bqbqPpgzcmjjLwpszT8MS)
+      endpoint: ENC(XrPoJGC5B1EkIaMfcLYZQr5ODGQhLXbSD1jPvh5uALXVGGeK8f89Cwe0RIQ65MQXJ0FGOAXIP6q+5P4An4PNLQ==)
     cloudfront:
-      endpoint: ${AWS_CLOUDFRONT_ENDPOINT}
+      endpoint: ENC(tX/4xozGxIJmG5WSYYwE/ik1cDTrKe3Qsl1J7QpRgQD9RMDodMvAw6ATDfh7tgPK)
     region:
-      static: ${AWS_REGION_STATIC}
+      static: ENC(yZpFfqqQH/FT+acjy9oSNta/LV6DIuGn)
     stack:
       auto: false
 image:
@@ -65,8 +70,6 @@ management:
     web:
       exposure:
         include: info, health, metrics, env, beans, threaddump, loggers, prometheus
-
-
 
 server:
   tomcat:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -43,9 +43,6 @@ security:
   jwt:
     token:
       secret-key: ENC(rTauTAGby+LR+4Km3UaSJDOq8gCbZzgaMDrO0vpgTHGloohaiWw/XPQK8Cr2/kHfb7xy5Lhc0ctX9LJjdn79aQjgQC7skIeI)
-  admin:
-    key: ${ADMIN_KEY}
-    token: ${ADMIN_TOKEN}
 cloud:
   aws:
     access-key: ENC(r3b3pCaGN+E5Tbxj1U+epJy28eby+mg2h5Kl8hy6yuY=)

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -38,7 +38,7 @@ springdoc:
 security:
   jwt:
     token:
-      secret-key: ENC(PTdRqoaq21lmba/mc5hZi2wSn4ZmvQIB7RDyi8lW0tgoJkUl3SozY7UhWobbmCWghYICKb4oNz2faxci9dGGV4Wl0bo5MNbs)
+      secret-key: ENC(w6iIOc1EMsu5lNXZZF7wz+wo/KziZPWM3jzsF6yeWnjnrfIaUifO6TD+i6jIeQMIB7EyY5Bj2rD2l4VZgDxuR38F1tIxp+RwofkPiaht+E+0WIR8GB94ur9whNL4oUQp)
 cloud:
   aws:
     access-key: accessKey

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -27,16 +27,18 @@ spring:
     multipart:
       max-file-size: 20MB
       max-request-size: 20MB
+
+jasypt:
+  encryptor:
+    password: ${JASYPT_PASSWORD}
+
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
 security:
   jwt:
     token:
-      secret-key: ${SECRET_KEY}
-  admin:
-    key: ${ADMIN_KEY}
-    token: ${ADMIN_TOKEN}
+      secret-key: ENC(PTdRqoaq21lmba/mc5hZi2wSn4ZmvQIB7RDyi8lW0tgoJkUl3SozY7UhWobbmCWghYICKb4oNz2faxci9dGGV4Wl0bo5MNbs)
 cloud:
   aws:
     access-key: accessKey

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -9,9 +9,9 @@ spring:
       mode: always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${SPRING_DATASOURCE_URL}
-    username: ${SPRING_DATASOURCE_USERNAME}
-    password: ${SPRING_DATASOURCE_PASSWORD}
+    url: ENC(VKMyrVpLrR1Mvtdx1zm3EB4gKFgeaqVIc6Wf3s+6Cu9e3w+lGLew5G62xyOyFZ2NeBUOlx11i8Z1aEZUzuPmC2PfdG9uzoTxi2Es3WWeZK3X4pP3h2dlN/crmkR8teISJR3xj/b6Zte5A2iYQ18GUo5QUNRnXbn8)
+    username: ENC(qwQULh2q73p3VZxYNssXO0/Y4IvJzBTU)
+    password: ENC(lIcEbKSmAdanR5azRumgNPVt+6+NFOOd)
     hikari:
       maximum-pool-size: 10
       minimum-idle: 10
@@ -59,6 +59,11 @@ spring:
     multipart:
       max-file-size: 20MB
       max-request-size: 20MB
+
+jasypt:
+  encryptor:
+    password: ${JASYPT_PASSWORD}
+
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
@@ -67,21 +72,21 @@ springdoc:
 security:
   jwt:
     token:
-      secret-key: ${SECRET_KEY}
+      secret-key: ENC(gFDkISN4LtWFZS3VqD8DcY/sJ7oQoSwp2IzgnQh3mZ7Uky6epMIDgk9TIZ57xfw8yOwBl5AbDKQae0SRAUJCFptIBAls44ty)
   admin:
     key: ${ADMIN_KEY}
     token: ${ADMIN_TOKEN}
 cloud:
   aws:
-    access-key: ${AWS_ACCESS_KEY}
-    secret-access-key: ${AWS_SECRET_ACCESS_KEY}
+    access-key: ENC(kJlFbJL+MaD3rV9fB+bQglhlbK82rlKvW0+g0hgsFJQ=)
+    secret-access-key: ENC(+hUItwfvS1Y+nU/j/zyf55o9NyB1Ak/60vbpBrNK9WGPfAMw+5XITnb06vMoknI112dFMhYA+Rw=)
     s3:
-      bucket: ${AWS_S3_BUCKET}
-      endpoint: ${AWS_S3_ENDPOINT}
+      bucket: ENC(VW+RubsMNPc33D+R+NU6X81EBrgAZyWh)
+      endpoint: ENC(ZgPOwy0o4ZLHsHWokjoDi1qyYnCSJVHct8zS4JN+RduQNRldP53WlGle0E33w7f7BIJNuARXhbnEOPIVUMv+pw==)
     cloudfront:
-      endpoint: ${AWS_CLOUDFRONT_ENDPOINT}
+      endpoint: ENC(7ZbtWn0aC7ctosFZt3HSzgT1sv3n3AQoVz52ZchiZrtSkq1jtWLNur5+KlRQqZqA)
     region:
-      static: ${AWS_REGION_STATIC}
+      static: ENC(zgXzsvay+o8RHzj5+OsJwW10YuVMruaf)
     stack:
       auto: false
 image:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -9,9 +9,9 @@ spring:
       mode: always
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ENC(VKMyrVpLrR1Mvtdx1zm3EB4gKFgeaqVIc6Wf3s+6Cu9e3w+lGLew5G62xyOyFZ2NeBUOlx11i8Z1aEZUzuPmC2PfdG9uzoTxi2Es3WWeZK3X4pP3h2dlN/crmkR8teISJR3xj/b6Zte5A2iYQ18GUo5QUNRnXbn8)
-    username: ENC(qwQULh2q73p3VZxYNssXO0/Y4IvJzBTU)
-    password: ENC(lIcEbKSmAdanR5azRumgNPVt+6+NFOOd)
+    url: ENC(QdX7RtOmixaK8JZYh9uxBmsnpkQEOQvKL7j2zSvT5+FOeCPgdxxE2q6R1/fFN/JaIg8wzcvy/64a1DVCoAZH+QpcX+0uSmL9uUfv99hffyY4azyYVxTs8fEKoKwE+voc1Y2KeagzudlQXjC5LAfBzFQGWLA/Fg5oIHdZg+RtC9oIERrpeCoClNaytryS3nYU)
+    username: ENC(S8qX2951mrx7H100uifIdrJPizgxCHyNXQGuVdN87JTrT3WIo4mYeXNXkSC8To1B)
+    password: ENC(wx1OIC98fnnql3kmBAzd4EUV1/yRcHh9i0zxFVA8YFP7yzFiodXd1UgcwDHUrnWL)
     hikari:
       maximum-pool-size: 10
       minimum-idle: 10
@@ -72,18 +72,18 @@ springdoc:
 security:
   jwt:
     token:
-      secret-key: ENC(gFDkISN4LtWFZS3VqD8DcY/sJ7oQoSwp2IzgnQh3mZ7Uky6epMIDgk9TIZ57xfw8yOwBl5AbDKQae0SRAUJCFptIBAls44ty)r
+      secret-key: ENC(+Qh3z6Vs/t2gOrKeEYcBBW/pgwQ6XVzd2HpnjxhcULrcHj4ILjSxlQ/gye/J/QX3WocVO+fdUqSZqJYmWVOsMp5Eph14Rb1jjkDlA8TzpZgHxbJAp3dzcwxpXxlMz0yp)
 cloud:
   aws:
-    access-key: ENC(kJlFbJL+MaD3rV9fB+bQglhlbK82rlKvW0+g0hgsFJQ=)
-    secret-access-key: ENC(+hUItwfvS1Y+nU/j/zyf55o9NyB1Ak/60vbpBrNK9WGPfAMw+5XITnb06vMoknI112dFMhYA+Rw=)
+    access-key: ENC(FkurMRWpLS2WpFdQLMkoY+LX+InfAKaB+MeTAlduvo8Iu8upBdCbHCxUOr/BWIMB6lVNiEAjudEr29Dp3V0Pgg==)
+    secret-access-key: ENC(q9iscV69jad2wTy5i/FjvktTcC2yCKy+bQVFpx5RbE+B2xOO+yzyz8nwzZKsH9T44HdbroHdfecbt0TpCxDGHQonk7KYpx6wjdW8arMAPaI=)
     s3:
-      bucket: ENC(VW+RubsMNPc33D+R+NU6X81EBrgAZyWh)
-      endpoint: ENC(ZgPOwy0o4ZLHsHWokjoDi1qyYnCSJVHct8zS4JN+RduQNRldP53WlGle0E33w7f7BIJNuARXhbnEOPIVUMv+pw==)
+      bucket: ENC(8wokWdzHnGVuaQxBq8FhSPTyCrbhzzxbOZ6avTtjKjmjFX1/XlbCI3/lVX1JCtj7)
+      endpoint: ENC(9lRj8rogcOdHbIpkXcC5AUpV7MlB3AWbbTvLYzbygHl8GXEgZFG8SJSPjwRd+eK728+gHJZGHIvb+Byq9hsJcukiTXJveIOSUGpY/SVPjflSSrN9VlH8J++X+yMhni/q)
     cloudfront:
-      endpoint: ENC(7ZbtWn0aC7ctosFZt3HSzgT1sv3n3AQoVz52ZchiZrtSkq1jtWLNur5+KlRQqZqA)
+      endpoint: ENC(adIKldEPdhYmx3EdT/x3aIgLxfzWeB26JNTXCzcfZW2bBRjMw+hhjTEQW0O69OQ6+iWoeJaICI3glyQtLqLtm2bVYm7vF0bfALHaJH81lco=)
     region:
-      static: ENC(zgXzsvay+o8RHzj5+OsJwW10YuVMruaf)
+      static: ENC(vJkU8XavMdzVGfsG12iAMrFWN5pX49FIL8MZLHfFPQVO12TwBjuzji1D8Z1eh4bn)
     stack:
       auto: false
 image:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -72,10 +72,7 @@ springdoc:
 security:
   jwt:
     token:
-      secret-key: ENC(gFDkISN4LtWFZS3VqD8DcY/sJ7oQoSwp2IzgnQh3mZ7Uky6epMIDgk9TIZ57xfw8yOwBl5AbDKQae0SRAUJCFptIBAls44ty)
-  admin:
-    key: ${ADMIN_KEY}
-    token: ${ADMIN_TOKEN}
+      secret-key: ENC(gFDkISN4LtWFZS3VqD8DcY/sJ7oQoSwp2IzgnQh3mZ7Uky6epMIDgk9TIZ57xfw8yOwBl5AbDKQae0SRAUJCFptIBAls44ty)r
 cloud:
   aws:
     access-key: ENC(kJlFbJL+MaD3rV9fB+bQglhlbK82rlKvW0+g0hgsFJQ=)

--- a/backend/src/test/java/com/staccato/config/JasyptConfigTest.java
+++ b/backend/src/test/java/com/staccato/config/JasyptConfigTest.java
@@ -1,0 +1,36 @@
+package com.staccato.config;
+
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
+import org.jasypt.encryption.pbe.config.SimpleStringPBEConfig;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JasyptConfigTest {
+
+    @Test
+    public void jasypt() {
+        //given
+        StandardPBEStringEncryptor jasypt = new StandardPBEStringEncryptor();
+        SimpleStringPBEConfig config = new SimpleStringPBEConfig();
+        config.setPassword("RandomPassword");
+        config.setAlgorithm("PBEWithHMACSHA512AndAES_256");
+        config.setKeyObtentionIterations("210000");
+        config.setPoolSize("2");
+        config.setProviderName("SunJCE");
+        config.setSaltGeneratorClassName("org.jasypt.salt.RandomSaltGenerator");
+        config.setIvGeneratorClassName("org.jasypt.iv.RandomIvGenerator");
+        config.setStringOutputType("base64");
+        jasypt.setConfig(config);
+        String password = "staccato";
+
+        //when
+        String encryptedText = jasypt.encrypt(password);
+        String decryptedText = jasypt.decrypt(encryptedText);
+
+        //then
+        assertThat(encryptedText).isNotEqualTo(password);
+        assertThat(decryptedText).isEqualTo(password);
+    }
+
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #647 

## 🚩 Summary
### Github Secrets으로 관리 -> X

- Github Secrets으로만 관리되던 민감정보들을 jasypt를 활용하는 것으로 변경합니다.
  - Github Secrets의 경우 추후에 어떠한 값을 지정했는지 알 수 없는 불편함이 존재합니다.

### Submodule로 관리 -> X
- submoudle을 사용하였을 때 아래와 같은 단점이 존재합니다.

**Git 워크플로우의 복잡성**

- 서브모듈은 별도의 저장소로 관리되기 때문에 클론, 업데이트, 브랜치 관리 등에서 추가적인 커맨드와 주의가 필요합니다.

**버전 동기화 문제**

- 상위 프로젝트와 서브모듈의 버전이 자동으로 동기화되지 않아, 업데이트 시 별도로 관리해줘야 하며, 이 과정에서 버전 불일치 문제가 발생할 수 있습니다.

`따라서 jasypt를 적용하게 되었습니다.`

## 🛠️ Technical Concerns

- jasypt 빈을 등록하면서 다양한 설정값들이 존재하였는데, 웬만한 부분들은 default로 구성하였습니다.
- pool size와 같은 경우에는 아래를 참고하여 t4g.micro 기준 코어 2개이므로, 2로 설정하였습니다.

http://www.jasypt.org/general-usage.html

## 🙂 To Reviewer

- [x] @linirini 
- [x] @BurningFalls 

## 📋 To Do

- 사용되지 않는 `admin` 관련 환경변수는 삭제했는데, 한번 확인 부탁드려용