### PR TITLE
build: Android CI 테스트 로깅 출력 #717

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -25,6 +25,8 @@ jobs:
 
     permissions:
       contents: read
+      checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -67,11 +69,17 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Run ktlint
+      - name: Check Lint
         run: ./gradlew ktlintCheck
 
-      - name: Run test
+      - name: Run Test
         run: ./gradlew test
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: always()
+        with:
+          files: app/build/test-results/**/*.xml
 
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -80,6 +80,3 @@ jobs:
         if: always()
         with:
           files: app/build/test-results/**/*.xml
-
-      - name: Build with Gradle
-        run: ./gradlew build

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,7 +3,7 @@ name: Android CI for develop
 on:
   pull_request:
     paths: 'android/**'
-    branches: [ "develop", "release-an", "main" ]
+    branches: [ "develop", "main" ]
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -3,7 +3,8 @@ name: Android CI for develop
 on:
   pull_request:
     paths: 'android/**'
-    branches: [ "develop", "main" ]
+    branches: [ "develop" ]
+  workflow_dispatch:
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: ./gradlew ktlintCheck
 
       - name: Run Test
-        run: ./gradlew test
+        run: ./gradlew testDebugUnitTest --stacktrace --no-build-cache --no-parallel
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2


### PR DESCRIPTION
## ⭐️ Issue Number
- #717 

## 🚩 Summary
- [Action : Publish Test Results](https://github.com/marketplace/actions/publish-test-results) 을 활용해 테스트 로그를 코멘트로 남깁니다.
- 테스트 실행 명령어 변경
  ```
  ./gradlew testDebugUnitTest --stacktrace --no-build-cache --no-parallel
  ```
  - `testDebugUnitTest` : 디버그 모드에서의 테스트만 실행
  - `--stacktrace` : 에러 발생 시 디버깅 로그 출력
  - `--no-build-cache` : 빌드 캐시 사용하지 않음, 모든 테스트를 새로 실행하여 신뢰도 보장
  - `--no-parallel` : 순차적 실행, 간헐적인 에러 발생 방지
- 브랜치 실행 조건 수정
  - `release-an`과 `main` 브랜치는 제거했습니다.
  - `workflow_dispatch`: base 브랜치에 병합되지 않은 CI 워크플로우를 수동으로 실행할 수 있는 조건입니다.
    - 임시로 CI를 수정하고 실행할 수 있습니다(CI 수정사항 반영 전 확인, 임시 디버깅에 용이)
- Build 단계 제거
  - test 실행 시 자동으로 build를 진행하기 때문에 Build 단계는 제거하였습니다.

## 🙂 To Reviewer
CI가 시간이 오래걸려서, Build 단계를 제거하고 Debug Test만 실행하도록 변경했습니다.
`./gradlew test` ➡️  `./gradlew testDebugUnitTest`
수정 사항이 괜찮은지 확인해주세요!
  - `test`: Debug, Release 두 모드에 대한 테스트 전부 실행
    - 장점: Release(배포) 모드에서도 테스트 통과 여부를 알 수 있어 앱 안정성 보장
    - 단점: 기능 병합 시 시간이 오래걸림
  - `testDebugUnitTest`: Debug 모드에 대한 테스트만 실행
    - 장점: CI 워크플로의 시간이 단축됨, Debug 테스트로 실질적으로 필요한 부분만 빠르게 확인 가능
    - 단점: Release 모드에서 테스트가 통과하지 않을 수도 있음

## 📋 To Do
- UI Test를 위한 CI 워크플로 수정