### PR TITLE
feat: 카테고리 생성 시 공유 여부 선택 기능 추가 #793

### DIFF
--- a/android/Staccato_AN/.editorconfig
+++ b/android/Staccato_AN/.editorconfig
@@ -1,0 +1,2 @@
+[*.{kt,kts}]
+ktlint_function_naming_ignore_when_annotated_with=Composable

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryApiService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/category/CategoryApiService.kt
@@ -31,7 +31,7 @@ interface CategoryApiService {
         @Query(CURRENT_DATE) currentDate: String?,
     ): ApiResult<CategoriesResponse>
 
-    @POST(CATEGORIES_PATH_V2)
+    @POST(CATEGORIES_PATH_V3)
     suspend fun postCategory(
         @Body categoryRequest: CategoryRequest,
     ): ApiResult<CategoryCreationResponse>
@@ -57,5 +57,6 @@ interface CategoryApiService {
         private const val CURRENT_DATE = "currentDate"
         private const val CATEGORIES_PATH_V2 = "/v2${CATEGORIES_PATH}"
         private const val CATEGORY_PATH_WITH_ID_V2 = "/v2$CATEGORIES_PATH/{$CATEGORY_ID}"
+        private const val CATEGORIES_PATH_V3 = "/v3${CATEGORIES_PATH}"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/category/CategoryRequest.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/category/CategoryRequest.kt
@@ -8,7 +8,8 @@ data class CategoryRequest(
     @SerialName("categoryThumbnailUrl") val categoryThumbnailUrl: String? = null,
     @SerialName("categoryTitle") val categoryTitle: String,
     @SerialName("description") val description: String? = null,
+    @SerialName("categoryColor") val color: String? = null,
     @SerialName("startAt") val startAt: String? = null,
     @SerialName("endAt") val endAt: String? = null,
-    @SerialName("categoryColor") val color: String? = null,
+    @SerialName("isShared") val isShared: Boolean,
 )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/mapper/CategoryMapper.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/dto/mapper/CategoryMapper.kt
@@ -50,7 +50,8 @@ fun NewCategory.toDto() =
         categoryThumbnailUrl = categoryThumbnailUrl,
         categoryTitle = categoryTitle,
         description = description,
+        color = color,
         startAt = startAt?.toString(),
         endAt = endAt?.toString(),
-        color = color,
+        isShared = isShared,
     )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/NewCategory.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/domain/model/NewCategory.kt
@@ -5,8 +5,9 @@ import java.time.LocalDate
 data class NewCategory(
     val categoryThumbnailUrl: String? = null,
     val categoryTitle: String,
-    val startAt: LocalDate? = null,
-    val endAt: LocalDate? = null,
     val description: String? = null,
     val color: String,
+    val startAt: LocalDate? = null,
+    val endAt: LocalDate? = null,
+    val isShared: Boolean = false,
 )

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -59,7 +59,7 @@ class CategoryCreationActivity :
         }
 
         binding.composeViewSharingSection.setContent {
-            CategoryShareSection()
+            CategoryShareSection(viewModel)
         }
     }
 
@@ -228,8 +228,9 @@ private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
 }
 
 @Composable
-private fun CategoryShareSection() {
+private fun CategoryShareSection(viewModel: CategoryCreationViewModel) {
+    val isShared by viewModel.isShared.collectAsState()
     CategoryShareSection(
-        checked = false,
-    ) {}
+        checked = isShared,
+    ) { viewModel.updateIsShared(it) }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
-import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
@@ -18,6 +17,7 @@ import com.on.staccato.R
 import com.on.staccato.databinding.ActivityCategoryCreationBinding
 import com.on.staccato.presentation.base.BindingActivity
 import com.on.staccato.presentation.category.CategoryFragment.Companion.CATEGORY_ID_KEY
+import com.on.staccato.presentation.categorycreation.compose.CategoryShareSection
 import com.on.staccato.presentation.categorycreation.viewmodel.CategoryCreationViewModel
 import com.on.staccato.presentation.common.PhotoAttachFragment
 import com.on.staccato.presentation.common.color.CategoryColor
@@ -56,6 +56,10 @@ class CategoryCreationActivity :
         handleError()
         binding.switchCategoryCreationPeriodSet.setContent {
             PeriodActiveSwitch(viewModel)
+        }
+
+        binding.composeViewSharingSection.setContent {
+            CategoryShareSection()
         }
     }
 
@@ -221,4 +225,11 @@ private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
     CustomSwitchComponent(
         checked = checked,
     ) { viewModel.updateIsPeriodActive(it) }
+}
+
+@Composable
+private fun CategoryShareSection() {
+    CategoryShareSection(
+        checked = false,
+    ) {}
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.core.util.Pair
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.snackbar.Snackbar
 import com.on.staccato.R
@@ -55,10 +56,10 @@ class CategoryCreationActivity :
         showErrorToast()
         handleError()
         binding.composeViewCategoryCreationPeriodSet.setContent {
-            PeriodActiveSwitch(viewModel)
+            PeriodActiveSwitch()
         }
         binding.composeViewCategoryCreationShare.setContent {
-            CategoryShareSection(viewModel)
+            CategoryShareSection()
         }
     }
 
@@ -219,7 +220,7 @@ class CategoryCreationActivity :
 }
 
 @Composable
-private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
+private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel = hiltViewModel()) {
     val isPeriodActive by viewModel.isPeriodActive.collectAsState()
     CustomSwitchComponent(
         checked = isPeriodActive,
@@ -227,7 +228,7 @@ private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
 }
 
 @Composable
-private fun CategoryShareSection(viewModel: CategoryCreationViewModel) {
+private fun CategoryShareSection(viewModel: CategoryCreationViewModel = hiltViewModel()) {
     val isShared by viewModel.isShared.collectAsState()
     CategoryShareSection(
         checked = isShared,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -221,9 +221,9 @@ class CategoryCreationActivity :
 
 @Composable
 private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
-    val checked by viewModel.isPeriodActive.collectAsState()
+    val isPeriodActive by viewModel.isPeriodActive.collectAsState()
     CustomSwitchComponent(
-        checked = checked,
+        checked = isPeriodActive,
     ) { viewModel.updateIsPeriodActive(it) }
 }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -54,11 +54,10 @@ class CategoryCreationActivity :
         observeIsPosting()
         showErrorToast()
         handleError()
-        binding.switchCategoryCreationPeriodSet.setContent {
+        binding.composeViewCategoryCreationPeriodSet.setContent {
             PeriodActiveSwitch(viewModel)
         }
-
-        binding.composeViewSharingSection.setContent {
+        binding.composeViewCategoryCreationShare.setContent {
             CategoryShareSection(viewModel)
         }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/CategoryCreationActivity.kt
@@ -5,8 +5,12 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
+import androidx.activity.compose.setContent
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.viewModels
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.core.util.Pair
 import com.google.android.material.datepicker.MaterialDatePicker
 import com.google.android.material.snackbar.Snackbar
@@ -21,6 +25,7 @@ import com.on.staccato.presentation.common.color.ColorSelectionDialogFragment
 import com.on.staccato.presentation.common.color.ColorSelectionDialogFragment.Companion.COLOR_SELECTION_REQUEST_KEY
 import com.on.staccato.presentation.common.color.ColorSelectionDialogFragment.Companion.SELECTED_COLOR_LABEL
 import com.on.staccato.presentation.common.photo.FileUiModel
+import com.on.staccato.presentation.component.CustomSwitchComponent
 import com.on.staccato.presentation.staccatocreation.OnUrisSelectedListener
 import com.on.staccato.presentation.util.ExceptionState2
 import com.on.staccato.presentation.util.convertCategoryUriToFile
@@ -49,6 +54,9 @@ class CategoryCreationActivity :
         observeIsPosting()
         showErrorToast()
         handleError()
+        binding.switchCategoryCreationPeriodSet.setContent {
+            PeriodActiveSwitch(viewModel)
+        }
     }
 
     override fun onPeriodSelectionClicked() {
@@ -205,4 +213,12 @@ class CategoryCreationActivity :
             }
         }
     }
+}
+
+@Composable
+private fun PeriodActiveSwitch(viewModel: CategoryCreationViewModel) {
+    val checked by viewModel.isPeriodActive.collectAsState()
+    CustomSwitchComponent(
+        checked = checked,
+    ) { viewModel.updateIsPeriodActive(it) }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
@@ -9,16 +9,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.on.staccato.R
 import com.on.staccato.presentation.component.CustomSwitchComponent
 import com.on.staccato.presentation.component.TextComponent
 import com.on.staccato.theme.Body4
 import com.on.staccato.theme.Gray3
 import com.on.staccato.theme.Title2
-
-const val CATEGORY_SHARE_TITLE = "카테고리 공유"
-const val CATEGORY_SHARE_HINT = "친구들을 초대해 함께 카테고리를 채워보세요."
 
 @Composable
 fun CategoryShareSection(
@@ -37,13 +36,13 @@ fun CategoryShareSection(
             horizontalAlignment = AbsoluteAlignment.Left,
         ) {
             TextComponent(
-                description = CATEGORY_SHARE_TITLE,
+                description = stringResource(id = R.string.category_creation_share_title),
                 style = Title2,
             )
             Spacer(modifier = Modifier.padding(top = 8.dp))
             TextComponent(
                 color = Gray3,
-                description = CATEGORY_SHARE_HINT,
+                description = stringResource(id = R.string.category_creation_share_hint),
                 style = Body4,
             )
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
@@ -1,0 +1,62 @@
+package com.on.staccato.presentation.categorycreation.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.on.staccato.presentation.component.CustomSwitchComponent
+import com.on.staccato.presentation.component.TextComponent
+import com.on.staccato.theme.Body4
+import com.on.staccato.theme.Gray3
+import com.on.staccato.theme.Title2
+
+const val CATEGORY_SHARE_TITLE = "카테고리 공유"
+const val CATEGORY_SHARE_HINT = "친구들을 초대해 함께 카테고리를 채워보세요."
+
+@Composable
+fun CategoryShareSection(
+    checked: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    Row(
+        modifier =
+            Modifier
+                .padding(top = 24.dp, end = 20.dp)
+                .fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(
+            modifier = Modifier.padding(start = 24.dp),
+            horizontalAlignment = AbsoluteAlignment.Left,
+        ) {
+            TextComponent(
+                description = CATEGORY_SHARE_TITLE,
+                style = Title2,
+            )
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+            TextComponent(
+                color = Gray3,
+                description = CATEGORY_SHARE_HINT,
+                style = Body4,
+            )
+        }
+        Spacer(modifier = Modifier.weight(1f))
+        CustomSwitchComponent(
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CategoryShareSectionPreview() {
+    CategoryShareSection(false) {}
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/compose/CategoryShareSection.kt
@@ -31,25 +31,30 @@ fun CategoryShareSection(
                 .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Column(
-            modifier = Modifier.padding(start = 24.dp),
-            horizontalAlignment = AbsoluteAlignment.Left,
-        ) {
-            TextComponent(
-                description = stringResource(id = R.string.category_creation_share_title),
-                style = Title2,
-            )
-            Spacer(modifier = Modifier.padding(top = 8.dp))
-            TextComponent(
-                color = Gray3,
-                description = stringResource(id = R.string.category_creation_share_hint),
-                style = Body4,
-            )
-        }
+        CategoryShareTitleAndHint()
         Spacer(modifier = Modifier.weight(1f))
         CustomSwitchComponent(
             checked = checked,
             onCheckedChange = onCheckedChange,
+        )
+    }
+}
+
+@Composable
+private fun CategoryShareTitleAndHint() {
+    Column(
+        modifier = Modifier.padding(start = 24.dp),
+        horizontalAlignment = AbsoluteAlignment.Left,
+    ) {
+        TextComponent(
+            description = stringResource(id = R.string.category_creation_share_title),
+            style = Title2,
+        )
+        Spacer(modifier = Modifier.padding(top = 8.dp))
+        TextComponent(
+            color = Gray3,
+            description = stringResource(id = R.string.category_creation_share_hint),
+            style = Body4,
         )
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -33,6 +33,7 @@ import kotlinx.coroutines.launch
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
+import okhttp3.MultipartBody.Part.Companion.createFormData
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.time.LocalDate

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -82,6 +82,9 @@ class CategoryCreationViewModel
         private val _color = MutableLiveData(CategoryColor.GRAY)
         val color: LiveData<CategoryColor> get() = _color
 
+        private val _isShared = MutableStateFlow<Boolean>(false)
+        val isShared: StateFlow<Boolean> = _isShared.asStateFlow()
+
         fun createThumbnailUrl(
             uri: Uri,
             file: FileUiModel,
@@ -122,6 +125,10 @@ class CategoryCreationViewModel
 
         fun updateIsPeriodActive(value: Boolean) {
             _isPeriodActive.value = value
+        }
+
+        fun updateIsShared(value: Boolean) {
+            _isShared.value = value
         }
 
         private fun setThumbnailUri(uri: Uri?) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -197,10 +197,11 @@ class CategoryCreationViewModel
             NewCategory(
                 categoryThumbnailUrl = _thumbnail.value?.url,
                 categoryTitle = title.value ?: throw IllegalArgumentException(),
-                startAt = getDateByPeriodSetting(startDate),
-                endAt = getDateByPeriodSetting(endDate),
                 description = description.value,
                 color = color.value?.label ?: CategoryColor.GRAY.label,
+                startAt = getDateByPeriodSetting(startDate),
+                endAt = getDateByPeriodSetting(endDate),
+                isShared = _isShared.value,
             )
 
         private fun getDateByPeriodSetting(date: LiveData<LocalDate?>): LocalDate? {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -175,7 +175,7 @@ class CategoryCreationViewModel
             val mediaType: MediaType? = fileUiModel.contentType?.toMediaTypeOrNull()
             val requestFile: RequestBody = fileUiModel.file.asRequestBody(mediaType)
 
-            return MultipartBody.Part.createFormData(
+            return createFormData(
                 IMAGE_FORM_DATA_NAME,
                 CATEGORY_FILE_CHILD_NAME,
                 requestFile,

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -26,6 +26,9 @@ import com.on.staccato.presentation.util.ExceptionState2
 import com.on.staccato.presentation.util.IMAGE_FORM_DATA_NAME
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -46,7 +49,9 @@ class CategoryCreationViewModel
     ) : ViewModel() {
         val title = MutableLiveData<String>()
         val description = MutableLiveData<String>()
-        val isPeriodActive = MutableLiveData<Boolean>(false)
+
+        private val _isPeriodActive = MutableStateFlow<Boolean>(false)
+        val isPeriodActive: StateFlow<Boolean> = _isPeriodActive.asStateFlow()
 
         private val _startDate = MutableLiveData<LocalDate?>(null)
         val startDate: LiveData<LocalDate?> get() = _startDate
@@ -113,6 +118,10 @@ class CategoryCreationViewModel
 
         fun updateCategoryColor(color: CategoryColor) {
             _color.value = color
+        }
+
+        fun updateIsPeriodActive(value: Boolean) {
+            _isPeriodActive.value = value
         }
 
         private fun setThumbnailUri(uri: Uri?) {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/categorycreation/viewmodel/CategoryCreationViewModel.kt
@@ -205,7 +205,7 @@ class CategoryCreationViewModel
             )
 
         private fun getDateByPeriodSetting(date: LiveData<LocalDate?>): LocalDate? {
-            return if (isPeriodActive.value == true) {
+            return if (isPeriodActive.value) {
                 date.value
             } else {
                 null

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/CustomSwitchComponent.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/CustomSwitchComponent.kt
@@ -1,0 +1,85 @@
+package com.on.staccato.presentation.component
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.on.staccato.theme.Gray2
+import com.on.staccato.theme.StaccatoBlue70
+import com.on.staccato.theme.White
+
+@Composable
+fun CustomSwitchComponent(
+    modifier: Modifier = Modifier,
+    checked: Boolean = false,
+    checkedTrackColor: Color = StaccatoBlue70,
+    uncheckedTrackColor: Color = Gray2,
+    thumbColor: Color = White,
+    width: Dp = 43.dp,
+    height: Dp = 23.dp,
+    thumbSize: Dp = 19.dp,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    val trackColor by animateColorAsState(
+        if (checked) checkedTrackColor else uncheckedTrackColor,
+        label = "TrackColor",
+    )
+    val padding = 2.dp
+    val thumbPosition by animateDpAsState(
+        if (checked) width - thumbSize - padding else padding,
+        label = "ThumbPosition",
+    )
+
+    Box(
+        modifier =
+            modifier
+                .size(width, height)
+                .clip(RoundedCornerShape(50))
+                .background(trackColor)
+                .clickable { onCheckedChange(!checked) },
+        contentAlignment = Alignment.CenterStart,
+    ) {
+        Box(
+            modifier =
+                Modifier
+                    .padding(start = thumbPosition)
+                    .size(thumbSize)
+                    .background(thumbColor, CircleShape),
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun CustomSwitchPreview(
+    @PreviewParameter(SwitchPreviewParameterProvider::class)
+    checked: Boolean,
+) {
+    CustomSwitchComponent(
+        checked = checked,
+    ) {}
+}
+
+class SwitchPreviewParameterProvider : PreviewParameterProvider<Boolean> {
+    override val values =
+        sequenceOf(
+            false,
+            true,
+        )
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/CustomSwitchComponent.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/CustomSwitchComponent.kt
@@ -15,11 +15,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.on.staccato.R
 import com.on.staccato.theme.Gray2
 import com.on.staccato.theme.StaccatoBlue70
 import com.on.staccato.theme.White
@@ -38,12 +40,12 @@ fun CustomSwitchComponent(
 ) {
     val trackColor by animateColorAsState(
         if (checked) checkedTrackColor else uncheckedTrackColor,
-        label = "TrackColor",
+        label = stringResource(id = R.string.label_custom_switch_track_color),
     )
     val padding = 2.dp
     val thumbPosition by animateDpAsState(
         if (checked) width - thumbSize - padding else padding,
-        label = "ThumbPosition",
+        label = stringResource(id = R.string.label_custom_switch_thumb_position),
     )
 
     Box(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/TextComponent.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/component/TextComponent.kt
@@ -1,0 +1,23 @@
+package com.on.staccato.presentation.component
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import com.on.staccato.theme.StaccatoBlack
+
+@Composable
+fun TextComponent(
+    modifier: Modifier = Modifier,
+    color: Color = StaccatoBlack,
+    description: String,
+    style: TextStyle,
+) {
+    Text(
+        text = description,
+        modifier = modifier,
+        style = style,
+        color = color,
+    )
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/theme/Typography.kt
@@ -8,74 +8,75 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.sp
 import com.on.staccato.R
 
-val pretendard =
-    FontFamily(
-        Font(R.font.pretendard_regular),
-        Font(R.font.pretendard_medium),
-        Font(R.font.pretendard_semibold),
-        Font(R.font.pretendard_bold),
-    )
-
-val title1 =
+val Title1 =
     defaultTextStyle(
         fontSize = 20.sp,
         fontWeight = FontWeight.Bold,
         lineHeight = 20.sp,
     )
 
-val title2 =
+val Title2 =
     defaultTextStyle(
         fontSize = 16.sp,
         fontWeight = FontWeight.Bold,
         lineHeight = 20.sp,
     )
 
-val title3 =
+val Title3 =
     defaultTextStyle(
         fontSize = 14.sp,
         fontWeight = FontWeight.SemiBold,
     )
 
-val body1 =
+val Body1 =
     defaultTextStyle(
         fontSize = 17.sp,
         fontWeight = FontWeight.Normal,
     )
 
-val body2 =
+val Body2 =
     defaultTextStyle(
         fontSize = 15.sp,
         fontWeight = FontWeight.Medium,
         lineHeight = 20.sp,
     )
 
-val body3 =
+val Body3 =
     defaultTextStyle(
         fontSize = 14.sp,
         fontWeight = FontWeight.Normal,
         lineHeight = 18.sp,
     )
 
-val body4 =
+val Body4 =
     defaultTextStyle(
         fontSize = 13.sp,
         fontWeight = FontWeight.Normal,
     )
 
-val body5 =
+val Body5 =
     defaultTextStyle(
         fontSize = 10.sp,
         fontWeight = FontWeight.Normal,
     )
 
-fun defaultTextStyle(
+private val Pretendard =
+    FontFamily(
+        Font(R.font.pretendard_regular, weight = FontWeight.Normal),
+        Font(R.font.pretendard_medium, weight = FontWeight.Medium),
+        Font(R.font.pretendard_semibold, weight = FontWeight.SemiBold),
+        Font(R.font.pretendard_bold, weight = FontWeight.Bold),
+    )
+
+private fun defaultTextStyle(
     fontSize: TextUnit,
     fontWeight: FontWeight,
     lineHeight: TextUnit = TextUnit.Unspecified,
-) = TextStyle(
-    fontSize = fontSize,
-    fontWeight = fontWeight,
-    lineHeight = lineHeight,
-    fontFamily = pretendard,
-    letterSpacing = (-0.02).sp,
-)
+): TextStyle =
+    TextStyle(
+        fontSize = fontSize,
+        fontWeight = fontWeight,
+        lineHeight = lineHeight,
+        fontFamily = Pretendard,
+        letterSpacing = (-0.02).sp,
+    )

--- a/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
@@ -195,7 +195,7 @@
                     app:layout_constraintTop_toBottomOf="@id/tv_category_creation_color" />
 
                 <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/switch_category_creation_period_set"
+                    android:id="@+id/compose_view_category_creation_period_set"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginEnd="20dp"
@@ -227,7 +227,7 @@
                     bind:visibleOrGone="@{viewModel.isPeriodActive}" />
 
                 <androidx.compose.ui.platform.ComposeView
-                    android:id="@+id/compose_view_sharing_section"
+                    android:id="@+id/compose_view_category_creation_share"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_category_creation_period_selection"
@@ -243,7 +243,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/compose_view_sharing_section"
+                    app:layout_constraintTop_toBottomOf="@id/compose_view_category_creation_share"
                     bind:categoryEndDate="@{viewModel.endDate}"
                     bind:categoryStartDate="@{viewModel.startDate}"
                     bind:categoryTitle="@{viewModel.title}"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
@@ -177,8 +177,8 @@
                     android:layout_width="45dp"
                     android:layout_height="45dp"
                     android:layout_marginEnd="24dp"
-                    android:onClick="@{()->handler.onColorSelectionClicked()}"
                     android:background="@android:color/transparent"
+                    android:onClick="@{()->handler.onColorSelectionClicked()}"
                     android:scaleType="fitCenter"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/tv_category_creation_color"
@@ -194,22 +194,14 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/tv_category_creation_color" />
 
-                <com.google.android.material.switchmaterial.SwitchMaterial
+                <androidx.compose.ui.platform.ComposeView
                     android:id="@+id/switch_category_creation_period_set"
                     android:layout_width="wrap_content"
-                    android:layout_height="20dp"
+                    android:layout_height="wrap_content"
                     android:layout_marginEnd="24dp"
-                    android:background="@android:color/transparent"
-                    android:checked="@={viewModel.isPeriodActive}"
-                    android:thumb="@drawable/shape_switch_thumb_oval"
-                    app:layout_constraintBottom_toBottomOf="@id/tv_category_creation_period_title"
+                    app:layout_constraintBottom_toBottomOf="@id/tv_category_creation_period_description"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/tv_category_creation_period_title"
-                    app:switchMinWidth="48dp"
-                    app:thumbTint="@color/white"
-                    app:track="@drawable/shape_switch_track_50dp"
-                    app:trackTint="@drawable/selector_switch_track_colors"
-                    app:trackTintMode="src_in" />
+                    app:layout_constraintTop_toTopOf="@id/tv_category_creation_period_title" />
 
                 <TextView
                     android:id="@+id/tv_category_creation_period_description"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
@@ -176,7 +176,7 @@
                 <ImageButton
                     android:layout_width="45dp"
                     android:layout_height="45dp"
-                    android:layout_marginEnd="24dp"
+                    android:layout_marginEnd="20dp"
                     android:background="@android:color/transparent"
                     android:onClick="@{()->handler.onColorSelectionClicked()}"
                     android:scaleType="fitCenter"
@@ -198,7 +198,7 @@
                     android:id="@+id/switch_category_creation_period_set"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginEnd="24dp"
+                    android:layout_marginEnd="20dp"
                     app:layout_constraintBottom_toBottomOf="@id/tv_category_creation_period_description"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/tv_category_creation_period_title" />
@@ -226,6 +226,14 @@
                     bind:startDate="@{viewModel.startDate}"
                     bind:visibleOrGone="@{viewModel.isPeriodActive}" />
 
+                <androidx.compose.ui.platform.ComposeView
+                    android:id="@+id/compose_view_sharing_section"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout_constraintTop_toBottomOf="@id/tv_category_creation_period_selection"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent" />
+
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_category_creation_save"
                     style="@style/ButtonStyle.Save"
@@ -235,7 +243,7 @@
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_category_creation_period_selection"
+                    app:layout_constraintTop_toBottomOf="@id/compose_view_sharing_section"
                     bind:categoryEndDate="@{viewModel.endDate}"
                     bind:categoryStartDate="@{viewModel.startDate}"
                     bind:categoryTitle="@{viewModel.title}"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_category_creation.xml
@@ -173,6 +173,15 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/text_input_category_creation_description" />
 
+                <TextView
+                    style="@style/HintTextStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:text="@string/category_creation_color_hint"
+                    app:layout_constraintStart_toStartOf="@id/tv_category_creation_color"
+                    app:layout_constraintTop_toBottomOf="@id/tv_category_creation_color" />
+
                 <ImageButton
                     android:layout_width="45dp"
                     android:layout_height="45dp"
@@ -230,9 +239,9 @@
                     android:id="@+id/compose_view_category_creation_share"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    app:layout_constraintTop_toBottomOf="@id/tv_category_creation_period_selection"
+                    app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintEnd_toEndOf="parent" />
+                    app:layout_constraintTop_toBottomOf="@id/tv_category_creation_period_selection" />
 
                 <androidx.appcompat.widget.AppCompatButton
                     android:id="@+id/btn_category_creation_save"

--- a/android/Staccato_AN/app/src/main/res/layout/activity_category_update.xml
+++ b/android/Staccato_AN/app/src/main/res/layout/activity_category_update.xml
@@ -174,12 +174,21 @@
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/text_input_category_update_description" />
 
+                <TextView
+                    style="@style/HintTextStyle"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="5dp"
+                    android:text="@string/category_creation_color_hint"
+                    app:layout_constraintStart_toStartOf="@id/tv_category_update_color"
+                    app:layout_constraintTop_toBottomOf="@id/tv_category_update_color" />
+
                 <ImageButton
                     android:layout_width="45dp"
                     android:layout_height="45dp"
                     android:layout_marginEnd="24dp"
-                    android:onClick="@{()->handler.onColorSelectionClicked()}"
                     android:background="@android:color/transparent"
+                    android:onClick="@{()->handler.onColorSelectionClicked()}"
                     android:scaleType="fitCenter"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintTop_toTopOf="@id/tv_category_update_color"

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="category_creation_description">카테고리 소개</string>
     <string name="category_creation_description_hint">소개를 입력해 주세요</string>
     <string name="category_creation_color">마커 색상</string>
+    <string name="category_creation_color_hint">지도 위에서 보여질 마커의 색을 선택해주세요.</string>
     <string name="category_creation_period_setting">기간 설정</string>
     <string name="category_creation_period_hint">기간을 선택해 주세요</string>
     <string name="category_creation_selected_period">%s ~ %s</string>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -88,6 +88,8 @@
     <string name="category_creation_period_description">여행처럼 시작일과 종료일을 설정할 수 있어요.</string>
     <string name="category_creation_toolbar_title">카테고리 만들기</string>
     <string name="category_creation_toolbar_subtitle">스타카토를 담을 카테고리를 만들어 보세요!</string>
+    <string name="category_creation_share_title">카테고리 공유</string>
+    <string name="category_creation_share_hint">친구들을 초대해 함께 카테고리를 채워보세요.</string>
 
     // activity_category_update
     <string name="category_update_toolbar_title">카테고리 수정하기</string>
@@ -211,6 +213,8 @@
     <string name="error_message_unknown">"예기치 못한 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요."</string>
     <string name="error_message_image_upload">"이미지 업로드에 실패했습니다."</string>
 
+    // custom_switch_component
     <string name="label_custom_switch_track_color">TrackColor</string>
     <string name="label_custom_switch_thumb_position">ThumbPosition</string>
+
 </resources>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -211,4 +211,6 @@
     <string name="error_message_unknown">"예기치 못한 오류가 발생했습니다.\n잠시 후 다시 시도해 주세요."</string>
     <string name="error_message_image_upload">"이미지 업로드에 실패했습니다."</string>
 
+    <string name="label_custom_switch_track_color">TrackColor</string>
+    <string name="label_custom_switch_thumb_position">ThumbPosition</string>
 </resources>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -85,7 +85,7 @@
     <string name="category_creation_period_setting">기간 설정</string>
     <string name="category_creation_period_hint">기간을 선택해 주세요</string>
     <string name="category_creation_selected_period">%s ~ %s</string>
-    <string name="category_creation_period_description">여행과 프로젝트처럼 시작일과 종료일을 설정할 수 있어요.</string>
+    <string name="category_creation_period_description">여행처럼 시작일과 종료일을 설정할 수 있어요.</string>
     <string name="category_creation_toolbar_title">카테고리 만들기</string>
     <string name="category_creation_toolbar_subtitle">스타카토를 담을 카테고리를 만들어 보세요!</string>
 

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/CategoryRemoteDataSourceTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/CategoryRemoteDataSourceTest.kt
@@ -1,0 +1,74 @@
+package com.on.staccato.data
+
+import com.on.staccato.CoroutinesTestExtension
+import com.on.staccato.InstantTaskExecutorExtension
+import com.on.staccato.data.category.CategoryApiService
+import com.on.staccato.data.category.CategoryRemoteDataSource
+import com.on.staccato.data.dto.category.CategoryCreationResponse
+import com.on.staccato.data.dto.category.CategoryRequest
+import com.on.staccato.data.network.Success
+import com.on.staccato.presentation.categorycreation.newCategory
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExperimentalCoroutinesApi
+@ExtendWith(CoroutinesTestExtension::class)
+@ExtendWith(InstantTaskExecutorExtension::class)
+class CategoryRemoteDataSourceTest {
+    @MockK
+    private lateinit var apiService: CategoryApiService
+
+    @InjectMockKs
+    private lateinit var dataSource: CategoryRemoteDataSource
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `공유 카테고리를 생성하면 공유가 활성화된 카테고리 요청이 성공적으로 수행된다`() =
+        runTest {
+            // given
+            val categoryRequest = slot<CategoryRequest>()
+            coEvery { apiService.postCategory(capture(categoryRequest)) } returns Success(CategoryCreationResponse(categoryId = 1L))
+
+            // when
+            val sharedCategory = newCategory.copy(categoryTitle = "공유 카테고리", isShared = true)
+            val actual = dataSource.createCategory(newCategory = sharedCategory)
+
+            // then
+            assertAll(
+                { assertThat(categoryRequest.captured.isShared).isTrue() },
+                { assertThat(actual).isInstanceOf(Success::class.java) },
+            )
+        }
+
+    @Test
+    fun `개인 카테고리를 생성하면 공유가 비활성화된 카테고리 요청이 성공적으로 수행된다`() =
+        runTest {
+            // given
+            val categoryRequest = slot<CategoryRequest>()
+            coEvery { apiService.postCategory(capture(categoryRequest)) } returns Success(CategoryCreationResponse(categoryId = 1L))
+
+            // when
+            val personalCategory = newCategory.copy(categoryTitle = "개인 카테고리", isShared = false)
+            val actual = dataSource.createCategory(newCategory = personalCategory)
+
+            // then
+            assertAll(
+                { assertThat(categoryRequest.captured.isShared).isFalse() },
+                { assertThat(actual).isInstanceOf(Success::class.java) },
+            )
+        }
+}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/categorycreation/NewCategoryFixture.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/presentation/categorycreation/NewCategoryFixture.kt
@@ -7,8 +7,9 @@ val newCategory =
     NewCategory(
         categoryThumbnailUrl = null,
         categoryTitle = "",
-        startAt = null,
-        endAt = null,
         description = null,
         color = CategoryColor.GRAY.label,
+        startAt = null,
+        endAt = null,
+        isShared = false,
     )


### PR DESCRIPTION
## ⭐️ Issue Number
- #793 

<br>

## 🎥 시연 영상 및 OkHttpClient Log
|    공동 카테고리 생성 |   개인 카테고리 생성   |
|:---:|:---:|
|<video src="https://github.com/user-attachments/assets/ee230af2-bb26-4b71-845d-c7dbe97cab67">|<video src="https://github.com/user-attachments/assets/b46b10af-786d-404b-b086-e1bd291f957c">|


변경된 카테고리 조회 API 연동은 빙티가 담당하고 있어 현재 화면 상에서는 공동 카테고리 생성 여부를 직접 확인할 수 없습니다.
이에 따라 공유 여부가 올바르게 전달되었는지 확인할 수 있도록 OkHttpClient 로그를 첨부합니다.
|    공동 카테고리 생성 로그   |    개인 카테고리 생성 로그   |
|:---:|:---:|
|<img width="537" alt="image" src="https://github.com/user-attachments/assets/d815b9ac-6319-4c8c-9f03-0a41fd43cbff" />| <img width="512" alt="image" src="https://github.com/user-attachments/assets/1a358acf-f5e3-4566-b7fc-c7af7bd36e95" /> |

<br>

## 🚩 Summary
- [x] 카테고리 공유 UI 구현 - Jetpack Compose
  - [x] Switch 커스텀
  - [x] 제목, 힌트
- [x] 디자인 변경에 따라 카테고리 기간 설정 Switch를 Custom Switch로 변경
- [x] 변경된 API에 맞게 코드 수정

<br>

## 🛠️ Technical Concerns
### Switch Custom
Material Design3 Switch로는 피그마에 있는 Switch 디자인과 동일하게 구현하기에 제약이 있어 Switch를 커스텀 했습니다.
[[참고자료] Jetpack Compose Switch Custom](https://habr.com/ru/sandbox/213147/)
| Figma에 있는 Switch 디자인 |Material Design3 Switch(기본 스위치)| Custom Switch|
|:---:|:---:|:---:|
| <img width="200" src="https://github.com/user-attachments/assets/cf02e4d0-1c3a-42af-aff3-fece46d689f1" >|<img src="https://github.com/user-attachments/assets/34ea027f-ee0d-4960-b5fa-c2d160a951fe" width=200>|<img src="https://github.com/user-attachments/assets/ba75b09c-600f-45d9-8c1d-b6e8bdcddb58" width=250>|

<br>

### CategoryRemoteDataSource 테스트 작성
변경된 카테고리 조회 API 연동은 빙티가 담당해 현재는 조회 API를 연결해 정상적으로 동작하는 지 확인할 수 없는 상황입니다. 따라서 카테고리 공유 여부 선택 기능이 올바르게 동작하는지 검증하기 위해 테스트 코드를 작성했습니다. slot을 활용해 API에 전달된 실제 CategoryRequest 객체를 캡처하고, 해당 요청의 isShared 필드 값이 기대한 대로 설정되었는지 검증하는 방식을 사용했습니다.

```kotlin
    @Test
    fun `공유 카테고리를 생성하면 공유가 활성화된 카테고리 요청이 성공적으로 수행된다`() =
        runTest {
            // given
            val categoryRequest = slot<CategoryRequest>()
            coEvery { apiService.postCategory(capture(categoryRequest)) } returns Success(CategoryCreationResponse(categoryId = 1L))

            // when
            val sharedCategory = newCategory.copy(categoryTitle = "공유 카테고리", isShared = true)
            val actual = dataSource.createCategory(newCategory = sharedCategory)

            // then
            assertAll(
                { assertThat(categoryRequest.captured.isShared).isTrue() },
                { assertThat(actual).isInstanceOf(Success::class.java) },
            )
        }
```
<br>

## 🙂 To Reviewer
Compose 관련 컨벤션을 같이 정해보면 좋을 것 같아요~!

저는 현재 임시로 아래와 같이 정리해두었습니다.
- `공통 컴포넌트 패키지 위치`: staccato/presentation/component
- `기능별 Compose 파일`: staccato/presentation/기능명/compose 
- `공통 컴포넌트 네이밍` : ~~Component (e.g. TextComponent)
- `영역 구분 네이밍` : ~~Section (영역은 카테고리 기간, 카테고리 공유 등 의미별 블록)
- `화면 구분 네이밍`: ~~ Screen (아직 사용한 곳은 X)

<br>

## 📋 To Do
