### PR TITLE
feat: 스타카토 공유 링크 썸네일 지정 #728

### DIFF
--- a/backend/src/main/java/com/staccato/web/PageController.java
+++ b/backend/src/main/java/com/staccato/web/PageController.java
@@ -13,6 +13,8 @@ import lombok.RequiredArgsConstructor;
 @Controller
 @RequiredArgsConstructor
 public class PageController {
+    private static final String DEFAULT_THUMBNAIL_URL = "https://image.staccato.kr/web/share/frame.png";
+
     private final StaccatoShareService staccatoShareService;
 
     @GetMapping("/")
@@ -25,7 +27,7 @@ public class PageController {
         StaccatoSharedResponse response = staccatoShareService.readSharedStaccatoByToken(token);
         String thumbnailUrl = response.staccatoImageUrls().stream()
                 .findFirst()
-                .orElse("https://image.staccato.kr/web/share/frame.png");
+                .orElse(DEFAULT_THUMBNAIL_URL);
 
         model.addAttribute("token", token);
         model.addAttribute("thumbnailUrl", thumbnailUrl);

--- a/backend/src/main/java/com/staccato/web/PageController.java
+++ b/backend/src/main/java/com/staccato/web/PageController.java
@@ -5,8 +5,15 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
+import com.staccato.staccato.service.StaccatoShareService;
+import com.staccato.staccato.service.dto.response.StaccatoSharedResponse;
+
+import lombok.RequiredArgsConstructor;
+
 @Controller
+@RequiredArgsConstructor
 public class PageController {
+    private final StaccatoShareService staccatoShareService;
 
     @GetMapping("/")
     public String index() {
@@ -15,7 +22,14 @@ public class PageController {
 
     @GetMapping("/share/{token}")
     public String share(@PathVariable String token, Model model) {
+        StaccatoSharedResponse response = staccatoShareService.readSharedStaccatoByToken(token);
+        String thumbnailUrl = response.staccatoImageUrls().stream()
+                .findFirst()
+                .orElse("https://image.staccato.kr/web/share/frame.png");
+
         model.addAttribute("token", token);
+        model.addAttribute("thumbnailUrl", thumbnailUrl);
+
         return "share";
     }
 }

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -155,6 +155,7 @@ body {
 
 .comments h2 {
     padding-left: 1.5rem;
+    font-size: 1rem;
 }
 
 .comments-list {

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -270,7 +270,9 @@ body {
 }
 
 .promotion img {
-    width: 300px;
+    height: auto;
+    width: 100%;
+    max-width: 300px;
     margin: 1rem 0;
 }
 
@@ -295,7 +297,9 @@ body {
 }
 
 .empty-comments-image {
+    width: 100%;
     max-width: 250px;
+    height: auto;
     opacity: 0.8;
     margin-bottom: 1rem;
 }

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -21,14 +21,14 @@ body {
     padding: 1.5rem;
 }
 
-.staccato-title {
+.staccato-header-title {
     font-size: 1.5rem;
     font-weight: bold;
     color: #333;
     margin: 0.5rem 0;
 }
 
-.staccato-subtitle {
+.staccato-header-expiration {
     font-size: 1rem;
     color: #555;
     margin: 0;
@@ -87,7 +87,7 @@ body {
 
 .title h1 {
     font-weight: bold;
-    font-size: 1.8rem;
+    font-size: 1.5rem;
     text-align: left;
     margin: 2rem 0 1rem 0;
     padding-left: 1.5rem;

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -156,6 +156,7 @@ body {
 .comments h2 {
     padding-left: 1.5rem;
     font-size: 1rem;
+    margin-top: 2rem;
 }
 
 .comments-list {
@@ -263,7 +264,7 @@ body {
 }
 
 .promotion h2 {
-    font-size: 2rem;
+    font-size: 1rem;
     font-weight: bold;
     color: #333;
     margin-bottom: 0;
@@ -277,7 +278,7 @@ body {
 }
 
 .promotion p {
-    font-size: 1.5rem;
+    font-size: 1rem;
     color: #555;
     margin: 0;
 }
@@ -308,4 +309,16 @@ body {
     margin-top: 10px;
     font-size: 18px;
     color: #666;
+}
+
+@media (max-width: 480px) {
+    html {
+        font-size: 90%;
+    }
+}
+
+@media (max-width: 360px) {
+    html {
+        font-size: 85%;
+    }
 }

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -126,7 +126,6 @@ body {
 }
 
 .feeling {
-    text-align: center;
     padding: 1.5rem;
 }
 
@@ -134,6 +133,7 @@ body {
     margin: 0 0 1rem 0;
     font-size: 1rem;
     font-weight: bold;
+    text-align: center;
 }
 
 .feeling .emojis {

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -37,7 +37,7 @@ body {
 .image-slider {
     width: 100%;
     max-width: 600px;
-    aspect-ratio: 1 / 1;
+    height: 60vh;
     overflow: hidden;
     position: relative;
     display: flex;
@@ -47,7 +47,7 @@ body {
 
 .image-slider img {
     width: 100%;
-    height: 600px;
+    height: 60vh;
     object-fit: cover;
     object-position: center;
     display: block;

--- a/backend/src/main/resources/static/js/share.js
+++ b/backend/src/main/resources/static/js/share.js
@@ -13,14 +13,14 @@ fetch(`/staccatos/shared/${token}`)
             comments,
         } = data;
 
-        document.querySelector('.staccato-title').innerText = `${nickname}님이 공유한 추억`;
+        document.querySelector('.staccato-header-title').innerText = `${nickname}님이 공유한 추억`;
 
         const expiredDate = new Date(expiredAt);
         const expiredYear = expiredDate.getUTCFullYear();
         const expiredMonth = expiredDate.getUTCMonth() + 1;
         const expiredDay = expiredDate.getUTCDate();
         const formattedExpiredAt = `${expiredYear}년 ${expiredMonth}월 ${expiredDay}일`;
-        document.querySelector('.staccato-subtitle').innerText = `${formattedExpiredAt}까지 열람할 수 있어요!`;
+        document.querySelector('.staccato-header-expiration').innerText = `${formattedExpiredAt}까지 열람할 수 있어요!`;
 
         const sliderWrapper = document.querySelector('.swiper-wrapper');
         sliderWrapper.innerHTML = '';

--- a/backend/src/main/resources/templates/share.html
+++ b/backend/src/main/resources/templates/share.html
@@ -16,8 +16,8 @@
 <body>
 <div class="container">
     <div class="staccato-header">
-        <h1 class="staccato-title"></h1>
-        <p class="staccato-subtitle"></p>
+        <h1 class="staccato-header-title"></h1>
+        <p class="staccato-header-expiration"></p>
     </div>
 
     <div class="image-slider">

--- a/backend/src/main/resources/templates/share.html
+++ b/backend/src/main/resources/templates/share.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Staccato</title>
 
+    <meta property="og:image" th:content="${thumbnailUrl}" />
+
     <link rel="stylesheet" href="/css/share.css">
     <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css">
 

--- a/backend/src/test/java/com/staccato/web/PageControllerTest.java
+++ b/backend/src/test/java/com/staccato/web/PageControllerTest.java
@@ -45,7 +45,6 @@ public class PageControllerTest extends ControllerTest {
 
         Category category = CategoryFixtures.defaultCategory().build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withId(1L)
                 .withCategory(category)
                 .withStaccatoImages(imageUrls).build();
         Member member = MemberFixtures.defaultMember().build();
@@ -70,7 +69,6 @@ public class PageControllerTest extends ControllerTest {
 
         Category category = CategoryFixtures.defaultCategory().build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withId(1L)
                 .withCategory(category)
                 .withStaccatoImages(imageUrls).build();
         Member member = MemberFixtures.defaultMember().build();

--- a/backend/src/test/java/com/staccato/web/PageControllerTest.java
+++ b/backend/src/test/java/com/staccato/web/PageControllerTest.java
@@ -1,0 +1,88 @@
+package com.staccato.web;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.staccato.ControllerTest;
+import com.staccato.category.domain.Category;
+import com.staccato.fixture.category.CategoryFixtures;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.fixture.staccato.StaccatoFixtures;
+import com.staccato.member.domain.Member;
+import com.staccato.staccato.domain.Staccato;
+import com.staccato.staccato.service.dto.response.StaccatoSharedResponse;
+
+public class PageControllerTest extends ControllerTest {
+    private static final String DEFAULT_THUMBNAIL_URL = "https://image.staccato.kr/web/share/frame.png";
+
+    @DisplayName("루트 페이지에 접근하면 index 뷰를 반환한다.")
+    @Test
+    void returnIndexViewWhenAccessingRoot() throws Exception {
+        mockMvc.perform(get("/"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("index"));
+    }
+
+    @DisplayName("공유 페이지 접근 시, 이미지가 있을 경우 첫 번째 이미지를 썸네일로 사용한다.")
+    @Test
+    void useFirstImageAsThumbnailWhenImagesExist() throws Exception {
+        // given
+        String token = "test-token";
+        List<String> imageUrls = List.of(
+                "https://image.staccato.kr/test-image1.png",
+                "https://image.staccato.kr/test-image2.png",
+                "https://image.staccato.kr/test-image3.png"
+        );
+
+        Category category = CategoryFixtures.defaultCategory().build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato()
+                .withId(1L)
+                .withCategory(category)
+                .withStaccatoImages(imageUrls).build();
+        Member member = MemberFixtures.defaultMember().build();
+        StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());
+
+        when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/share/{token}", token))
+                .andExpect(status().isOk())
+                .andExpect(view().name("share"))
+                .andExpect(model().attribute("token", token))
+                .andExpect(model().attribute("thumbnailUrl", imageUrls.get(0)));
+    }
+
+    @DisplayName("공유 페이지 접근 시, 이미지가 없을 경우 기본 썸네일을 사용한다.")
+    @Test
+    void useDefaultImageAsThumbnailWhenNoImagesExist() throws Exception {
+        // given
+        String token = "test-token";
+        List<String> imageUrls = List.of();
+
+        Category category = CategoryFixtures.defaultCategory().build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato()
+                .withId(1L)
+                .withCategory(category)
+                .withStaccatoImages(imageUrls).build();
+        Member member = MemberFixtures.defaultMember().build();
+        StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());
+
+        when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/share/{token}", token))
+                .andExpect(status().isOk())
+                .andExpect(view().name("share"))
+                .andExpect(model().attribute("token", token))
+                .andExpect(model().attribute("thumbnailUrl", DEFAULT_THUMBNAIL_URL));
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number

Closes #728 

## 🚩 Summary

- 해당 스타카토의 이미지가 있는 경우, 첫 번째 이미지를 링크 썸네일로 띄웁니다.
- 해당 스타카토의 이미지가 없는 경우, 기본 이미지를 링크 썸네일로 띄웁니다.
- 스타카토 이미지에 반응형 디자인 적용
