### PR TITLE
refactor: 네트워크 패키지 분리 및 CallAdpater 테스트의 이미지 비즈니스 로직 제거 #710

### DIFF
--- a/android/Staccato_AN/app/proguard-rules.pro
+++ b/android/Staccato_AN/app/proguard-rules.pro
@@ -20,4 +20,4 @@
 # hide the original source file name.
 -renamesourcefileattribute SourceFile
 
--keepnames, allowobfuscation class com.on.staccato.data.ApiResult
+-keepnames, allowobfuscation class com.on.staccato.data.network.ApiResult

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/StaccatoApplication.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/StaccatoApplication.kt
@@ -3,8 +3,8 @@ package com.on.staccato
 import android.app.Application
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.on.staccato.data.PlacesClientProvider
-import com.on.staccato.data.StaccatoClient
 import com.on.staccato.data.UserInfoPreferencesManager
+import com.on.staccato.data.network.StaccatoClient
 import dagger.hilt.android.HiltAndroidApp
 import retrofit2.Retrofit
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/StaccatoClient.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/StaccatoClient.kt
@@ -3,6 +3,7 @@ package com.on.staccato.data
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.on.staccato.BuildConfig
 import com.on.staccato.data.dto.ErrorResponse
+import com.on.staccato.data.network.ApiResultCallAdapterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryApiService.kt
@@ -1,10 +1,10 @@
 package com.on.staccato.data.category
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoriesResponse
 import com.on.staccato.data.dto.category.CategoryCreationResponse
 import com.on.staccato.data.dto.category.CategoryRequest
 import com.on.staccato.data.dto.category.CategoryResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryDataSource.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.category
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoriesResponse
 import com.on.staccato.data.dto.category.CategoryCreationResponse
 import com.on.staccato.data.dto.category.CategoryResponse
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.NewCategory
 
 interface CategoryDataSource {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryDefaultRepository.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.category
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoryCreationResponse
 import com.on.staccato.data.dto.mapper.toDomain
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.model.Category
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.NewCategory

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryRemoteDataSource.kt
@@ -1,10 +1,10 @@
 package com.on.staccato.data.category
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoriesResponse
 import com.on.staccato.data.dto.category.CategoryCreationResponse
 import com.on.staccato.data.dto.category.CategoryResponse
 import com.on.staccato.data.dto.mapper.toDto
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.NewCategory
 import javax.inject.Inject
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentApiService.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.comment
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.comment.CommentRequest
 import com.on.staccato.data.dto.comment.CommentUpdateRequest
 import com.on.staccato.data.dto.comment.CommentsResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentDataSource.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.comment
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.comment.CommentRequest
 import com.on.staccato.data.dto.comment.CommentUpdateRequest
 import com.on.staccato.data.dto.comment.CommentsResponse
+import com.on.staccato.data.network.ApiResult
 
 interface CommentDataSource {
     suspend fun getComments(staccatoId: Long): ApiResult<CommentsResponse>

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentDefaultRepository.kt
@@ -1,10 +1,10 @@
 package com.on.staccato.data.comment
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.comment.CommentUpdateRequest
 import com.on.staccato.data.dto.mapper.toDomain
 import com.on.staccato.data.dto.mapper.toDto
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.model.Comment
 import com.on.staccato.domain.model.NewComment
 import com.on.staccato.domain.repository.CommentRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/comment/CommentRemoteDataSource.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.comment
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.comment.CommentRequest
 import com.on.staccato.data.dto.comment.CommentUpdateRequest
 import com.on.staccato.data.dto.comment.CommentsResponse
+import com.on.staccato.data.network.ApiResult
 import javax.inject.Inject
 
 class CommentRemoteDataSource

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/image/ImageApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/image/ImageApiService.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.image
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.image.ImageResponse
+import com.on.staccato.data.network.ApiResult
 import okhttp3.MultipartBody
 import retrofit2.http.Multipart
 import retrofit2.http.POST

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/image/ImageDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/image/ImageDefaultRepository.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.image
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.image.ImageResponse
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.repository.ImageRepository
 import okhttp3.MultipartBody
 import javax.inject.Inject

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginApiService.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.login
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.login.NicknameLoginRequest
 import com.on.staccato.data.dto.login.NicknameLoginResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.Body
 import retrofit2.http.POST
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginDataSource.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.login
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.login.NicknameLoginResponse
+import com.on.staccato.data.network.ApiResult
 
 interface LoginDataSource {
     suspend fun requestLoginWithNickname(nickname: String): ApiResult<NicknameLoginResponse>

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginDefaultRepository.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.login
 
 import com.on.staccato.StaccatoApplication
-import com.on.staccato.data.ApiResult
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.repository.LoginRepository
 import javax.inject.Inject
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/login/LoginRemoteDataSource.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.login
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.login.NicknameLoginRequest
 import com.on.staccato.data.dto.login.NicknameLoginResponse
+import com.on.staccato.data.network.ApiResult
 import javax.inject.Inject
 
 class LoginRemoteDataSource

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/member/MemberApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/member/MemberApiService.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.member
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.member.RecoveryCodeResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.POST
 import retrofit2.http.Query
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/member/MemberDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/member/MemberDefaultRepository.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.member
 
 import com.on.staccato.StaccatoApplication
-import com.on.staccato.data.ApiResult
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.repository.MemberRepository
 import javax.inject.Inject
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageApiService.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.mypage
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.mypage.MemberProfileResponse
 import com.on.staccato.data.dto.mypage.ProfileImageResponse
+import com.on.staccato.data.network.ApiResult
 import okhttp3.MultipartBody
 import retrofit2.http.GET
 import retrofit2.http.Multipart

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageDefaultRepository.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.mypage
 
-import com.on.staccato.data.ApiResult
-import com.on.staccato.data.Success
 import com.on.staccato.data.dto.mapper.toDomain
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.Success
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.model.MemberProfile
 import com.on.staccato.domain.repository.MyPageRepository
 import okhttp3.MultipartBody

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageRemoteDataSource.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.mypage
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.mypage.MemberProfileResponse
 import com.on.staccato.data.dto.mypage.ProfileImageResponse
+import com.on.staccato.data.network.ApiResult
 import okhttp3.MultipartBody
 
 interface MyPageRemoteDataSource {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageRemoteDataSourceImpl.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/mypage/MyPageRemoteDataSourceImpl.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.data.mypage
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.mypage.MemberProfileResponse
 import com.on.staccato.data.dto.mypage.ProfileImageResponse
+import com.on.staccato.data.network.ApiResult
 import okhttp3.MultipartBody
 import javax.inject.Inject
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResult.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResult.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import com.on.staccato.data.dto.Status
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import com.on.staccato.StaccatoApplication.Companion.retrofit
 import com.on.staccato.data.StaccatoClient.getErrorResponse

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.network
 
 import com.on.staccato.StaccatoApplication.Companion.retrofit
-import com.on.staccato.data.StaccatoClient.getErrorResponse
 import com.on.staccato.data.dto.ErrorResponse
 import com.on.staccato.data.dto.Status
+import com.on.staccato.data.network.StaccatoClient.getErrorResponse
 import okhttp3.Request
 import okhttp3.ResponseBody
 import okio.Timeout

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapter.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import retrofit2.Call
 import retrofit2.CallAdapter

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapterFactory.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapterFactory.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import retrofit2.Call
 import retrofit2.CallAdapter

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultHandler.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import com.on.staccato.presentation.util.ExceptionState
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/HeaderInterceptor.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/HeaderInterceptor.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/StaccatoClient.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/StaccatoClient.kt
@@ -1,9 +1,10 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.on.staccato.BuildConfig
+import com.on.staccato.data.HeaderInterceptor
+import com.on.staccato.data.TokenManager
 import com.on.staccato.data.dto.ErrorResponse
-import com.on.staccato.data.network.ApiResultCallAdapterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/StaccatoClient.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/StaccatoClient.kt
@@ -2,8 +2,6 @@ package com.on.staccato.data.network
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.on.staccato.BuildConfig
-import com.on.staccato.data.HeaderInterceptor
-import com.on.staccato.data.TokenManager
 import com.on.staccato.data.dto.ErrorResponse
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/TokenManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/TokenManager.kt
@@ -1,4 +1,4 @@
-package com.on.staccato.data
+package com.on.staccato.data.network
 
 import com.on.staccato.StaccatoApplication
 import kotlinx.coroutines.Dispatchers

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoApiService.kt
@@ -1,12 +1,12 @@
 package com.on.staccato.data.staccato
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.staccato.FeelingRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationResponse
 import com.on.staccato.data.dto.staccato.StaccatoLocationResponse
 import com.on.staccato.data.dto.staccato.StaccatoResponse
 import com.on.staccato.data.dto.staccato.StaccatoUpdateRequest
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoDataSource.kt
@@ -1,12 +1,12 @@
 package com.on.staccato.data.staccato
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.staccato.FeelingRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationResponse
 import com.on.staccato.data.dto.staccato.StaccatoLocationResponse
 import com.on.staccato.data.dto.staccato.StaccatoResponse
 import com.on.staccato.data.dto.staccato.StaccatoUpdateRequest
+import com.on.staccato.data.network.ApiResult
 
 interface StaccatoDataSource {
     suspend fun fetchStaccatos(): ApiResult<StaccatoLocationResponse>

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoDefaultRepository.kt
@@ -1,12 +1,12 @@
 package com.on.staccato.data.staccato
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.mapper.toDomain
 import com.on.staccato.data.dto.mapper.toFeelingRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationResponse
 import com.on.staccato.data.dto.staccato.StaccatoUpdateRequest
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.model.Feeling
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.model.StaccatoLocation

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/staccato/StaccatoRemoteDataSource.kt
@@ -1,12 +1,12 @@
 package com.on.staccato.data.staccato
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.staccato.FeelingRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationRequest
 import com.on.staccato.data.dto.staccato.StaccatoCreationResponse
 import com.on.staccato.data.dto.staccato.StaccatoLocationResponse
 import com.on.staccato.data.dto.staccato.StaccatoResponse
 import com.on.staccato.data.dto.staccato.StaccatoUpdateRequest
+import com.on.staccato.data.network.ApiResult
 import javax.inject.Inject
 
 class StaccatoRemoteDataSource

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimeLineApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimeLineApiService.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.timeline
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.timeline.TimelineResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.GET
 import retrofit2.http.Query
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineDataSource.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.timeline
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.timeline.TimelineResponse
+import com.on.staccato.data.network.ApiResult
 
 interface TimelineDataSource {
     suspend fun getTimeline(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineDefaultRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineDefaultRepository.kt
@@ -1,9 +1,9 @@
 package com.on.staccato.data.timeline
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.mapper.toCategoryCandidates
 import com.on.staccato.data.dto.mapper.toDomain
-import com.on.staccato.data.handle
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.handle
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.Timeline
 import com.on.staccato.domain.repository.TimelineRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineRemoteDataSource.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/timeline/TimelineRemoteDataSource.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.data.timeline
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.timeline.TimelineResponse
+import com.on.staccato.data.network.ApiResult
 import javax.inject.Inject
 
 class TimelineRemoteDataSource

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/CategoryRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/CategoryRepository.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoryCreationResponse
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.Category
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.NewCategory

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/CommentRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/CommentRepository.kt
@@ -1,6 +1,6 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.Comment
 import com.on.staccato.domain.model.NewComment
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/ImageRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/ImageRepository.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.image.ImageResponse
+import com.on.staccato.data.network.ApiResult
 import okhttp3.MultipartBody
 
 interface ImageRepository {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/LoginRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/LoginRepository.kt
@@ -1,6 +1,6 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
+import com.on.staccato.data.network.ApiResult
 
 interface LoginRepository {
     suspend fun loginWithNickname(nickname: String): ApiResult<Unit>

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/MemberRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/MemberRepository.kt
@@ -1,6 +1,6 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
+import com.on.staccato.data.network.ApiResult
 
 interface MemberRepository {
     suspend fun fetchTokenWithRecoveryCode(recoveryCode: String): ApiResult<Unit>

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/MyPageRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/MyPageRepository.kt
@@ -1,6 +1,6 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.MemberProfile
 import okhttp3.MultipartBody
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/StaccatoRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/StaccatoRepository.kt
@@ -1,7 +1,7 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.staccato.StaccatoCreationResponse
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.Feeling
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.model.StaccatoLocation

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/TimelineRepository.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/repository/TimelineRepository.kt
@@ -1,6 +1,6 @@
 package com.on.staccato.domain.repository
 
-import com.on.staccato.data.ApiResult
+import com.on.staccato.data.network.ApiResult
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.Timeline
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/category/viewmodel/CategoryViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/category/viewmodel/CategoryViewModel.kt
@@ -4,10 +4,10 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.ApiResult
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.Category
 import com.on.staccato.domain.repository.CategoryRepository
 import com.on.staccato.presentation.category.model.CategoryUiModel

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -7,12 +7,12 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.category.CategoryCreationResponse
 import com.on.staccato.data.dto.image.ImageResponse
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.NewCategory
 import com.on.staccato.domain.repository.CategoryRepository
 import com.on.staccato.domain.repository.ImageRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categoryupdate/viewmodel/CategoryUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categoryupdate/viewmodel/CategoryUpdateViewModel.kt
@@ -7,11 +7,11 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.ApiResult
 import com.on.staccato.data.dto.image.ImageResponse
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.Category
 import com.on.staccato.domain.model.NewCategory
 import com.on.staccato.domain.repository.CategoryRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/login/viewmodel/LoginViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/login/viewmodel/LoginViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.Nickname
 import com.on.staccato.domain.model.NicknameState
 import com.on.staccato.domain.repository.LoginRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/main/viewmodel/SharedViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.MemberProfile
 import com.on.staccato.domain.repository.MyPageRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/map/viewmodel/MapsViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/map/viewmodel/MapsViewModel.kt
@@ -7,9 +7,9 @@ import androidx.lifecycle.viewModelScope
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.Marker
 import com.google.android.gms.maps.model.MarkerOptions
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.StaccatoLocation
 import com.on.staccato.domain.repository.LocationRepository
 import com.on.staccato.domain.repository.StaccatoRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/mypage/viewmodel/MyPageViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/mypage/viewmodel/MyPageViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.MemberProfile
 import com.on.staccato.domain.repository.MyPageRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/recovery/viewmodel/RecoveryViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/recovery/viewmodel/RecoveryViewModel.kt
@@ -3,9 +3,9 @@ package com.on.staccato.presentation.recovery.viewmodel
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.repository.MemberRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData
 import com.on.staccato.presentation.common.SingleLiveData

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/comments/StaccatoCommentsViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/comments/StaccatoCommentsViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.NewComment
 import com.on.staccato.domain.repository.CommentRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/viewmodel/StaccatoViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccato/viewmodel/StaccatoViewModel.kt
@@ -4,9 +4,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.Feeling
 import com.on.staccato.domain.repository.StaccatoRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModel.kt
@@ -10,9 +10,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.tasks.Task
 import com.on.staccato.data.image.ImageDefaultRepository
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.CategoryCandidate
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.repository.LocationRepository

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -9,9 +9,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.android.gms.tasks.Task
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.CategoryCandidate
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.CategoryCandidates.Companion.emptyCategoryCandidates

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/timeline/viewmodel/TimelineViewModel.kt
@@ -5,9 +5,9 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.on.staccato.data.onException
-import com.on.staccato.data.onServerError
-import com.on.staccato.data.onSuccess
+import com.on.staccato.data.network.onException
+import com.on.staccato.data.network.onServerError
+import com.on.staccato.data.network.onSuccess
 import com.on.staccato.domain.model.Timeline
 import com.on.staccato.domain.repository.TimelineRepository
 import com.on.staccato.presentation.common.MutableSingleLiveData

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
@@ -6,6 +6,10 @@ import com.on.staccato.data.dto.GetResponse
 import com.on.staccato.data.dto.PostResponse
 import com.on.staccato.data.dto.image.ImageResponse
 import com.on.staccato.data.image.ImageApiService
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.Exception
+import com.on.staccato.data.network.ServerError
+import com.on.staccato.data.network.Success
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.mockwebserver.MockResponse

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
@@ -3,9 +3,8 @@ package com.on.staccato.data
 import com.on.staccato.CoroutinesTestExtension
 import com.on.staccato.StaccatoApplication.Companion.retrofit
 import com.on.staccato.data.dto.GetResponse
+import com.on.staccato.data.dto.ImagePostResponse
 import com.on.staccato.data.dto.PostResponse
-import com.on.staccato.data.dto.image.ImageResponse
-import com.on.staccato.data.image.ImageApiService
 import com.on.staccato.data.network.ApiResult
 import com.on.staccato.data.network.Exception
 import com.on.staccato.data.network.ServerError
@@ -26,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 class ApiResultCallAdapterTest {
     private val mockWebServer: MockWebServer = MockWebServer()
 
-    private lateinit var imageApiService: ImageApiService
     private lateinit var fakeApiService: FakeApiService
 
     @BeforeEach
@@ -34,7 +32,6 @@ class ApiResultCallAdapterTest {
         mockWebServer.start()
 
         retrofit = buildRetrofitFor(mockWebServer)
-        imageApiService = retrofit.create(ImageApiService::class.java)
         fakeApiService = retrofit.create(FakeApiService::class.java)
     }
 
@@ -128,7 +125,7 @@ class ApiResultCallAdapterTest {
         mockWebServer.enqueue(serverError)
 
         runTest {
-            val actual: ApiResult<ImageResponse> = imageApiService.postImage(imageFile = createFakeImageFile())
+            val actual: ApiResult<ImagePostResponse> = fakeApiService.postImage(imageFile = createFakeImageFile())
 
             assertThat(actual).isInstanceOf(ServerError::class.java)
         }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/FakeApiService.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/FakeApiService.kt
@@ -1,13 +1,17 @@
 package com.on.staccato.data
 
 import com.on.staccato.data.dto.GetResponse
+import com.on.staccato.data.dto.ImagePostResponse
 import com.on.staccato.data.dto.PostRequest
 import com.on.staccato.data.dto.PostResponse
 import com.on.staccato.data.network.ApiResult
+import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
 
 interface FakeApiService {
@@ -25,4 +29,10 @@ interface FakeApiService {
     suspend fun delete(
         @Path("id") id: Long,
     ): ApiResult<Unit>
+
+    @Multipart
+    @POST("/images")
+    suspend fun postImage(
+        @Part imageFile: MultipartBody.Part,
+    ): ApiResult<ImagePostResponse>
 }

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/FakeApiService.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/FakeApiService.kt
@@ -3,6 +3,7 @@ package com.on.staccato.data
 import com.on.staccato.data.dto.GetResponse
 import com.on.staccato.data.dto.PostRequest
 import com.on.staccato.data.dto.PostResponse
+import com.on.staccato.data.network.ApiResult
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/MockWebServerProvider.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/MockWebServerProvider.kt
@@ -1,6 +1,7 @@
 package com.on.staccato.data
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.on.staccato.data.network.ApiResultCallAdapterFactory
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.mockwebserver.MockResponse

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/dto/ImagePostResponse.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/dto/ImagePostResponse.kt
@@ -1,0 +1,9 @@
+package com.on.staccato.data.dto
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ImagePostResponse(
+    @SerialName("imageUrl") val imageUrl: String,
+)

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatocreation/viewmodel/StaccatoCreationViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.presentation.staccatocreation.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.on.staccato.data.Success
 import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.data.network.Success
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.TARGET_CATEGORY_ID
 import com.on.staccato.domain.model.categoryCandidateWithId1

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.on.staccato.presentation.staccatoupdate.viewmodel
 
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
-import com.on.staccato.data.Success
 import com.on.staccato.data.image.ImageDefaultRepository
+import com.on.staccato.data.network.Success
 import com.on.staccato.domain.model.CategoryCandidates
 import com.on.staccato.domain.model.Staccato
 import com.on.staccato.domain.model.TARGET_STACCATO_ID

--- a/android/Staccato_AN/app/src/test/java/study/InlineStudyTest.kt
+++ b/android/Staccato_AN/app/src/test/java/study/InlineStudyTest.kt
@@ -1,9 +1,9 @@
 package study
 
-import com.on.staccato.data.ApiResult
-import com.on.staccato.data.Exception
-import com.on.staccato.data.ServerError
-import com.on.staccato.data.Success
+import com.on.staccato.data.network.ApiResult
+import com.on.staccato.data.network.Exception
+import com.on.staccato.data.network.ServerError
+import com.on.staccato.data.network.Success
 import com.on.staccato.domain.model.Category
 import com.on.staccato.domain.model.CategoryStaccato
 import com.on.staccato.domain.model.Member


### PR DESCRIPTION
## ⭐️ Issue Number
- #710 

<br>

## 🚩 Summary
- data/network 패키지 추가
- CallAdapter 테스트 내 이미지 비즈니스 로직을 FakeApiService를 이용해 제거

<br>

## 🙂 To Reviewer
data/network 패키지를 추가하면서 변경된 파일이 많지만 실제 코드가 변경된 파일은 CallAdapterTest뿐입니다. 
따라서 CallAdapterTest를 중심으로 리뷰해 주시면 됩니다!

네트워크 응답을 처리하는 파일들을 data/network 패키지로 이동시켰습니다.
network라는 네이밍이 적절할지 고민되는데 좋은 의견 있으시면 언제든 환영입니다!