### PR TITLE
feat: 특정 카테고리 조회 시 색상 응답 필드를 포함하는 API V2 구현 #741

### DIFF
--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -22,6 +22,7 @@ import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
@@ -71,8 +72,8 @@ public class CategoryController implements CategoryControllerDocs {
     public ResponseEntity<CategoryDetailResponse> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponse categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
-        return ResponseEntity.ok(categoryDetailResponse);
+        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponse());
     }
 
     @PutMapping("/{categoryId}")

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
@@ -20,6 +20,8 @@ import com.staccato.category.controller.docs.CategoryControllerV2Docs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -54,6 +56,14 @@ public class CategoryControllerV2 implements CategoryControllerV2Docs {
     ) {
         CategoryResponsesV2 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
         return ResponseEntity.ok(categoryResponses);
+    }
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryDetailResponseV2> readCategory(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
+        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        return ResponseEntity.ok(categoryDetailResponse);
     }
 
     @PutMapping("/{categoryId}")

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
@@ -1,10 +1,8 @@
 package com.staccato.category.controller;
 
 import java.net.URI;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,20 +13,16 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.category.controller.docs.CategoryControllerV2Docs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
-import com.staccato.category.service.dto.response.CategoryDetailResponse;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
-import com.staccato.category.service.dto.response.CategoryResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
@@ -12,6 +12,7 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
@@ -56,6 +57,22 @@ public interface CategoryControllerV2Docs {
             @Parameter(hidden = true) Member member,
             @Parameter(description = "정렬 기준은 생략하거나 유효하지 않은 값에 대해서는 최근 수정 순(UPDATED)이 기본 정렬로 적용됩니다. 필터링 조건은 생략하거나 유효하지 않은 값이 들어오면 적용되지 않습니다.") CategoryReadRequest categoryReadRequest
     );
+
+    @Operation(summary = "카테고리 조회", description = "사용자의 카테고리을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                    
+                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    
+                    (2) Path Variable 형식이 잘못되었을 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<CategoryDetailResponseV2> readCategory(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "카테고리 ID", example = "1") @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId);
 
     @Operation(summary = "카테고리 수정", description = "카테고리 정보(썸네일, 제목, 내용, 기간)를 수정합니다.")
     @ApiResponses(value = {

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
@@ -25,7 +25,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
-@Tag(name = "Category", description = "Category API V2")
+@Tag(name = "Category V2", description = "Category API V2")
 public interface CategoryControllerV2Docs {
     @Operation(summary = "카테고리 생성", description = "카테고리(썸네일, 제목, 내용, 기간)을 생성합니다.")
     @ApiResponses(value = {

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -13,6 +13,7 @@ import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -76,11 +77,11 @@ public class CategoryService {
         return sort.apply(categories);
     }
 
-    public CategoryDetailResponse readCategoryById(long categoryId, Member member) {
+    public CategoryDetailResponseV2 readCategoryById(long categoryId, Member member) {
         Category category = getCategoryById(categoryId);
         validateOwner(category, member);
         List<Staccato> staccatos = staccatoRepository.findAllByCategoryIdOrdered(categoryId);
-        return new CategoryDetailResponse(category, staccatos);
+        return new CategoryDetailResponseV2(category, staccatos);
     }
 
     @Transactional

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV2.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV2.java
@@ -1,0 +1,71 @@
+package com.staccato.category.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
+import com.staccato.member.service.dto.response.MemberResponse;
+import com.staccato.staccato.domain.Staccato;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리에 대한 응답 형식입니다.")
+public record CategoryDetailResponseV2(
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
+        Long categoryId,
+        @Schema(example = SwaggerExamples.IMAGE_URL)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String categoryThumbnailUrl,
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
+        String categoryTitle,
+        @Schema(example = SwaggerExamples.CATEGORY_DESCRIPTION)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String description,
+        @Schema(example = SwaggerExamples.CATEGORY_COLOR)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String categoryColor,
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate startAt,
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate endAt,
+        List<MemberResponse> mates,
+        List<StaccatoResponse> staccatos
+) {
+
+    public CategoryDetailResponseV2(Category category, List<Staccato> staccatos) {
+        this(
+                category.getId(),
+                category.getThumbnailUrl(),
+                category.getTitle(),
+                category.getDescription(),
+                category.getColor().getName(),
+                category.getTerm().getStartAt(),
+                category.getTerm().getEndAt(),
+                toMemberResponses(category),
+                toStaccatoResponses(staccatos)
+        );
+    }
+
+    private static List<MemberResponse> toMemberResponses(Category category) {
+        return category.getMates().stream().map(MemberResponse::new).toList();
+    }
+
+    private static List<StaccatoResponse> toStaccatoResponses(List<Staccato> staccatos) {
+        return staccatos.stream().map(StaccatoResponse::new).toList();
+    }
+
+    public CategoryDetailResponse toCategoryDetailResponse() {
+        return new CategoryDetailResponse(
+                categoryId,
+                categoryThumbnailUrl,
+                categoryTitle,
+                description,
+                startAt,
+                endAt,
+                mates,
+                staccatos
+        );
+    }
+}

--- a/backend/src/main/java/com/staccato/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/staccato/config/OpenApiConfig.java
@@ -2,6 +2,7 @@ package com.staccato.config;
 
 import java.util.Arrays;
 
+import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -33,5 +34,21 @@ public class OpenApiConfig {
                         .type(Type.APIKEY)
                         .in(In.HEADER)
                         .description("Enter your token in the Authorization header"));
+    }
+
+    @Bean
+    public GroupedOpenApi v1Api() {
+        return GroupedOpenApi.builder()
+                .group("V1 API")
+                .pathsToExclude("/v2/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi v2Api() {
+        return GroupedOpenApi.builder()
+                .group("V2 API")
+                .pathsToMatch("/v2/**")
+                .build();
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -39,6 +39,9 @@ jasypt:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    persist-authorization: true
+
 security:
   jwt:
     token:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -35,6 +35,9 @@ jasypt:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    persist-authorization: true
+
 security:
   jwt:
     token:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -67,8 +67,11 @@ jasypt:
 springdoc:
   default-consumes-media-type: application/json;charset=UTF-8
   default-produces-media-type: application/json;charset=UTF-8
+  swagger-ui:
+    persist-authorization: true
   api-docs:
     enabled: false
+
 security:
   jwt:
     token:

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -18,6 +18,7 @@ import com.staccato.category.domain.Color;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -280,7 +281,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponse categoryDetailResponse = new CategoryDetailResponse(category, List.of(staccato));
+        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -329,7 +330,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponse categoryDetailResponse = new CategoryDetailResponse(category, List.of(staccato));
+        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -254,10 +254,10 @@ class CategoryControllerV2Test extends ControllerTest {
                     "categoryId": null,
                     "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
                     "categoryTitle": "categoryTitle",
+                    "description": "categoryDescription",
                     "categoryColor": "pink",
                     "startAt": "2024-01-01",
                     "endAt": "2024-12-31",
-                    "description": "categoryDescription",
                     "mates": [
                         {
                             "memberId": null,

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -19,6 +19,7 @@ import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -199,7 +200,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryRequestV2Fixtures.defaultCategoryRequestV2().build(), member);
 
         // when
-        CategoryDetailResponse categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(
@@ -218,7 +219,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryRequestV2Fixtures.defaultCategoryRequestV2().withTerm(null, null).build(), member);
 
         // when
-        CategoryDetailResponse categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(
@@ -265,7 +266,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withCategory(category).buildAndSave(staccatoRepository);
 
         // when
-        CategoryDetailResponse categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(


### PR DESCRIPTION
## ⭐️ Issue Number
- #741 

## 🚩 Summary
- 카테고리 수정 시 특정 카테고리 조회 API를 이용하여 기존 정보를 불러옵니다.
- 따라서, 수정 시 색상 수정을 위해서는 특정 카테고리 조회 API에서도 색상 응답 필드가 필요하여 이를 추가한 V2 를 구현했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
