### PR TITLE
fix: Firebase Analytics 이벤트 로깅 시 매개변수 정보 누락 #675

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/util/logging/Param.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/util/logging/Param.kt
@@ -2,24 +2,24 @@ package com.on.staccato.util.logging
 
 data class Param<T : Any>(val key: String, val value: T) {
     companion object {
-        const val KEY_SDK_VERSION = "안드로이드 SDK 버전"
+        const val KEY_SDK_VERSION = "Android_SDK_version"
 
-        const val KEY_BOTTOM_SHEET_STATE = "바텀시트 상태 종류"
+        const val KEY_BOTTOM_SHEET_STATE = "bottom_sheet_state"
         const val PARAM_BOTTOM_SHEET_COLLAPSED = "COLLAPSED"
         const val PARAM_BOTTOM_SHEET_EXPANDED = "EXPANDED"
         const val PARAM_BOTTOM_SHEET_HALF_EXPANDED = "HALF_EXPANDED"
-        const val KEY_BOTTOM_SHEET_DURATION = "지속시간"
+        const val KEY_BOTTOM_SHEET_DURATION = "bottom_sheet_state_duration"
 
-        const val KEY_IS_CREATED_IN_MAIN = "메인 화면에서 만들어진 스타카토인가?"
-        const val KEY_IS_VIEWED_BY_MARKER = "마커 클릭으로 조회된 스타카토인가?"
-        const val KEY_IS_GALLERY = "갤러리에서 사진을 첨부했나?"
+        const val KEY_IS_CREATED_IN_MAIN = "is_created_in_main_activity"
+        const val KEY_IS_VIEWED_BY_MARKER = "is_viewed_from_marker_click"
+        const val KEY_IS_GALLERY = "is_attached_from_gallery"
 
-        const val KEY_FRAGMENT_NAME = "프래그먼트 이름"
-        const val PARAM_CATEGORY_LIST = "카테고리 리스트"
-        const val PARAM_CATEGORY_FRAGMENT = "카테고리 조회"
-        const val PARAM_STACCATO_FRAGMENT = "스타카토 조회"
+        const val KEY_FRAGMENT_NAME = "fragment_name"
+        const val PARAM_CATEGORY_LIST = "category_list_timeline"
+        const val PARAM_CATEGORY_FRAGMENT = "category_fragment"
+        const val PARAM_STACCATO_FRAGMENT = "staccato_fragment"
 
-        const val KEY_EXCEPTION = "예외"
-        const val KEY_EXCEPTION_MESSAGE = "예외 메시지"
+        const val KEY_EXCEPTION = "exception"
+        const val KEY_EXCEPTION_MESSAGE = "exception_message"
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #675

## 🚩 Summary
- Param.kt 파일 내부의 이벤트 파라미터 문자열 상수들을 한글에서 영문으로 변경했습니다.

## 🛠️ Technical Concerns
![image](https://github.com/user-attachments/assets/bab2a11a-9cbe-42bf-9b8e-9a802ffd4413)
Firebase Analytics에서 확인한 결과 위 사진처럼 **모든 로그에 매개변수 정보가 누락**되어있었습니다.
로깅은 되는데 매개변수 정보가 없는 것에 의문이 들어 adb로 연결해 `tag:FA 로그캣`을 살펴보니 아래와 같은 오류 메시지가 뜨고 있었습니다.
<img width="1351" alt="image" src="https://github.com/user-attachments/assets/7f437d5f-fa00-4212-b1aa-494d2d7c4687" />
이에 빠르게 한글을 영문으로 변경했고, 그 결과 아래처럼 정상적으로 매개변수 정보도 함께 로깅이 되는 것을 확인했습니다.
```kotlin
// bottom_sheet_state : 바텀 시트 상태, bottom_sheet_state_duration : 유지 시간
Logging event: origin=app,name=bottom_sheet,params=Bundle[{bottom_sheet_state=EXPANDED, ga_event_origin(_o)=app, ga_screen_class(_sc)=MainActivity, ga_screen_id(_si)=-1241891066083350676, bottom_sheet_state_duration=16.844}]

// is_viewed_from_marker_click : 마커 클릭으로 조회된 스타카토인지?
Logging event: origin=app,name=staccato_read,params=Bundle[{ga_event_origin(_o)=app, ga_screen_class(_sc)=MainActivity, ga_screen_id(_si)=-1241891066083350676, is_viewed_from_marker_click=1}]
```

이후 새로운 이벤트 로그나 매개변수를 추가한다면 [Firebase 공식문서 Analytics 오류 코드](https://firebase.google.com/docs/analytics/errors?hl=ko)를 참고하면 좋을 것 같아요~
그리고 adb로 로그가 정상적으로 기록되는지도 확인하면 좋을 것 같습니다!
adb로 FA 이벤트 로그 실시간 확인하는 법 [(출처 : Firebase 공식문서 Analytics 시작하기)](https://firebase.google.com/docs/analytics/get-started?hl=ko&platform=android)
```
// 아래 adb 명령어로 상세 로깅을 사용 설정할 수 있습니다.
adb shell setprop log.tag.FA VERBOSE
adb shell setprop log.tag.FA-SVC VERBOSE
adb logcat -v time -s FA FA-SVC
```

## 🙂 To Reviewer
커밋 1개짜리라 큰 문제가 없다면 LGTM 날려주셔도 됩니다!

## 📋 To Do
배포 후 매개변수 데이터가 정상 수집 되는지 재확인 필요