### PR TITLE
refactor: swagger 예시 명세에 맞게 수정 #714

### DIFF
--- a/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/request/LoginRequest.java
@@ -5,13 +5,14 @@ import java.util.Objects;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원을 등록하기 위한 요청 형식입니다.")
 public record LoginRequest(
-        @Schema(example = "hi_staccato")
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         @NotNull(message = "닉네임을 입력해주세요.")
         @Size(min = 1, max = 10, message = "1자 이상 10자 이하의 닉네임으로 설정해주세요.")
         String nickname

--- a/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
+++ b/backend/src/main/java/com/staccato/auth/service/dto/response/LoginResponse.java
@@ -1,10 +1,12 @@
 package com.staccato.auth.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "회원 등록 시 발급되는 토큰에 대한 응답 형식입니다.")
 public record LoginResponse(
-        @Schema(example = "{tokenString}")
+        @Schema(example = SwaggerExamples.TOKEN)
         String token
 ) {
 }

--- a/backend/src/main/java/com/staccato/category/service/dto/request/CategoryReadRequest.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/request/CategoryReadRequest.java
@@ -11,9 +11,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리 목록 조회시 정렬과 필터링 조건을 위한 요청 형식입니다.")
 public record CategoryReadRequest(
-        @Schema(description = "사용할 필터링을 구분자(,)로 구분하여 나열 (WITH_TERM, WITHOUT_TERM / 대소문자 구분 X)", example = "WITH_TERM")
+        @Schema(description = "사용할 필터링을 구분자(,)로 구분하여 나열 (WITH_TERM, WITHOUT_TERM / 대소문자 구분 X)", example = "WITHOUT_TERM")
         String filters,
-        @Schema(description = "정렬 기준 (UPDATED, NEWEST, OLDEST / 대소문자 구분 X)", example = "NEWEST")
+        @Schema(description = "정렬 기준 (UPDATED, NEWEST, OLDEST / 대소문자 구분 X)", example = "UPDATED")
         String sort
 ) {
     private static final String DELIMITER = ",";

--- a/backend/src/main/java/com/staccato/category/service/dto/request/CategoryRequest.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/request/CategoryRequest.java
@@ -1,6 +1,8 @@
 package com.staccato.category.service.dto.request;
 
 import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
+
 import java.time.LocalDate;
 import java.util.Objects;
 
@@ -13,19 +15,19 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리를 생성/수정하기 위한 요청 형식입니다.")
 public record CategoryRequest(
-        @Schema(example = "http://example.com/london.png")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         String categoryThumbnailUrl,
-        @Schema(example = "런던 여행")
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
         @NotBlank(message = "카테고리 제목을 입력해주세요.")
         @Size(max = 30, message = "제목은 공백 포함 30자 이하로 설정해주세요.")
         String categoryTitle,
-        @Schema(example = "런던 시내 탐방")
+        @Schema(example = SwaggerExamples.CATEGORY_DESCRIPTION)
         @Size(max = 500, message = "내용의 최대 허용 글자수는 공백 포함 500자입니다.")
         String description,
-        @Schema(example = "2024-07-27")
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate startAt,
-        @Schema(example = "2024-07-29")
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @DateTimeFormat(pattern = "yyyy-MM-dd")
         LocalDate endAt) {
     public CategoryRequest {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponse.java
@@ -1,6 +1,7 @@
 package com.staccato.category.service.dto.response;
 
 import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 import java.time.LocalDate;
 import java.util.List;
@@ -12,20 +13,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리에 대한 응답 형식입니다.")
 public record CategoryDetailResponse(
-    @Schema(example = "1")
+    @Schema(example = SwaggerExamples.CATEGORY_ID)
     Long categoryId,
-    @Schema(example = "https://example.com/categorys/geumohrm.jpg")
+    @Schema(example = SwaggerExamples.IMAGE_URL)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String categoryThumbnailUrl,
-    @Schema(example = "런던 여행")
+    @Schema(example = SwaggerExamples.CATEGORY_TITLE)
     String categoryTitle,
-    @Schema(example = "런던 시내 탐방")
+    @Schema(example = SwaggerExamples.CATEGORY_DESCRIPTION)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String description,
-    @Schema(example = "2024-07-27")
+    @Schema(example = SwaggerExamples.CATEGORY_START_AT)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     LocalDate startAt,
-    @Schema(example = "2024-07-29")
+    @Schema(example = SwaggerExamples.CATEGORY_END_AT)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     LocalDate endAt,
     List<MemberResponse> mates,

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryIdResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryIdResponse.java
@@ -1,10 +1,12 @@
 package com.staccato.category.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리를 생성했을 때에 대한 응답 형식입니다.")
 public record CategoryIdResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
         long categoryId
 ) {
 }

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryNameResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryNameResponse.java
@@ -1,14 +1,15 @@
 package com.staccato.category.service.dto.response;
 
 import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "특정 날짜를 포함하는 카테고리 목록 조회 시 각각의 카테고리에 대한 응답 형식입니다.")
 public record CategoryNameResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
         Long categoryId,
-        @Schema(example = "런던 여행")
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
         String categoryTitle
 ) {
     public CategoryNameResponse(Category category) {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponse.java
@@ -4,22 +4,23 @@ import java.time.LocalDate;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리 목록 조회 시 각각의 카테고리에 대한 응답 형식입니다.")
 public record CategoryResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
         Long categoryId,
-        @Schema(example = "https://example.com/categories/geumohrm.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String categoryThumbnailUrl,
-        @Schema(example = "런던 여행")
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
         String categoryTitle,
-        @Schema(example = "2024-07-27")
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate startAt,
-        @Schema(example = "2024-07-29")
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt
 ) {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/StaccatoResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/StaccatoResponse.java
@@ -3,20 +3,21 @@ package com.staccato.category.service.dto.response;
 import java.time.LocalDateTime;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리 조회 시 보여주는 스타카토의 정보에 대한 응답 형식입니다.")
 public record StaccatoResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         Long staccatoId,
-        @Schema(example = "런던 아이")
+        @Schema(example = SwaggerExamples.STACCATO_TITLE)
         String staccatoTitle,
-        @Schema(example = "https://example.com/categories/london_eye.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String staccatoImageUrl,
-        @Schema(example = "2024-07-27T11:58:20")
+        @Schema(example = SwaggerExamples.STACCATO_VISITED_AT)
         LocalDateTime visitedAt
 ) {
     public StaccatoResponse(Staccato staccato) {

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequestV2.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentRequestV2.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import com.staccato.comment.domain.Comment;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 
@@ -13,11 +14,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "댓글 생성 시 요청 형식입니다.")
 public record CommentRequestV2(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         @NotNull(message = "스타카토를 선택해주세요.")
         @Min(value = 1L, message = "스타카토 식별자는 양수로 이루어져야 합니다.")
         Long staccatoId,
-        @Schema(example = "예시 댓글 내용")
+        @Schema(example = SwaggerExamples.COMMENT_CONTENT)
         @NotBlank(message = "댓글 내용을 입력해주세요.")
         @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
         String content

--- a/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/request/CommentUpdateRequest.java
@@ -3,11 +3,13 @@ package com.staccato.comment.service.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "댓글 수정 시 요청 형식입니다.")
 public record CommentUpdateRequest(
-        @Schema(example = "예시 수정된 댓글 내용")
+        @Schema(example = SwaggerExamples.COMMENT_CONTENT)
         @NotBlank(message = "댓글 내용을 입력해주세요.")
         @Size(max = 500, message = "댓글은 공백 포함 500자 이하로 입력해주세요.")
         String content

--- a/backend/src/main/java/com/staccato/comment/service/dto/response/CommentResponse.java
+++ b/backend/src/main/java/com/staccato/comment/service/dto/response/CommentResponse.java
@@ -2,21 +2,22 @@ package com.staccato.comment.service.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.comment.domain.Comment;
+import com.staccato.config.swagger.SwaggerExamples;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토에 대해 함께 한 친구와 나눈 대화 응답 형식입니다.")
 public record CommentResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.COMMENT_ID)
         Long commentId,
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.MEMBER_ID)
         Long memberId,
-        @Schema(example = "카고")
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
-        @Schema(example = "https://example.com/images/kargo.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String memberImageUrl,
-        @Schema(example = "즐거운 추억")
+        @Schema(example = SwaggerExamples.COMMENT_CONTENT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String content
 ) {

--- a/backend/src/main/java/com/staccato/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/staccato/config/OpenApiConfig.java
@@ -19,8 +19,7 @@ public class OpenApiConfig {
     public OpenAPI customOpenAPI() {
         return new OpenAPI()
                 .servers(Arrays.asList(
-                        new Server().url("https://stage.staccato.kr").description("Stage Server URL"),
-                        new Server().url("https://dev.staccato.kr").description("Dev Server URL"),
+                        new Server().url("https://stage.staccato.kr").description("Development Server URL"),
                         new Server().url("http://localhost:8080").description("Local Server URL")
                 ))
                 .addSecurityItem(new SecurityRequirement().addList("Auth"))

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -1,0 +1,28 @@
+package com.staccato.config.swagger;
+
+public class SwaggerExamples {
+    public static final String CATEGORY_ID = "1";
+    public static final String CATEGORY_TITLE = "소소한 일상 기록";
+    public static final String CATEGORY_DESCRIPTION = "무심코 지나친 일상 속 소중한 순간들을 모아두었습니다.";
+    public static final String CATEGORY_START_AT = "2024-01-01";
+    public static final String CATEGORY_END_AT = "2024-12-31";
+    public static final String STACCATO_ID = "1";
+    public static final String STACCATO_TITLE = "햇살 좋은 오후, 창가에서";
+    public static final String STACCATO_VISITED_AT = "2024-06-01T14:30:00";
+    public static final String STACCATO_PLACE_NAME = "스타벅스";
+    public static final String STACCATO_ADDRESS = "서울특별시 마포구 양화로 123";
+    public static final String STACCATO_LATITUDE = "37.5564";
+    public static final String STACCATO_LONGITUDE = "126.9220";
+    public static final String COMMENT_ID = "1";
+    public static final String COMMENT_CONTENT = "아무 약속도 없는 하루, 창가에 앉아 멍하니 하늘을 바라봤다.";
+    public static final String MEMBER_ID = "1";
+    public static final String MEMBER_CODE = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
+    public static final String MEMBER_NICKNAME = "김스타";
+    public static final String IMAGE_URL = "https://image.staccato.kr/web/share/excited.png";
+    public static final String IMAGE_URLS = "[\"https://image.staccato.kr/web/share/happy.png\", " +
+            "\"https://image.staccato.kr/web/share/angry.png\", " +
+            "\"https://image.staccato.kr/web/share/sad.png\"]";
+    public static final String FEELING = "happy";
+    public static final String EXPIRED_AT = "2025-06-01T00:00:00";
+    public static final String SHARE_LINK = "https://staccato.kr/share/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+}

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -24,5 +24,6 @@ public class SwaggerExamples {
             "\"https://image.staccato.kr/web/share/sad.png\"]";
     public static final String FEELING = "happy";
     public static final String EXPIRED_AT = "2025-06-01T00:00:00";
+    public static final String TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
     public static final String SHARE_LINK = "https://staccato.kr/share/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
 }

--- a/backend/src/main/java/com/staccato/image/service/dto/ImageUrlResponse.java
+++ b/backend/src/main/java/com/staccato/image/service/dto/ImageUrlResponse.java
@@ -1,10 +1,12 @@
 package com.staccato.image.service.dto;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "이미지 업로드를 했을 때 응답 형식입니다.")
 public record ImageUrlResponse(
-        @Schema(example = "https://d1234abcdefg.cloudfront.net/staccato/image/abcdefg.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         String imageUrl
 ) {
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberProfileImageResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberProfileImageResponse.java
@@ -1,10 +1,12 @@
 package com.staccato.member.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "프로필 사진을 변경 했을 때 응답 형식입니다.")
 public record MemberProfileImageResponse(
-        @Schema(example = "https://d1234abcdefg.cloudfront.net/staccato/image/abcdefg.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         String profileImageUrl
 ) {
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberProfileResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberProfileResponse.java
@@ -1,16 +1,17 @@
 package com.staccato.member.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 
 @Schema(description = "프로필을 조회 했을 때 응답 형식입니다.")
 public record MemberProfileResponse(
-        @Schema(example = "staccato")
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
-        @Schema(example = "https://d1234abcdefg.cloudfront.net/staccato/image/abcdefg.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         String profileImageUrl,
-        @Schema(example = "{UUID}")
+        @Schema(example = SwaggerExamples.MEMBER_CODE)
         String code) {
     public MemberProfileResponse(Member member) {
         this(member.getNickname().getNickname(), member.getImageUrl(), member.getCode());

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponse.java
@@ -1,17 +1,18 @@
 package com.staccato.member.service.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "여러 회원 정보를 표시할 때 필요한 정보에 대한 응답 형식입니다.")
 public record MemberResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.MEMBER_ID)
         Long memberId,
-        @Schema(example = "staccato")
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
-        @Schema(example = "https://example.com/members/profile.jpg")
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String memberImageUrl
 ) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/request/FeelingRequest.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/request/FeelingRequest.java
@@ -2,13 +2,14 @@ package com.staccato.staccato.service.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Feeling;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토 기분 표현 요청")
 public record FeelingRequest(
-        @Schema(description = "기분 표현", example = "happy")
+        @Schema(description = "기분 표현", example = SwaggerExamples.FEELING)
         @NotNull(message = "기분 값을 입력해주세요.")
         String feeling
 ) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/request/StaccatoRequest.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/request/StaccatoRequest.java
@@ -1,5 +1,6 @@
 package com.staccato.staccato.service.dto.request;
 
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -21,32 +22,32 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토 생성 시 요청 형식입니다. 단, 멀티파트로 보내는 사진 파일은 여기에 포함되지 않습니다.")
 public record StaccatoRequest(
-        @Schema(example = "재밌었던 런던 박물관에서의 기억")
+        @Schema(example = SwaggerExamples.STACCATO_TITLE)
         @NotBlank(message = "스타카토 제목을 입력해주세요.")
         @Size(max = 30, message = "스타카토 제목은 공백 포함 30자 이하로 설정해주세요.")
         String staccatoTitle,
-        @Schema(example = "Great Russell St, London WC1B 3DG")
+        @Schema(example = SwaggerExamples.STACCATO_PLACE_NAME)
         @NotNull(message = "장소 이름을 입력해주세요.")
         String placeName,
-        @Schema(example = "British Museum")
+        @Schema(example = SwaggerExamples.STACCATO_ADDRESS)
         @NotNull(message = "스타카토의 주소를 입력해주세요.")
         String address,
-        @Schema(example = "51.51978412729915")
+        @Schema(example = SwaggerExamples.STACCATO_LATITUDE)
         @NotNull(message = "스타카토의 위도를 입력해주세요.")
         BigDecimal latitude,
-        @Schema(example = "-0.12712788587027796")
+        @Schema(example = SwaggerExamples.STACCATO_LONGITUDE)
         @NotNull(message = "스타카토의 경도를 입력해주세요.")
         BigDecimal longitude,
-        @Schema(example = "2024-07-27")
+        @Schema(example = SwaggerExamples.STACCATO_VISITED_AT)
         @NotNull(message = "스타카토 날짜를 입력해주세요.")
         @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
         LocalDateTime visitedAt,
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
         @NotNull(message = "카테고리를 선택해주세요.")
         @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.")
         long categoryId,
         @ArraySchema(
-                arraySchema = @Schema(example = "[\"https://example.com/images/namsan_tower.jpg\", \"https://example.com/images/namsan_tower2.jpg\"]"))
+                arraySchema = @Schema(example = SwaggerExamples.IMAGE_URLS))
         @Size(max = 5, message = "사진은 5장까지만 추가할 수 있어요.")
         List<String> staccatoImageUrls
 ) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/CommentShareResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/CommentShareResponse.java
@@ -1,10 +1,17 @@
 package com.staccato.staccato.service.dto.response;
 
 import com.staccato.comment.domain.Comment;
+import com.staccato.config.swagger.SwaggerExamples;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "스타카토를 공유했을 때 댓글 응답 형식입니다.")
 public record CommentShareResponse(
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
+        @Schema(example = SwaggerExamples.COMMENT_CONTENT)
         String content,
+        @Schema(example = SwaggerExamples.IMAGE_URL)
         String memberImageUrl
 ) {
     public CommentShareResponse(Comment comment) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoDetailResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoDetailResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.domain.StaccatoImage;
 
@@ -14,33 +15,33 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토를 조회했을 때 응답 형식입니다.")
 public record StaccatoDetailResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         long staccatoId,
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
         long categoryId,
-        @Schema(example = "2024 서울 투어")
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
         String categoryTitle,
-        @Schema(example = "2024-06-30")
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate startAt,
-        @Schema(example = "2024-07-04")
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
-        @Schema(example = "즐거웠던 남산에서의 기억")
+        @Schema(example = SwaggerExamples.STACCATO_TITLE)
         String staccatoTitle,
-        @ArraySchema(arraySchema = @Schema(example = "[\"https://example.com/images/namsan_tower.jpg\", \"https://example.com/images/namsan_tower2.jpg\"]"))
+        @ArraySchema(arraySchema = @Schema(example = SwaggerExamples.IMAGE_URLS))
         List<String> staccatoImageUrls,
-        @Schema(example = "2021-11-08T11:58:20")
+        @Schema(example = SwaggerExamples.STACCATO_VISITED_AT)
         LocalDateTime visitedAt,
-        @Schema(example = "happy")
+        @Schema(example = SwaggerExamples.FEELING)
         String feeling,
-        @Schema(example = "남산서울타워")
+        @Schema(example = SwaggerExamples.STACCATO_PLACE_NAME)
         String placeName,
-        @Schema(example = "서울 용산구 남산공원길 105")
+        @Schema(example = SwaggerExamples.STACCATO_ADDRESS)
         String address,
-        @Schema(example = "51.51978412729915")
+        @Schema(example = SwaggerExamples.STACCATO_LATITUDE)
         BigDecimal latitude,
-        @Schema(example = "-0.12712788587027796")
+        @Schema(example = SwaggerExamples.STACCATO_LONGITUDE)
         BigDecimal longitude
 ) {
     public StaccatoDetailResponse(Staccato staccato) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoIdResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoIdResponse.java
@@ -1,10 +1,12 @@
 package com.staccato.staccato.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토 생성 시 응답 형식입니다.")
 public record StaccatoIdResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         long staccatoId
 ) {
 }

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoLocationResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoLocationResponse.java
@@ -2,17 +2,18 @@ package com.staccato.staccato.service.dto.response;
 
 import java.math.BigDecimal;
 
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토 목록 중 하나의 스타카토에 해당하는 응답입니다.")
 public record StaccatoLocationResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         long staccatoId,
-        @Schema(example = "51.51978412729915")
+        @Schema(example = SwaggerExamples.STACCATO_LATITUDE)
         BigDecimal latitude,
-        @Schema(example = "-0.12712788587027796")
+        @Schema(example = SwaggerExamples.STACCATO_LONGITUDE)
         BigDecimal longitude) {
 
     public StaccatoLocationResponse(Staccato staccato) {

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoShareLinkResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoShareLinkResponse.java
@@ -1,11 +1,13 @@
 package com.staccato.staccato.service.dto.response;
 
+import com.staccato.config.swagger.SwaggerExamples;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record StaccatoShareLinkResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         long staccatoId,
-        @Schema(example = "https://staccato.kr/share/sample-token")
+        @Schema(example = SwaggerExamples.SHARE_LINK)
         String shareLink
 ) {
         private static final String SHARE_LINK_PREFIX = "https://staccato.kr/share/";

--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoSharedResponse.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoSharedResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import com.staccato.comment.domain.Comment;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.domain.StaccatoImage;
@@ -13,28 +14,23 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "스타카토를 공유했을 때 응답 형식입니다.")
 public record StaccatoSharedResponse(
-        @Schema(example = "1")
+        @Schema(example = SwaggerExamples.STACCATO_ID)
         long staccatoId,
-        @Schema(example = "2024-09-30T17:00:00")
+        @Schema(example = SwaggerExamples.EXPIRED_AT)
         LocalDateTime expiredAt,
-        @Schema(example = "staccato")
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
-        @ArraySchema(arraySchema = @Schema(example = "[" +
-                "\"https://image.staccato.kr/dev/squirrel.png\"," +
-                "\"https://image.staccato.kr/dev/squirrel.png\"," +
-                "\"https://image.staccato.kr/dev/squirrel.png\"," +
-                "\"https://image.staccato.kr/dev/squirrel.png\"," +
-                "\"https://image.staccato.kr/dev/%E1%84%80%E1%85%B5%E1%84%87%E1%85%AE%E1%84%82%E1%85%B5%E1%84%83%E1%85%B3%E1%86%AF.jpeg\"]"))
+        @ArraySchema(arraySchema = @Schema(example = SwaggerExamples.IMAGE_URLS))
         List<String> staccatoImageUrls,
-        @Schema(example = "귀여운 스타카토 키링")
+        @Schema(example = SwaggerExamples.STACCATO_TITLE)
         String staccatoTitle,
-        @Schema(example = "한국 루터회관 8층")
+        @Schema(example = SwaggerExamples.STACCATO_PLACE_NAME)
         String placeName,
-        @Schema(example = "대한민국 서울특별시 송파구 올림픽로35다길 42 한국루터회관 8층")
+        @Schema(example = SwaggerExamples.STACCATO_ADDRESS)
         String address,
-        @Schema(example = "2024-09-29T17:00:00")
+        @Schema(example = SwaggerExamples.STACCATO_VISITED_AT)
         LocalDateTime visitedAt,
-        @Schema(example = "scared")
+        @Schema(example = SwaggerExamples.FEELING)
         String feeling,
         List<CommentShareResponse> comments
 ) {


### PR DESCRIPTION
## ⭐️ Issue Number
- #714 

## 🚩 Summary

Swagger 예시 문자열들을 `SwaggerExamples`에서 한 번에 관리하도록 수정했습니다. 장점은 아래와 같습니다.

* DTO 예시들 간의 데이터 정합성 유지
* 새로운 DTO를 만들 때 쉽게 가져다가 사용 가능
* 데이터들이 논리적인 오류가 없는지 쉽게 확인 가능
  * `CATEGORY_TITLE`은 10자 이하여야 한다.
  * `STACCATO_VISITED_AT`는 `CATEGORY_START_AT`과 `CATEGORY_END_AT` 사이의 날짜여야 한다.

## 🙂 To Reviewer

`CategoryReadRequest`의 `filters` 기본 예제를 `WITH_TERM`에서 `WITHOUT_TERM`으로 바꾸었는데, Swagger를 사용하면서 아래와 같은 불편함을 느껴서 변경했습니다.

* 로그인으로 토큰 생성하고 Authorization header에 설정
* 스타카토를 생성할 때, 로그인과 함께 생성된 기본 카테고리에 담게 됨
* 기본 카테고리는 기간이 없어, 디폴트 필터인 `WITH_TERM`으로 검색하면 카테고리 목록에 뜨지 않음
* 기본 카테고리가 잘 있는지 혹은 아이디가 무엇인지 확인하려면, filter 값을 `WITHOUT_TERM`으로 바꿔주는 작업이 필요함
* Swagger를 사용하면서 이런 경우가 다수 발생해서, 카테고리 목록 조회 API 사용 시 기본 카테고리가 목록에 뜨도록 filter의 디폴트 값을 `WITHOUT_TERM`으로 설정하는 것이 좋겠다고 생각함

`CommentRequestV2`의 `V2`는 다른 PR에서 작업하면서 삭제했기 때문에, 이 브랜치에서는 해당 작업을 하지 않았습니다. develop에 머지하고 충돌을 해결하는 과정에서 사라질 예정입니다.

예제에 실제 이미지를 넣고 테스트해야 할 일이 자주 생겨서(ex. 스타카토 공유 페이지에 이미지가 잘 렌더링되는지 확인) 실제 S3에 담겨있는 이미지 링크를 넣었습니다. 이 링크는 `html`과 `js` 파일에도 raw한 값으로 있으며, 민감한 이미지가 아니고, cloudfront 경로(`image.staccato.kr`)는 노출되지만 DB에 저장되는 사진들은 뒷부분을 랜덤 UUID로 관리하므로 보안적인 문제는 없다고 생각합니다.
