### PR TITLE
refactor: 스타카토 공유 페이지 디자인 수정 #745

### DIFF
--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -145,12 +145,6 @@ body {
 .feeling .emojis img {
     width: 50px;
     height: 50px;
-    cursor: default;
-    transition: transform 0.2s ease;
-}
-
-.feeling .emojis img:hover {
-    transform: scale(1.2);
 }
 
 .comments h2 {

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -254,7 +254,7 @@ body {
     text-align: center;
     background-color: #fff;
     padding: 2rem;
-    margin: 2rem 0 1rem 0;
+    margin: 1rem 0 1rem 0;
 }
 
 .promotion h2 {

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -254,14 +254,7 @@ body {
     text-align: center;
     background-color: #fff;
     padding: 2rem;
-    margin: 1rem 0 1rem 0;
-}
-
-.promotion h2 {
-    font-size: 1rem;
-    font-weight: bold;
-    color: #333;
-    margin-bottom: 0;
+    margin-bottom: 1rem;
 }
 
 .promotion img {

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -267,7 +267,7 @@ body {
 .promotion img {
     height: auto;
     width: 100%;
-    max-width: 300px;
+    max-width: 240px;
     margin: 1rem 0;
 }
 
@@ -293,7 +293,7 @@ body {
 
 .empty-comments-image {
     width: 100%;
-    max-width: 250px;
+    max-width: 200px;
     height: auto;
     opacity: 0.8;
     margin-bottom: 1rem;

--- a/backend/src/main/resources/static/css/share.css
+++ b/backend/src/main/resources/static/css/share.css
@@ -133,7 +133,7 @@ body {
     margin: 0 0 1rem 0;
     font-size: 1rem;
     font-weight: bold;
-    text-align: center;
+    text-align: left;
 }
 
 .feeling .emojis {

--- a/backend/src/main/resources/static/js/share.js
+++ b/backend/src/main/resources/static/js/share.js
@@ -73,7 +73,7 @@ fetch(`/staccatos/shared/${token}`)
             commentsContainer.innerHTML = `
                 <div class="empty-comments-container">
                     <img class="empty-comments-image" src="https://image.staccato.kr/web/share/frame.png" alt="Frame Image">
-                    <p class="empty-comments-text">코멘트가 없어요! 코멘트를 달아보세요.</p>
+                    <p class="empty-comments-text">아직 코멘트가 없어요!</p>
                 </div>
             `;
         } else {

--- a/backend/src/main/resources/static/js/share.js
+++ b/backend/src/main/resources/static/js/share.js
@@ -22,18 +22,25 @@ fetch(`/staccatos/shared/${token}`)
         const formattedExpiredAt = `${expiredYear}년 ${expiredMonth}월 ${expiredDay}일`;
         document.querySelector('.staccato-header-expiration').innerText = `${formattedExpiredAt}까지 열람할 수 있어요!`;
 
+        const imageSlider = document.querySelector('.image-slider');
         const sliderWrapper = document.querySelector('.swiper-wrapper');
-        sliderWrapper.innerHTML = '';
-        staccatoImageUrls.forEach((url) => {
-            const slideElement = document.createElement('div');
-            slideElement.classList.add('swiper-slide');
-            slideElement.innerHTML = `<img src="${url}" alt="Staccato Image">`;
-            sliderWrapper.appendChild(slideElement);
-        });
 
-        swiper.update();
+        if (staccatoImageUrls.length === 0) {
+            imageSlider.style.display = 'none';
+        } else {
+            imageSlider.style.display = '';
+            sliderWrapper.innerHTML = '';
+            staccatoImageUrls.forEach((url) => {
+                const slideElement = document.createElement('div');
+                slideElement.classList.add('swiper-slide');
+                slideElement.innerHTML = `<img src="${url}" alt="Staccato Image">`;
+                sliderWrapper.appendChild(slideElement);
+            });
 
-        updateNavigationButtons(swiper);
+            swiper.update();
+
+            updateNavigationButtons(swiper);
+        }
 
         document.querySelector('.title h1').innerText = staccatoTitle;
 

--- a/backend/src/main/resources/templates/share.html
+++ b/backend/src/main/resources/templates/share.html
@@ -58,7 +58,6 @@
     </div>
 
     <div class="promotion">
-        <h2>더 많은 추억을 남기고 싶다면?</h2>
         <a href="https://play.google.com/store/apps/details?id=com.on.staccato&pcampaignid=web_share" target="_blank" class="google-play-link">
             <img th:src="${'https://image.staccato.kr/web/share/google-play-badge.png'}" alt="Get it on Google Play">
         </a>


### PR DESCRIPTION
## ⭐️ Issue Number
- #745 

## 🚩 Summary

* 사진 없을 때 빈 공간 축소
* 이모지 확대 기능 삭제
* 기본 이미지 크기 축소 (0.8배)
* 기분 문구 왼쪽 정렬
* 코멘트 없을때 문구 수정 (아직 코멘트가 없어요!)
* 홍보 위쪽 문구 삭제 (더 많은 추억을 남기고 싶다면?)

### 📸 사진 있는 스타카토
![screencapture-localhost-8080-share-eyJhbGciOiJIUzI1NiJ9-eyJzdGFjY2F0b0lkIjoxLCJtZW1iZXJJZCI6MSwiZXhwIjoxNzQ2NjgyMzEwfQ-NKZNmlSYl2WYFaCp8iiqTgCYeljoGrwdL-Ozlxz0V-w-2025-04-23-14_32_19](https://github.com/user-attachments/assets/8b27fd4e-e936-4074-aa38-8839ff951aec)

### 📷 사진 없는 스타카토
![screencapture-localhost-8080-share-eyJhbGciOiJIUzI1NiJ9-eyJzdGFjY2F0b0lkIjoyLCJtZW1iZXJJZCI6MSwiZXhwIjoxNzQ2NjgyMzU4fQ-rBErXaVgiHl94KqZN0BKYiFCqAtmPdzD-4Y2nr-vEV4-2025-04-23-14_32_56](https://github.com/user-attachments/assets/d1fbbc42-9fc1-4a2f-a3c7-f5a2f05a5826)

