### PR TITLE
feat: 카테고리 조회 API의 함께하는 사람들 구현 #816

### DIFF
--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -2,10 +2,8 @@ package com.staccato.category.controller;
 
 import java.net.URI;
 import java.time.LocalDate;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.category.controller.docs.CategoryControllerDocs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryColorRequest;
@@ -26,7 +23,7 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
-import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
@@ -35,7 +32,6 @@ import com.staccato.category.service.dto.response.CategoryStaccatoLocationRespon
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -78,7 +74,7 @@ public class CategoryController implements CategoryControllerDocs {
     public ResponseEntity<CategoryDetailResponse> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
         return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponse());
     }
 

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
@@ -1,10 +1,8 @@
 package com.staccato.category.controller;
 
 import java.net.URI;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,19 +13,18 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.category.controller.docs.CategoryControllerV2Docs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -61,8 +58,8 @@ public class CategoryControllerV2 implements CategoryControllerV2Docs {
     public ResponseEntity<CategoryDetailResponseV2> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
-        return ResponseEntity.ok(categoryDetailResponse);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponseV2());
     }
 
     @PutMapping("/{categoryId}")

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
@@ -1,24 +1,24 @@
 package com.staccato.category.controller;
 
 import java.net.URI;
-
 import jakarta.validation.Valid;
-
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.category.controller.docs.CategoryControllerV3Docs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -37,5 +37,13 @@ public class CategoryControllerV3 implements CategoryControllerV3Docs {
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(categoryCreateRequest, member);
         return ResponseEntity.created(URI.create("/categories/" + categoryIdResponse.categoryId()))
                 .body(categoryIdResponse);
+    }
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryDetailResponseV3> readCategory(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        return ResponseEntity.ok(categoryDetailResponse);
     }
 }

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
@@ -1,13 +1,12 @@
 package com.staccato.category.controller.docs;
 
 import jakarta.validation.Valid;
-
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
-
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.member.domain.Member;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -21,17 +20,17 @@ public interface CategoryControllerV3Docs {
             @ApiResponse(description = "카테고리 생성 성공", responseCode = "201"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-
+                    
                     (1) 필수 값(카테고리 제목, 색상, 카테고리 공개 여부)이 누락되었을 때
-
+                    
                     (2) 날짜 형식(yyyy-MM-dd)이 잘못되었을 때
-
+                    
                     (3) 제목이 공백 포함 30자를 초과했을 때
-
+                    
                     (4) 내용이 공백 포함 500자를 초과했을 때
-
+                    
                     (5) 기간 설정이 잘못되었을 때 (시작 날짜와 끝날짜 중 하나만 설정할 수 없음)
-
+                    
                     (6) 이미 존재하는 카테고리 이름일 때
                     """,
                     responseCode = "400")
@@ -39,4 +38,20 @@ public interface CategoryControllerV3Docs {
     ResponseEntity<CategoryIdResponse> createCategory(
             @Parameter(required = true) @Valid CategoryCreateRequest categoryCreateRequest,
             @Parameter(hidden = true) Member member);
+
+    @Operation(summary = "카테고리 조회", description = "사용자의 카테고리을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                    
+                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    
+                    (2) Path Variable 형식이 잘못되었을 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<CategoryDetailResponseV3> readCategory(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "카테고리 ID", example = "1") @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId);
 }

--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -121,10 +121,8 @@ public class Category extends BaseEntity {
         return term.doesNotContain(date);
     }
 
-    public List<Member> getMates() {
-        return categoryMembers.stream()
-                .map(CategoryMember::getMember)
-                .toList();
+    public List<CategoryMember> getMates() {
+        return categoryMembers;
     }
 
     public boolean isNotOwnedBy(Member member) {

--- a/backend/src/main/java/com/staccato/category/repository/CategoryMemberRepository.java
+++ b/backend/src/main/java/com/staccato/category/repository/CategoryMemberRepository.java
@@ -14,9 +14,6 @@ public interface CategoryMemberRepository extends JpaRepository<CategoryMember, 
     @Query("SELECT mm FROM CategoryMember mm JOIN FETCH mm.category WHERE mm.member.id = :memberId")
     List<CategoryMember> findAllByMemberId(long memberId);
 
-    @Query("SELECT mm FROM CategoryMember mm JOIN FETCH mm.category WHERE mm.category.id = :categoryId")
-    List<CategoryMember> findAllByCategoryId(long categoryId);
-
     @Query("""
             SELECT mm FROM CategoryMember mm JOIN FETCH mm.category WHERE mm.member.id = :memberId
             AND ((mm.category.term.startAt is null AND mm.category.term.endAt is null)

--- a/backend/src/main/java/com/staccato/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/staccato/category/repository/CategoryRepository.java
@@ -1,7 +1,18 @@
 package com.staccato.category.repository;
 
+import java.util.Optional;
 import com.staccato.category.domain.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("""
+            SELECT c FROM Category c
+            LEFT JOIN FETCH c.categoryMembers cm
+            LEFT JOIN FETCH cm.member
+            WHERE c.id = :categoryId
+            """)
+    Optional<Category> findWithCategoryMembersById(@Param("categoryId") long categoryId);
 }

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -136,7 +136,7 @@ public class CategoryService {
     }
 
     private Category getCategoryById(long categoryId) {
-        return categoryRepository.findById(categoryId)
+        return categoryRepository.findWithCategoryMembersById(categoryId)
                 .orElseThrow(() -> new StaccatoException("요청하신 카테고리를 찾을 수 없어요."));
     }
 

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -3,10 +3,8 @@ package com.staccato.category.service;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.CategoryMember;
 import com.staccato.category.repository.CategoryMemberRepository;
@@ -14,10 +12,9 @@ import com.staccato.category.repository.CategoryRepository;
 import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
-import com.staccato.category.service.dto.request.CategoryUpdateRequest;
-import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
-import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.request.CategoryUpdateRequest;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -30,7 +27,6 @@ import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.repository.StaccatoImageRepository;
 import com.staccato.staccato.repository.StaccatoRepository;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -83,11 +79,11 @@ public class CategoryService {
         return sort.apply(categories);
     }
 
-    public CategoryDetailResponseV2 readCategoryById(long categoryId, Member member) {
+    public CategoryDetailResponseV3 readCategoryById(long categoryId, Member member) {
         Category category = getCategoryById(categoryId);
         validateReadPermission(category, member);
         List<Staccato> staccatos = staccatoRepository.findAllByCategoryIdOrdered(categoryId);
-        return new CategoryDetailResponseV2(category, staccatos);
+        return new CategoryDetailResponseV3(category, staccatos);
     }
 
     public CategoryStaccatoLocationResponses readAllStaccatoByCategory(

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponse.java
@@ -1,6 +1,7 @@
 package com.staccato.category.service.dto.response;
 
 import com.staccato.category.domain.Category;
+import com.staccato.category.domain.CategoryMember;
 import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 import java.time.LocalDate;
@@ -47,7 +48,9 @@ public record CategoryDetailResponse(
   }
 
   private static List<MemberResponse> toMemberResponses(Category category) {
-    return category.getMates().stream().map(MemberResponse::new).toList();
+    return category.getMates().stream()
+            .map(CategoryMember::getMember)
+            .map(MemberResponse::new).toList();
   }
 
   private static List<StaccatoResponse> toStaccatoResponses(List<Staccato> staccatos) {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
@@ -1,17 +1,17 @@
 package com.staccato.category.service.dto.response;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.category.domain.Category;
-import com.staccato.category.domain.CategoryMember;
 import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.service.dto.response.MemberResponse;
 import com.staccato.staccato.domain.Staccato;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리에 대한 응답 형식입니다.")
-public record CategoryDetailResponseV2(
+public record CategoryDetailResponseV3(
         @Schema(example = SwaggerExamples.CATEGORY_ID)
         Long categoryId,
         @Schema(example = SwaggerExamples.IMAGE_URL)
@@ -31,11 +31,11 @@ public record CategoryDetailResponseV2(
         @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
-        List<MemberResponse> mates,
+        List<MemberDetailResponse> mates,
         List<StaccatoResponse> staccatos
 ) {
 
-    public CategoryDetailResponseV2(Category category, List<Staccato> staccatos) {
+    public CategoryDetailResponseV3(Category category, List<Staccato> staccatos) {
         this(
                 category.getId(),
                 category.getThumbnailUrl(),
@@ -44,15 +44,14 @@ public record CategoryDetailResponseV2(
                 category.getColor().getName(),
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
-                toMemberResponses(category),
+                toMemberDetailResponses(category),
                 toStaccatoResponses(staccatos)
         );
     }
 
-    private static List<MemberResponse> toMemberResponses(Category category) {
+    private static List<MemberDetailResponse> toMemberDetailResponses(Category category) {
         return category.getMates().stream()
-                .map(CategoryMember::getMember)
-                .map(MemberResponse::new)
+                .map(MemberDetailResponse::new)
                 .toList();
     }
 
@@ -68,8 +67,31 @@ public record CategoryDetailResponseV2(
                 description,
                 startAt,
                 endAt,
-                mates,
+                toMemberResponses(mates),
                 staccatos
         );
     }
+
+    public CategoryDetailResponseV2 toCategoryDetailResponseV2() {
+        return new CategoryDetailResponseV2(
+                categoryId,
+                categoryThumbnailUrl,
+                categoryTitle,
+                description,
+                categoryColor,
+                startAt,
+                endAt,
+                toMemberResponses(mates),
+                staccatos
+        );
+    }
+
+    private List<MemberResponse> toMemberResponses(List<MemberDetailResponse> mates) {
+        List<MemberResponse> memberResponses = new ArrayList<>();
+        for (MemberDetailResponse mate : mates) {
+            memberResponses.add(new MemberResponse(mate.memberId(), mate.nickname(), mate.memberImageUrl()));
+        }
+        return memberResponses;
+    }
 }
+

--- a/backend/src/main/java/com/staccato/category/service/dto/response/MemberDetailResponse.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/MemberDetailResponse.java
@@ -1,0 +1,28 @@
+package com.staccato.category.service.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.category.domain.CategoryMember;
+import com.staccato.config.swagger.SwaggerExamples;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리 조회 시 함께하는 회원 정보를 표시할 때 필요한 정보에 대한 응답 형식입니다.")
+public record MemberDetailResponse(
+        @Schema(example = SwaggerExamples.MEMBER_ID)
+        Long memberId,
+        @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
+        String nickname,
+        @Schema(example = SwaggerExamples.IMAGE_URL)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String memberImageUrl,
+        @Schema(example = SwaggerExamples.CATEGORY_ROLE)
+        String memberRole
+) {
+    public MemberDetailResponse(CategoryMember categoryMember) {
+        this(
+                categoryMember.getMember().getId(),
+                categoryMember.getMember().getNickname().getNickname(),
+                categoryMember.getMember().getImageUrl(),
+                categoryMember.getRole().getRole()
+        );
+    }
+}

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -27,4 +27,5 @@ public class SwaggerExamples {
     public static final String TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
     public static final String SHARE_LINK = "https://staccato.kr/share/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
     public static final String CATEGORY_COLOR = "PINK";
+    public static final String CATEGORY_ROLE = "host";
 }

--- a/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
+++ b/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
@@ -89,7 +89,7 @@ public class StaccatoService {
     }
 
     private Category getCategoryById(long categoryId) {
-        return categoryRepository.findById(categoryId)
+        return categoryRepository.findWithCategoryMembersById(categoryId)
                 .orElseThrow(() -> new StaccatoException("요청하신 카테고리를 찾을 수 없어요."));
     }
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -1,23 +1,9 @@
 package com.staccato.category.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -27,14 +13,13 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
 import com.staccato.ControllerTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.Color;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
-import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -47,6 +32,19 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class CategoryControllerTest extends ControllerTest {
 
@@ -286,7 +284,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -336,7 +334,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -1,22 +1,8 @@
 package com.staccato.category.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,13 +11,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
 import com.staccato.ControllerTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.Color;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
-import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
 import com.staccato.exception.ExceptionResponse;
@@ -41,6 +26,18 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class CategoryControllerV2Test extends ControllerTest {
 
@@ -241,7 +238,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -292,7 +289,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV2 categoryDetailResponse = new CategoryDetailResponseV2(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {

--- a/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,45 @@
+package com.staccato.category.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.staccato.RepositoryTest;
+import com.staccato.category.domain.Category;
+import com.staccato.category.domain.CategoryMember;
+import com.staccato.fixture.category.CategoryFixtures;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+class CategoryRepositoryTest extends RepositoryTest {
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @DisplayName("카테고리 id로 조회 시, categoryMembers와 member까지 함께 조회된다")
+    @Test
+    void findWithCategoryMembersByIdWithCategoryMembersAndMembers() {
+        // given
+        Member member1 = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(member1)
+                .withGuests(member2)
+                .buildAndSave(categoryRepository);
+
+        // when
+        Category result = categoryRepository.findWithCategoryMembersById(category.getId()).get();
+
+        // then
+        assertAll(
+                () -> assertThat(result.getCategoryMembers()).hasSize(2),
+                () -> assertThat(result.getCategoryMembers().stream().map(CategoryMember::getMember).toList())
+                        .containsExactlyInAnyOrder(member1, member2)
+        );
+    }
+}

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -490,7 +490,7 @@ class CategoryServiceTest extends ServiceSliceTest {
         );
     }
 
-    @DisplayName("카테고리를 삭제하면 속한 스타카토들도 함께 삭제된다.")
+    @DisplayName("카테고리를 삭제하면 속한 스타카토, 댓글, 함께하는 사람들도 함께 삭제된다.")
     @Test
     void deleteCategoryWithStaccato() {
         // given
@@ -594,30 +594,5 @@ class CategoryServiceTest extends ServiceSliceTest {
         assertThatThrownBy(() -> categoryService.updateCategoryColor(category.getId(), categoryColorRequest, member))
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
-    }
-
-    @DisplayName("HOST가 카테고리를 삭제하면, 카테고리와 연관된 모든 카테고리멤버가 삭제된다.")
-    @Test
-    void deleteCategoryAlsoDeletesAllRelatedCategoryMembers() {
-        // given
-        Member hostMember = MemberFixtures.defaultMember()
-                .withNickname("host").buildAndSave(memberRepository);
-        Member guestMember = MemberFixtures.defaultMember()
-                .withNickname("guest").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
-                .withHost(hostMember)
-                .withGuests(guestMember)
-                .buildAndSave(categoryRepository);
-
-        // when
-        categoryService.deleteCategory(category.getId(), hostMember);
-
-        // then
-        assertAll(
-                () -> assertThat(categoryMemberRepository.findAllByCategoryId(category.getId())).isEmpty(),
-                () -> assertThat(categoryMemberRepository.findAllByMemberId(hostMember.getId())).isEmpty(),
-                () -> assertThat(categoryMemberRepository.findAllByMemberId(guestMember.getId())).isEmpty(),
-                () -> assertThat(categoryRepository.findById(category.getId())).isEmpty()
-        );
     }
 }

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -1,21 +1,14 @@
 package com.staccato.category.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import com.staccato.ServiceSliceTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.CategoryMember;
@@ -28,7 +21,7 @@ import com.staccato.category.service.dto.request.CategoryCreateRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
 import com.staccato.category.service.dto.request.CategoryUpdateRequest;
-import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
@@ -50,6 +43,11 @@ import com.staccato.member.repository.MemberRepository;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.repository.StaccatoRepository;
 import com.staccato.staccato.service.StaccatoService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CategoryServiceTest extends ServiceSliceTest {
     @Autowired
@@ -212,7 +210,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), host);
 
         // when
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
 
         // then
         assertAll(
@@ -232,10 +230,11 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), host);
         // TODO: 함께하는 사람 추가 서비스 메서드로 교체?
         Category category = categoryRepository.findById(categoryIdResponse.categoryId()).get();
-        categoryMemberRepository.save(CategoryMember.builder().category(category).member(guest).role(Role.GUEST).build());
+        categoryMemberRepository.save(CategoryMember.builder().category(category).member(guest).role(Role.GUEST)
+                .build());
 
         // when
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
 
         // then
         assertAll(
@@ -254,7 +253,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest().withTerm(null, null).build(), member);
 
         // when
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(
@@ -301,7 +300,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withCategory(category).buildAndSave(staccatoRepository);
 
         // when
-        CategoryDetailResponseV2 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(


### PR DESCRIPTION
## ⭐️ Issue Number
- #816 

## 🚩 Summary
- 함께하는 사람 목록 조회 시 Role을 함께 응답으로 주는 V3 API 정의
- category 조회 시 필요한 categoryMember 및 member 정보 fetch join

## 🛠️ Technical Concerns
- categoryMember 양방향 필요성에 대한 의문이 들기 시작했습니다..

## 🙂 To Reviewer


## 📋 To Do
