### PR TITLE
build: Jetpack Compose 의존성 추가 #796

### DIFF
--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -55,6 +55,7 @@ android {
         defaultConfig {
             buildConfig = true
         }
+        compose = true
     }
 
     buildTypes {
@@ -91,6 +92,10 @@ android {
 
     kapt {
         correctErrorTypes = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 }
 
@@ -208,6 +213,21 @@ dependencies {
     implementation(libs.androidx.camera.lifecycle)
     implementation(libs.androidx.camera.view)
     implementation(libs.androidx.camera.extension)
+
+    // Compose
+    implementation(libs.androidx.activity.compose)
+    implementation(platform(libs.androidx.compose.bom))
+
+    // Material Design 3
+    implementation(libs.androidx.material3)
+
+    // Android Studio Preview support
+    implementation(libs.androidx.ui.tooling.preview)
+
+    // Compose UI Test
+    androidTestImplementation(platform(libs.androidx.compose.bom))
+    androidTestImplementation(libs.androidx.ui.test.junit4)
+    debugImplementation(libs.androidx.ui.test.manifest)
 }
 
 secrets {

--- a/android/Staccato_AN/app/build.gradle.kts
+++ b/android/Staccato_AN/app/build.gradle.kts
@@ -214,15 +214,25 @@ dependencies {
     implementation(libs.androidx.camera.view)
     implementation(libs.androidx.camera.extension)
 
-    // Compose
+    // Compose 기본 설정
     implementation(libs.androidx.activity.compose)
     implementation(platform(libs.androidx.compose.bom))
 
     // Material Design 3
     implementation(libs.androidx.material3)
 
-    // Android Studio Preview support
+    // Compose core UI
+    implementation(libs.androidx.ui)
+    implementation(libs.androidx.ui.graphics)
+    implementation(libs.androidx.ui.tooling)
     implementation(libs.androidx.ui.tooling.preview)
+
+    // Hilt & Navigation
+    implementation(libs.hilt.navigation.compose)
+    implementation(libs.androidx.navigation.compose)
+
+    // coil
+    implementation(libs.coil.compose)
 
     // Compose UI Test
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ coreKtx = "1.13.1"
 junit = "4.13.2"
 junitparams = "1.1.0"
 junit5 = "5.10.2"
-junit5AndroidTest="1.3.0"
+junit5AndroidTest = "1.3.0"
 androidxJunitVersion = "1.2.1"
 androidxTestRunner = "1.4.0"
 androidxTestRules = "1.4.0"
@@ -49,6 +49,9 @@ camerax = "1.1.0-beta01"
 androidJUnit5 = "1.10.0.0"
 activityCompose = "1.9.1"
 composeBom = "2024.06.00"
+compose-rules = "0.4.5"
+navigationCompose = "2.8.6"
+hilt-navigation-compose = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -109,9 +112,15 @@ androidx-camera-extension = { group = "androidx.camera", name = "camera-extensio
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
+androidx-ui = { group = "androidx.compose.ui", name = "ui" }
+androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
+androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -47,6 +47,8 @@ playServicesMaps = "19.0.0"
 viewpager2 = "1.1.0"
 camerax = "1.1.0-beta01"
 androidJUnit5 = "1.10.0.0"
+activityCompose = "1.9.1"
+composeBom = "2024.06.00"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -104,6 +106,12 @@ androidx-camera-camera2 = { group = "androidx.camera", name = "camera-camera2", 
 androidx-camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "camerax" }
 androidx-camera-view = { group = "androidx.camera", name = "camera-view", version.ref = "camerax" }
 androidx-camera-extension = { group = "androidx.camera", name = "camera-extensions", version.ref = "camerax" }
+androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
+androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
+androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
+androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
+androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/android/Staccato_AN/gradle/libs.versions.toml
+++ b/android/Staccato_AN/gradle/libs.versions.toml
@@ -25,15 +25,15 @@ glide = "4.16.0"
 places = "3.5.0"
 playServicesLocation = "21.3.0"
 retrofit = "2.11.0"
-retrofit-serialization-converter = "1.0.0"
-kotlinx-serialization-json = "1.6.3"
-kotlinx-coroutines-test = "1.8.1"
-okhttp-logging-interceptor = "4.12.0"
-okhttp-mockwebserver = "4.12.0"
+retrofitSerializationConverter = "1.0.0"
+kotlinxSerializationJson = "1.6.3"
+kotlinxCoroutinesTest = "1.8.1"
+okhttpLoggingInterceptor = "4.12.0"
+okhttpMockwebserver = "4.12.0"
 mockk = "1.13.11"
 lifecycle = "2.8.3"
 splashscreen = "1.0.1"
-firebase-bom = "32.3.1"
+firebaseBom = "32.3.1"
 room = "2.6.1"
 googleMapsSecrets = "2.0.1"
 recyclerview = "1.3.2"
@@ -49,9 +49,8 @@ camerax = "1.1.0-beta01"
 androidJUnit5 = "1.10.0.0"
 activityCompose = "1.9.1"
 composeBom = "2024.06.00"
-compose-rules = "0.4.5"
 navigationCompose = "2.8.6"
-hilt-navigation-compose = "1.2.0"
+hiltNavigationCompose = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -82,18 +81,18 @@ glide = { group = "com.github.bumptech.glide", name = "glide", version.ref = "gl
 places = { module = "com.google.android.libraries.places:places", version.ref = "places" }
 play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofit-serialization-converter" }
-kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
-kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
-okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp-logging-interceptor" }
-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp-mockwebserver" }
+retrofit-serialization-converter = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitSerializationConverter" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttpLoggingInterceptor" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttpMockwebserver" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
 mockk-agent = { group = "io.mockk", name = "mockk-agent-jvm", version.ref = "mockk" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 lifecycle-livedata = { group = "androidx.lifecycle", name = "lifecycle-livedata-ktx", version.ref = "lifecycle" }
 splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "splashscreen" }
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
 room = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
@@ -118,7 +117,7 @@ androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hilt-navigation-compose" }
+hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #796 

<br>

## 🚩 Summary
새로운 기능을 Compose로 구현하기 위해 Jetpack Compose 의존성을 추가했습니다.
- Jetpack Compose 의존성 추가
- Compose Material Design3 의존성 추가
- Preview 의존성 추가
- Jetpack Compose UI Test 의존성 추가

<br>

## 🛠️ Technical Concerns
[Compose to Kotlin Compatibility Map](https://developer.android.com/jetpack/androidx/releases/compose-kotlin#pre-release_kotlin_compatibility)

<br>

Kotlin `1.9.0`에 호환되도록 Compose Compiler Version을 `1.5.2`로 설정했습니다.
```kotlin
composeOptions {
    kotlinCompilerExtensionVersion = "1.5.2"
}
```

<br>

## 🙂 To Reviewer
추가로 필요한 의존성이 있는지 확인해 주세요!
공동 카테고리 기능 구현을 위해 빠른 리뷰 부탁드립니다~

<br>

## 📋 To Do
