### PR TITLE
fix: 안드로이드 CI UI Test 영구 실행 오류 #826

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -22,7 +22,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./android/Staccato_AN
-
     outputs:
       files-prepared: ${{ steps.upload-files.outputs.artifact-name }}
 
@@ -31,7 +30,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -41,21 +39,18 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
-
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
-
       - name: Create Config Files
         run: |
           echo "dev_base_url=\"$DEV_BASE_URL\"" >> local.properties
           echo $SECRETS_PROPERTIES > secrets.properties
           echo $LOCAL_DEFAULTS_PROPERTIES > local.defaults.properties
           echo $GOOGLE_SERVICES_JSON > app/google-services.json
-
       - name: Upload Config Files
         uses: actions/upload-artifact@v4
         with:
@@ -76,7 +71,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./android/Staccato_AN
-
     permissions:
       contents: read
 
@@ -84,20 +78,17 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
-
       - name: Download Config Files
         uses: actions/download-artifact@v4
         with:
           name: config-files
           path: ./android/Staccato_AN
-
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
 
@@ -112,7 +103,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./android/Staccato_AN
-
     permissions:
       contents: read
       checks: write
@@ -122,26 +112,22 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
-
       - name: Download Config Files
         uses: actions/download-artifact@v4
         with:
           name: config-files
           path: ./android/Staccato_AN
-
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
 
       - name: Run Unit Test
         run: ./gradlew testDebugUnitTest --stacktrace --no-build-cache --no-parallel
-
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
@@ -156,7 +142,6 @@ jobs:
       run:
         shell: bash
         working-directory: ./android/Staccato_AN
-
     strategy:
       matrix:
         include:
@@ -167,40 +152,33 @@ jobs:
           - api-level: 34
             profile: "Nexus 7"
       fail-fast: false
-
     permissions:
       contents: read
       actions: read
       checks: write
       pull-requests: write
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
-
       - name: Setup JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
           cache: gradle
-
       - name: Download Config Files
         uses: actions/download-artifact@v4
         with:
           name: config-files
           path: ./android/Staccato_AN
-
       - name: Cache Gradle
         uses: gradle/actions/setup-gradle@v3
-
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
 
@@ -213,7 +191,6 @@ jobs:
           arch: x86_64
           working-directory: ./android/Staccato_AN
           script: ./gradlew connectedCheck --stacktrace
-
       - name: Upload UI Test Results
         uses: actions/upload-artifact@v4
         with:
@@ -221,7 +198,6 @@ jobs:
           path: |
             **/build/reports/*
             **/build/outputs/*/connected/*
-
       - name: Publish UI Test Results
         uses: dorny/test-reporter@v2
         if: always()

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -138,6 +138,7 @@ jobs:
     name: Run UI Test on [API ${{ matrix.api-level }} - ${{ matrix.profile }}]
     runs-on: ubuntu-latest
     needs: setup
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -204,38 +204,13 @@ jobs:
       - name: Grant Execute Permission for Gradlew
         run: chmod +x gradlew
 
-      - name: Cache AVD
-        uses: actions/cache@v4
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-${{ matrix.api-level }}-${{ matrix.profile }}
-
-      - name: Create AVD and Generate Snapshot for Caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: ${{ matrix.api-level }}
-          profile: ${{ matrix.profile }}
-          force-avd-creation: false
-          target: google_apis
-          arch: x86_64
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: echo "Generated AVD snapshot for caching."
-
       - name: Run UI Test with Emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           profile: ${{ matrix.profile }}
-          force-avd-creation: false
           target: google_apis
           arch: x86_64
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
           working-directory: ./android/Staccato_AN
           script: ./gradlew connectedCheck --stacktrace
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #826 

## 🚩 Summary
- 안드로이드 CI 워크플로에서 UI Test가 영구적으로 실행되는 오류를 해결합니다.

## 🛠️ Technical Concerns
### Gradle, AVD 를 캐싱하는 Step을 제거했습니다.
- 테스트가 끝났음에도 특정 기기의 AVD가 종료되지 않고 Step이 무한히 실행 중인 에러가 자주 발생했습니다.
- 또한 특정 기기에서 UI 테스트의 실패도 잦았습니다.
- 이에 캐싱 사용이 문제 원인일 것이라 추측하여 캐싱을 사용하는 step을 제거하였습니다.

## 🙂 To Reviewer
해당 PR의 워크플로가 잘 동작하는지 확인해주세요!
- [x] @hxeyexn 
- [x] @s6m1n 

## 📋 To Do
- 문제 없이 CI 적용하기
- 열린 PR 리뷰하기