### PR TITLE
refactor: 스타카토 공유 링크 도메인 관리 방법 변경 #688

### DIFF
--- a/backend/src/main/java/com/staccato/staccato/controller/StaccatoController.java
+++ b/backend/src/main/java/com/staccato/staccato/controller/StaccatoController.java
@@ -21,6 +21,7 @@ import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.controller.docs.StaccatoControllerDocs;
 import com.staccato.staccato.service.StaccatoService;
+import com.staccato.staccato.service.StaccatoShareLinkFactory;
 import com.staccato.staccato.service.dto.request.FeelingRequest;
 import com.staccato.staccato.service.dto.request.StaccatoRequest;
 import com.staccato.staccato.service.dto.response.StaccatoDetailResponse;
@@ -98,7 +99,8 @@ public class StaccatoController implements StaccatoControllerDocs {
             @PathVariable @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.") long staccatoId
     ) {
         StaccatoShareLinkResponse staccatoShareLinkResponse = staccatoService.createStaccatoShareLink(staccatoId, member);
-        return ResponseEntity.created(URI.create("/staccatos/shared/" + staccatoShareLinkResponse.getToken()))
+        String token = StaccatoShareLinkFactory.extractToken(staccatoShareLinkResponse.shareLink());
+        return ResponseEntity.created(URI.create("/staccatos/shared/" + token))
                 .body(staccatoShareLinkResponse);
     }
 

--- a/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
+++ b/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
@@ -38,7 +38,6 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class StaccatoService {
-    private static final String SHARE_LINK_PREFIX = "https://staccato.kr/share/";
 
     private final StaccatoRepository staccatoRepository;
     private final CategoryRepository categoryRepository;
@@ -124,7 +123,7 @@ public class StaccatoService {
 
         ShareTokenPayload shareTokenPayload = new ShareTokenPayload(staccatoId, member.getId());
         String token = shareTokenProvider.create(shareTokenPayload);
-        String shareLink = SHARE_LINK_PREFIX + token;
+        String shareLink = StaccatoShareLinkFactory.create(token);
 
         return new StaccatoShareLinkResponse(staccatoId, shareLink);
     }

--- a/backend/src/main/java/com/staccato/staccato/service/StaccatoShareLinkFactory.java
+++ b/backend/src/main/java/com/staccato/staccato/service/StaccatoShareLinkFactory.java
@@ -1,0 +1,22 @@
+package com.staccato.staccato.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StaccatoShareLinkFactory {
+
+    private static String shareLinkPrefix;
+
+    public StaccatoShareLinkFactory(@Value("${staccato.share.link-prefix}") String linkPrefix) {
+        shareLinkPrefix = linkPrefix;
+    }
+
+    public static String create(String token) {
+        return shareLinkPrefix + token;
+    }
+
+    public static String extractToken(String shareLink) {
+        return shareLink.substring(shareLinkPrefix.length());
+    }
+}

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoShareLinkResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoShareLinkResponse.java
@@ -8,9 +8,4 @@ public record StaccatoShareLinkResponse(
         @Schema(example = "https://staccato.kr/share/sample-token")
         String shareLink
 ) {
-        private static final String SHARE_LINK_PREFIX = "https://staccato.kr/share/";
-
-        public String getToken() {
-                return shareLink.substring(SHARE_LINK_PREFIX.length());
-        }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -77,3 +77,7 @@ server:
       enabled: false
     include-message: never
     include-binding-errors: never
+
+staccato:
+  share:
+    link-prefix: https://stage.staccato.kr/share/

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -73,3 +73,7 @@ server:
       enabled: false
     include-message: never
     include-binding-errors: never
+
+staccato:
+  share:
+    link-prefix: http://localhost:8080/share/

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -118,3 +118,7 @@ server:
       enabled: false
     include-message: never
     include-binding-errors: never
+
+staccato:
+  share:
+    link-prefix: https://staccato.kr/share/

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
@@ -20,6 +20,7 @@ import com.staccato.fixture.staccato.StaccatoDetailResponseFixture;
 import com.staccato.fixture.staccato.StaccatoLocationResponsesFixture;
 import com.staccato.fixture.staccato.StaccatoSharedResponseFixture;
 import com.staccato.member.domain.Member;
+import com.staccato.staccato.service.StaccatoShareLinkFactory;
 import com.staccato.staccato.service.dto.request.FeelingRequest;
 import com.staccato.staccato.service.dto.request.StaccatoRequest;
 import com.staccato.staccato.service.dto.response.StaccatoDetailResponse;
@@ -27,6 +28,7 @@ import com.staccato.staccato.service.dto.response.StaccatoIdResponse;
 import com.staccato.staccato.service.dto.response.StaccatoLocationResponses;
 import com.staccato.staccato.service.dto.response.StaccatoShareLinkResponse;
 
+import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,6 +41,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.thymeleaf.spring6.util.FieldUtils;
 
 class StaccatoControllerTest extends ControllerTest {
 
@@ -393,6 +396,10 @@ class StaccatoControllerTest extends ControllerTest {
     @Test
     void createStaccatoShareLink() throws Exception {
         // given
+        Field shareLinkPrefixField = StaccatoShareLinkFactory.class.getDeclaredField("shareLinkPrefix");
+        shareLinkPrefixField.setAccessible(true);
+        shareLinkPrefixField.set(null, "https://staccato.kr/share/");
+
         long staccatoId = 1L;
         StaccatoShareLinkResponse response = new StaccatoShareLinkResponse(staccatoId, "https://staccato.kr/share/sample-token");
         when(staccatoService.createStaccatoShareLink(any(), any())).thenReturn(response);

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
@@ -360,7 +360,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
 
         // when
         StaccatoShareLinkResponse response = staccatoService.createStaccatoShareLink(staccato.getId(), member);
-        String token = response.getToken();
+        String token = StaccatoShareLinkFactory.extractToken(response.shareLink());
 
         // then
         assertThat(token).isNotNull();
@@ -375,7 +375,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Staccato staccato = saveStaccatoWithImages(category);
 
         StaccatoShareLinkResponse response = staccatoService.createStaccatoShareLink(staccato.getId(), member);
-        String token = response.getToken();
+        String token = StaccatoShareLinkFactory.extractToken(response.shareLink());
 
         // when & then
         assertThatCode(() -> shareTokenProvider.extractStaccatoId(token))
@@ -392,7 +392,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Staccato staccato = saveStaccatoWithImages(category);
 
         StaccatoShareLinkResponse response = staccatoService.createStaccatoShareLink(staccato.getId(), member);
-        String token = response.getToken();
+        String token = StaccatoShareLinkFactory.extractToken(response.shareLink());
 
         // when
         Claims claims = shareTokenProvider.getPayload(token);
@@ -410,7 +410,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Staccato staccato = saveStaccatoWithImages(category);
 
         StaccatoShareLinkResponse response = staccatoService.createStaccatoShareLink(staccato.getId(), member);
-        String token = response.getToken();
+        String token = StaccatoShareLinkFactory.extractToken(response.shareLink());
 
         // when & then
         assertThatCode(() -> shareTokenProvider.validateToken(token))


### PR DESCRIPTION
## ⭐️ Issue Number
- #688 

## 🚩 Summary
- 도메인을 포함하는 공유 링크는 개발 환경에 따라 달라지기 때문에, `yml`파일로 도메인을 관리하도록 변경했습니다.
- `StaccatoShareLinkFactory` 클래스를 만들어, 공유 링크 관련 작업을 위임했습니다.
