### PR TITLE
feat: 닉네임으로 사용자 목록 검색 API 구현 #815

### DIFF
--- a/backend/src/main/java/com/staccato/member/controller/MemberController.java
+++ b/backend/src/main/java/com/staccato/member/controller/MemberController.java
@@ -5,6 +5,8 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import com.staccato.config.auth.LoginMember;
+import com.staccato.member.domain.Member;
 import com.staccato.member.service.MemberService;
 import com.staccato.member.service.dto.response.MemberResponses;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +18,10 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping("/search")
-    public ResponseEntity<MemberResponses> readMembersByNickname(@RequestParam(value = "nickname") String nickname) {
-        MemberResponses memberResponses = memberService.readMembersByNickname(nickname);
+    public ResponseEntity<MemberResponses> readMembersByNickname(
+            @LoginMember Member member, @RequestParam(value = "nickname") String nickname
+    ) {
+        MemberResponses memberResponses = memberService.readMembersByNickname(member, nickname);
         return ResponseEntity.ok(memberResponses);
     }
 }

--- a/backend/src/main/java/com/staccato/member/controller/MemberController.java
+++ b/backend/src/main/java/com/staccato/member/controller/MemberController.java
@@ -1,0 +1,23 @@
+package com.staccato.member.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.staccato.member.service.MemberService;
+import com.staccato.member.service.dto.response.MemberResponses;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @GetMapping("/search")
+    public ResponseEntity<MemberResponses> readMembersByNickname(@RequestParam(value = "nickname") String nickname) {
+        MemberResponses memberResponses = memberService.readMembersByNickname(nickname);
+        return ResponseEntity.ok(memberResponses);
+    }
+}

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -1,9 +1,8 @@
 package com.staccato.member.repository;
 
+import java.util.List;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 
@@ -11,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(Nickname nickname);
 
     Optional<Member> findByCode(String code);
+
+    List<Member> findByNicknameNicknameContains(String nickname);
 }

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -11,5 +11,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByCode(String code);
 
-    List<Member> findByNicknameNicknameContains(String nickname);
+    List<Member> findByNicknameNicknameContainsAndIdNot(String nickname, long memberId);
 }

--- a/backend/src/main/java/com/staccato/member/service/MemberService.java
+++ b/backend/src/main/java/com/staccato/member/service/MemberService.java
@@ -1,11 +1,13 @@
 package com.staccato.member.service;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
 import com.staccato.member.service.dto.response.MemberProfileImageResponse;
+import com.staccato.member.service.dto.response.MemberResponses;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -24,5 +26,10 @@ public class MemberService {
     private Member getMemberById(long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new StaccatoException("요청하신 사용자 정보를 찾을 수 없어요."));
+    }
+
+    public MemberResponses readMembersByNickname(String nickname) {
+        List<Member> members = memberRepository.findByNicknameNicknameContains(nickname);
+        return MemberResponses.of(members);
     }
 }

--- a/backend/src/main/java/com/staccato/member/service/MemberService.java
+++ b/backend/src/main/java/com/staccato/member/service/MemberService.java
@@ -28,8 +28,8 @@ public class MemberService {
                 .orElseThrow(() -> new StaccatoException("요청하신 사용자 정보를 찾을 수 없어요."));
     }
 
-    public MemberResponses readMembersByNickname(String nickname) {
-        List<Member> members = memberRepository.findByNicknameNicknameContains(nickname);
+    public MemberResponses readMembersByNickname(Member member, String nickname) {
+        List<Member> members = memberRepository.findByNicknameNicknameContainsAndIdNot(nickname, member.getId());
         return MemberResponses.of(members);
     }
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponses.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponses.java
@@ -1,0 +1,14 @@
+package com.staccato.member.service.dto.response;
+
+import java.util.List;
+import com.staccato.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 정보 목록에 대한 응답 형식입니다.")
+public record MemberResponses(List<MemberResponse> members) {
+    public static MemberResponses of(List<Member> members) {
+        return new MemberResponses(members.stream()
+                .map(MemberResponse::new)
+                .toList());
+    }
+}

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -1,0 +1,52 @@
+package com.staccato.member.controller;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.staccato.ControllerTest;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.member.domain.Member;
+import com.staccato.member.service.dto.response.MemberResponses;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class MemberControllerTest extends ControllerTest {
+
+    @DisplayName("닉네임으로 검색 요청/응답의 역직렬화/직렬화에 성공한다.")
+    @Test
+    void readMembersByNickname() throws Exception {
+        // given
+        Member member = MemberFixtures.defaultMember().withNickname("스타카토").build();
+        Member member2 = MemberFixtures.defaultMember().withNickname("스타").build();
+        MemberResponses memberResponses = MemberResponses.of(List.of(member, member2));
+        when(memberService.readMembersByNickname(anyString())).thenReturn(memberResponses);
+
+        String expectedResponse = """
+                {
+                    "members": [
+                        {
+                            "id": null,
+                            "nickname": "스타카토",
+                            "memberImageUrl": "https://example.com/memberImage.png"
+                        },
+                        {
+                            "id": null,
+                            "nickname": "스타",
+                            "memberImageUrl": "https://example.com/memberImage.png"
+                        }
+                    ]
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/members/search")
+                        .param("nickname", "스타"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedResponse));
+    }
+
+}

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -29,12 +29,12 @@ class MemberControllerTest extends ControllerTest {
                 {
                     "members": [
                         {
-                            "id": null,
+                            "memberId": null,
                             "nickname": "스타카토",
                             "memberImageUrl": "https://example.com/memberImage.png"
                         },
                         {
-                            "id": null,
+                            "memberId": null,
                             "nickname": "스타",
                             "memberImageUrl": "https://example.com/memberImage.png"
                         }

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -3,11 +3,13 @@ package com.staccato.member.controller;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import com.staccato.ControllerTest;
 import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.member.service.dto.response.MemberResponses;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -22,17 +24,13 @@ class MemberControllerTest extends ControllerTest {
         // given
         Member member = MemberFixtures.defaultMember().withNickname("스타카토").build();
         Member member2 = MemberFixtures.defaultMember().withNickname("스타").build();
-        MemberResponses memberResponses = MemberResponses.of(List.of(member, member2));
-        when(memberService.readMembersByNickname(anyString())).thenReturn(memberResponses);
+        MemberResponses memberResponses = MemberResponses.of(List.of(member2));
+        when(authService.extractFromToken(anyString())).thenReturn(member);
+        when(memberService.readMembersByNickname(any(Member.class), anyString())).thenReturn(memberResponses);
 
         String expectedResponse = """
                 {
                     "members": [
-                        {
-                            "memberId": null,
-                            "nickname": "스타카토",
-                            "memberImageUrl": "https://example.com/memberImage.png"
-                        },
                         {
                             "memberId": null,
                             "nickname": "스타",
@@ -44,7 +42,8 @@ class MemberControllerTest extends ControllerTest {
 
         // when & then
         mockMvc.perform(get("/members/search")
-                        .param("nickname", "스타"))
+                        .param("nickname", "스타")
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedResponse));
     }

--- a/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.staccato.member.service;
 
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +10,11 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
 import com.staccato.member.service.dto.response.MemberProfileImageResponse;
+import com.staccato.member.service.dto.response.MemberResponse;
+import com.staccato.member.service.dto.response.MemberResponses;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 
@@ -51,5 +54,34 @@ class MemberServiceTest extends ServiceSliceTest {
         assertThatThrownBy(() -> memberService.changeProfileImage(member, imageUrl))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessage("요청하신 사용자 정보를 찾을 수 없어요.");
+    }
+
+    @DisplayName("주어진 문자열을 포함하는 닉네임을 가진 사용자 목록을 반환한다.")
+    @Test
+    void readMembersByNickname() {
+        // given
+        Member member1 = MemberFixtures.defaultMember()
+                .withNickname("스타카토")
+                .buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.defaultMember()
+                .withNickname("스타")
+                .buildAndSave(memberRepository);
+        Member member3 = MemberFixtures.defaultMember()
+                .withNickname("타스")
+                .buildAndSave(memberRepository);
+
+        // when
+        String keyword = "스타";
+        MemberResponses result = memberService.readMembersByNickname(keyword);
+
+        // then
+        List<Long> resultNicknames = result.members().stream()
+                .map(MemberResponse::memberId)
+                .toList();
+
+        assertThat(resultNicknames)
+                .hasSize(2)
+                .containsExactlyInAnyOrder(member1.getId(), member2.getId())
+                .doesNotContain(member3.getId());
     }
 }

--- a/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
@@ -60,6 +60,9 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersByNickname() {
         // given
+        Member member = MemberFixtures.defaultMember()
+                .withNickname("사용자")
+                .buildAndSave(memberRepository);
         Member member1 = MemberFixtures.defaultMember()
                 .withNickname("스타카토")
                 .buildAndSave(memberRepository);
@@ -72,16 +75,41 @@ class MemberServiceTest extends ServiceSliceTest {
 
         // when
         String keyword = "스타";
-        MemberResponses result = memberService.readMembersByNickname(keyword);
+        MemberResponses result = memberService.readMembersByNickname(member, keyword);
 
         // then
-        List<Long> resultNicknames = result.members().stream()
+        List<Long> resultIds = result.members().stream()
                 .map(MemberResponse::memberId)
                 .toList();
 
-        assertThat(resultNicknames)
+        assertThat(resultIds)
                 .hasSize(2)
                 .containsExactlyInAnyOrder(member1.getId(), member2.getId())
-                .doesNotContain(member3.getId());
+                .doesNotContain(member.getId(), member3.getId());
+    }
+
+    @DisplayName("주어진 문자열을 포함하는 닉네임으로 사용자 목록을 반환 시 본인은 제외한다.")
+    @Test
+    void readMembersByNicknameWithoutMember() {
+        // given
+        Member member = MemberFixtures.defaultMember()
+                .withNickname("스타")
+                .buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.defaultMember()
+                .withNickname("스타카토")
+                .buildAndSave(memberRepository);
+        // when
+        String keyword = "스타";
+        MemberResponses result = memberService.readMembersByNickname(member, keyword);
+
+        // then
+        List<Long> resultIds = result.members().stream()
+                .map(MemberResponse::memberId)
+                .toList();
+
+        assertThat(resultIds)
+                .hasSize(1)
+                .containsExactlyInAnyOrder(member2.getId())
+                .doesNotContain(member.getId());
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #815 

## 🚩 Summary
- 닉네임으로 사용자 목록을 검색합니다.
- `GET /members/search?nickname={}`
- 응답으로 반환하는 사용자 목록의 사용자 정보는 식별자, 닉네임, 프로필 이미지 경로를 포함합니다.

## 🛠️ Technical Concerns
- 검색한 사용자 중 이미 카테고리에 포함된 사용자 여부를 판단하는 필드를 추가하는 것은 REST하지 않다고 생각이 들었습니다. 따라서, 특정 카테고리에 포함된 사용자 목록 조회 API(이어서 구현 예정)와 닉네임으로 사용자 목록 검색 API를 함께 사용하여 클라이언트 측에서 이미 카테고리에 포함된 사용자를 판단하는 방식이 적합하다고 생각했습니다. 다른 분들의 의견도 궁금해요!

## 🙂 To Reviewer


## 📋 To Do
