### PR TITLE
fix: 닉네임 입력 형식 피드백 문구 수정 #807

### DIFF
--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -143,7 +143,7 @@
     <string name="login_start">시작하기</string>
     <string name="login_nickname_hint">닉네임을 입력해 주세요</string>
     <string name="login_nickname_valid_message">사용 가능한 닉네임이에요!</string>
-    <string name="login_nickname_error_message_format">닉네임은 한글, 영어, 숫자,\n마침표(.), 밑줄(_)만 사용할 수 있어요.</string>
+    <string name="login_nickname_error_message_format">닉네임은 한글, 영어, 숫자, 띄어쓰기,\n마침표(.), 밑줄(_)만 사용할 수 있어요.</string>
     <string name="login_nickname_error_message_blank_first">닉네임은 공백으로 시작할 수 없어요.</string>
     <string name="login_nickname_error_message_length">%d~%d 사이의 길이로 입력해 주세요.</string>
     <string name="login_recovery_click_here_if_need_recovery"><u>이전 기록을 불러오려면 여기를 눌러주세요</u></string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #807 

<br>

## 🚩 Summary
닉네임 입력 형식 피드백 문구에 띄어쓰기가 누락되어 있었습니다. 문구를 아래와 같이 변경했습니다.
- `닉네임은 한글, 영어, 숫자, 띄어쓰기,\n마침표(.), 밑줄(_)만 사용할 수 있어요.`

| 변경 전 | 변경 후 |
|---|---|
| ![image](https://github.com/user-attachments/assets/7df7fb0e-b795-4806-9ded-689091e75525) | ![image](https://github.com/user-attachments/assets/2f0ce384-01e6-4603-a7dc-5dead99fe829) |

<br>

## 🙂 To Reviewer
- 이번 주 배포에 함께 적용하려 합니다!

<br>

## 📋 To Do
- 새 기능 컴포즈 열심히~