### PR TITLE
feat: P99 latency 적용 + Spring Boot OTLP 설정 #744

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -74,7 +74,7 @@ management:
   metrics:
     distribution:
       percentiles-histogram:
-        http.server.requests: true   # 히스토그램 활성화
+        http.server.requests: true
       percentiles:
         http.server.requests: 0.5, 0.9, 0.95, 0.99
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -78,6 +78,14 @@ management:
       percentiles:
         http.server.requests: 0.5, 0.9, 0.95, 0.99
 
+  tracing:
+    sampling:
+      probability: 1.0
+
+otel:
+  exporter:
+    otlp:
+      endpoint: ENC(5UpVPijgUP3POMXJfpiN7mp3Q66ywOmvb3uelGeLu/hlRD7JTJPcXKoTPDkpxDjUY+mco4EZy0g0njZynWHDCw==)
 
 server:
   tomcat:

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -71,6 +71,14 @@ management:
       exposure:
         include: info, health, metrics, env, beans, threaddump, loggers, prometheus
 
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true   # 히스토그램 활성화
+      percentiles:
+        http.server.requests: 0.5, 0.9, 0.95, 0.99
+
+
 server:
   tomcat:
     mbeanregistry:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -74,6 +74,14 @@ management:
       percentiles:
         http.server.requests: 0.5, 0.9, 0.95, 0.99
 
+  tracing:
+    sampling:
+      probability: 1.0
+
+otel:
+  exporter:
+    otlp:
+      endpoint: ENC(5UpVPijgUP3POMXJfpiN7mp3Q66ywOmvb3uelGeLu/hlRD7JTJPcXKoTPDkpxDjUY+mco4EZy0g0njZynWHDCw==)
 
 server:
   tomcat:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -67,6 +67,14 @@ management:
       exposure:
         include: "*"
 
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true   # 히스토그램 활성화
+      percentiles:
+        http.server.requests: 0.5, 0.9, 0.95, 0.99
+
+
 server:
   tomcat:
     mbeanregistry:

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -67,22 +67,6 @@ management:
       exposure:
         include: "*"
 
-  metrics:
-    distribution:
-      percentiles-histogram:
-        http.server.requests: true   # 히스토그램 활성화
-      percentiles:
-        http.server.requests: 0.5, 0.9, 0.95, 0.99
-
-  tracing:
-    sampling:
-      probability: 1.0
-
-otel:
-  exporter:
-    otlp:
-      endpoint: ENC(5UpVPijgUP3POMXJfpiN7mp3Q66ywOmvb3uelGeLu/hlRD7JTJPcXKoTPDkpxDjUY+mco4EZy0g0njZynWHDCw==)
-
 server:
   tomcat:
     mbeanregistry:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -107,6 +107,14 @@ management:
     health:
       show-components: never
 
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true   # 히스토그램 활성화
+      percentiles:
+        http.server.requests: 0.5, 0.9, 0.95, 0.99
+
+
 server:
   tomcat:
     accept-count: 100

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -110,7 +110,7 @@ management:
   metrics:
     distribution:
       percentiles-histogram:
-        http.server.requests: true   # 히스토그램 활성화
+        http.server.requests: true
       percentiles:
         http.server.requests: 0.5, 0.9, 0.95, 0.99
 

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -114,6 +114,14 @@ management:
       percentiles:
         http.server.requests: 0.5, 0.9, 0.95, 0.99
 
+  tracing:
+    sampling:
+      probability: 1.0
+
+otel:
+  exporter:
+    otlp:
+      endpoint: ENC(5UpVPijgUP3POMXJfpiN7mp3Q66ywOmvb3uelGeLu/hlRD7JTJPcXKoTPDkpxDjUY+mco4EZy0g0njZynWHDCw==)
 
 server:
   tomcat:


### PR DESCRIPTION
## ⭐️ Issue Number
- #744 
- #750 

## 🚩 Summary
- P99는 꼭대기 부하 구간에서 얼마나 느린 요청이 있는지를 보여줌
- 평균이나 중앙값은 극단적인 outlier를 반영하지 않아 성능 문제를 숨길 수 있기에 P99를 적용
- Spring Boot Trace 생성 및 OTLP 전송 설정

## 🛠️ Technical Concerns


## 🙂 To Reviewer

exporter endpoint의 암호화 전 값은 노션에 있습니다.

## 📋 To Do
