### PR TITLE
ui: Compose용 Typography 추가 #809

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
@@ -8,12 +8,13 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.on.staccato.R
 
-val pretendard = FontFamily(
-    Font(R.font.pretendard_regular),
-    Font(R.font.pretendard_medium),
-    Font(R.font.pretendard_semibold),
-    Font(R.font.pretendard_bold),
-)
+val pretendard =
+    FontFamily(
+        Font(R.font.pretendard_regular),
+        Font(R.font.pretendard_medium),
+        Font(R.font.pretendard_semibold),
+        Font(R.font.pretendard_bold),
+    )
 
 val title1 =
     defaultTextStyle(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
@@ -1,0 +1,80 @@
+package com.on.staccato.theme
+
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
+import com.on.staccato.R
+
+val pretendard = FontFamily(
+    Font(R.font.pretendard_regular),
+    Font(R.font.pretendard_medium),
+    Font(R.font.pretendard_semibold),
+    Font(R.font.pretendard_bold),
+)
+
+val title1 =
+    defaultTextStyle(
+        fontSize = 20.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 20.sp,
+    )
+
+val title2 =
+    defaultTextStyle(
+        fontSize = 16.sp,
+        fontWeight = FontWeight.Bold,
+        lineHeight = 20.sp,
+    )
+
+val title3 =
+    defaultTextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.SemiBold,
+    )
+
+val body1 =
+    defaultTextStyle(
+        fontSize = 17.sp,
+        fontWeight = FontWeight.Normal,
+    )
+
+val body2 =
+    defaultTextStyle(
+        fontSize = 15.sp,
+        fontWeight = FontWeight.Medium,
+        lineHeight = 20.sp,
+    )
+
+val body3 =
+    defaultTextStyle(
+        fontSize = 14.sp,
+        fontWeight = FontWeight.Normal,
+        lineHeight = 18.sp,
+    )
+
+val body4 =
+    defaultTextStyle(
+        fontSize = 13.sp,
+        fontWeight = FontWeight.Normal,
+    )
+
+val body5 =
+    defaultTextStyle(
+        fontSize = 10.sp,
+        fontWeight = FontWeight.Normal,
+    )
+
+fun defaultTextStyle(
+    fontSize: TextUnit,
+    fontWeight: FontWeight,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+) = TextStyle(
+    fontSize = fontSize,
+    fontWeight = fontWeight,
+    lineHeight = lineHeight,
+    fontFamily = pretendard,
+    letterSpacing = (-0.02).sp,
+)


### PR DESCRIPTION
## ⭐️ Issue Number
- #809

<br>

## 🚩 Summary
- Compose용 Typography 추가

<br>

## 🛠️ Technical Concerns
`사용 방법`
```kotlin
@Composable
fun TextComponent(
    modifier: Modifier = Modifier,
    color: Color = StaccatoBlack,
    description: String,
    style: TextStyle,
) {
    Text(
        text = description,
        modifier = modifier,
        style = style,
        color = color
    )
}

@Preview(showBackground = true)
@Composable
private fun TextPreview() {
    // style에 정의된 typography 설정
    TextComponent(modifier = Modifier, description = "Compose 🚀", style = body1)
}

```

<br>

## 🙂 To Reviewer
Compose app’s theme의 Typography를 사용하면 기존 typography를 사용하기엔 제약이 있어서 style만 정의했습니다!
또한 color는 자유롭게 설정할 수 있도록 Style에 설정하지 않았습니다.

<br>

## 📋 To Do
