### PR TITLE
feat: 카테고리 목록 조회 API V3 구현 #821

### DIFF
--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -27,7 +27,7 @@ import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
-import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
@@ -57,7 +57,7 @@ public class CategoryController implements CategoryControllerDocs {
             @LoginMember Member member,
             @ModelAttribute("CategoryReadRequest") CategoryReadRequest categoryReadRequest
     ) {
-        CategoryResponsesV2 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
+        CategoryResponsesV3 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
         return ResponseEntity.ok(categoryResponses.toCategoryResponses());
     }
 

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
@@ -22,6 +22,7 @@ import com.staccato.category.service.dto.response.CategoryDetailResponseV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -50,8 +51,8 @@ public class CategoryControllerV2 implements CategoryControllerV2Docs {
             @LoginMember Member member,
             @ModelAttribute("CategoryReadRequest") CategoryReadRequest categoryReadRequest
     ) {
-        CategoryResponsesV2 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
-        return ResponseEntity.ok(categoryResponses);
+        CategoryResponsesV3 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
+        return ResponseEntity.ok(categoryResponses.toCategoryResponsesV2());
     }
 
     @GetMapping("/{categoryId}")

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,8 +15,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.staccato.category.controller.docs.CategoryControllerV3Docs;
 import com.staccato.category.service.CategoryService;
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
+import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -45,5 +48,14 @@ public class CategoryControllerV3 implements CategoryControllerV3Docs {
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
         CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
         return ResponseEntity.ok(categoryDetailResponse);
+    }
+
+    @GetMapping
+    public ResponseEntity<CategoryResponsesV3> readAllCategories(
+            @LoginMember Member member,
+            @ModelAttribute("CategoryReadRequest") CategoryReadRequest categoryReadRequest
+    ) {
+        CategoryResponsesV3 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
+        return ResponseEntity.ok(categoryResponses);
     }
 }

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
@@ -4,8 +4,10 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
+import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -54,4 +56,11 @@ public interface CategoryControllerV3Docs {
     ResponseEntity<CategoryDetailResponseV3> readCategory(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "카테고리 ID", example = "1") @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId);
+
+    @Operation(summary = "카테고리 목록 조회", description = "사용자의 모든 카테고리 목록을 조회합니다.")
+    @ApiResponse(description = "카테고리 목록 조회 성공", responseCode = "200")
+    ResponseEntity<CategoryResponsesV3> readAllCategories(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "정렬 기준은 생략하거나 유효하지 않은 값에 대해서는 최근 수정 순(UPDATED)이 기본 정렬로 적용됩니다. 필터링 조건은 생략하거나 유효하지 않은 값이 들어오면 적용되지 않습니다.") CategoryReadRequest categoryReadRequest
+    );
 }

--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -1,10 +1,10 @@
 package com.staccato.category.domain;
 
-import com.staccato.staccato.domain.Staccato;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -18,7 +18,7 @@ import jakarta.persistence.OneToMany;
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
-
+import com.staccato.staccato.domain.Staccato;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -55,6 +55,8 @@ public class Category extends BaseEntity {
     private Boolean isShared;
     @OneToMany(mappedBy = "category", cascade = CascadeType.PERSIST)
     private List<CategoryMember> categoryMembers = new ArrayList<>();
+/*    @Column
+    private Long staccatoCount;*/
 
     public Category(String thumbnailUrl, @NonNull String title, String description, Color color, LocalDate startAt,
                     LocalDate endAt, @NonNull Boolean isShared) {
@@ -64,6 +66,9 @@ public class Category extends BaseEntity {
         this.color = color;
         this.term = new Term(startAt, endAt);
         this.isShared = isShared;
+/*        if (Objects.isNull(this.staccatoCount)) {
+            this.staccatoCount = 0L;
+        }*/
     }
 
     @Builder
@@ -145,7 +150,18 @@ public class Category extends BaseEntity {
         return term.isExist();
     }
 
-    public void changeColor(Color color){
+    public void changeColor(Color color) {
         this.color = color;
     }
+
+/*    public void increaseStaccatoCount() {
+        staccatoCount = staccatoCount + 1;
+    }
+
+    public void decreaseStaccatoCount() {
+        if (staccatoCount == 0) {
+            return;
+        }
+        staccatoCount = staccatoCount - 1;
+    }*/
 }

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -1,6 +1,7 @@
 package com.staccato.category.service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
+import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.comment.repository.CommentRepository;
@@ -55,8 +57,16 @@ public class CategoryService {
     public CategoryResponsesV3 readAllCategories(Member member, CategoryReadRequest categoryReadRequest) {
         List<Category> rawCategories = getCategories(categoryMemberRepository.findAllByMemberId(member.getId()));
         List<Category> categories = filterAndSort(rawCategories, categoryReadRequest.getFilters(), categoryReadRequest.getSort());
+        return getCategoryResponsesV3(categories);
+    }
 
-        return CategoryResponsesV3.from(categories);
+    private CategoryResponsesV3 getCategoryResponsesV3(List<Category> categories) {
+        List<CategoryResponseV3> responses = new ArrayList<>();
+        for (Category category : categories) {
+            long staccatoCount = staccatoRepository.countAllByCategoryId(category.getId());
+            responses.add(new CategoryResponseV3(category, staccatoCount));
+        }
+        return new CategoryResponsesV3(responses);
     }
 
     public CategoryNameResponses readAllCategoriesByDate(Member member, LocalDate currentDate) {

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -17,7 +17,7 @@ import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
-import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.config.log.annotation.Trace;
@@ -52,11 +52,11 @@ public class CategoryService {
         return new CategoryIdResponse(category.getId());
     }
 
-    public CategoryResponsesV2 readAllCategories(Member member, CategoryReadRequest categoryReadRequest) {
+    public CategoryResponsesV3 readAllCategories(Member member, CategoryReadRequest categoryReadRequest) {
         List<Category> rawCategories = getCategories(categoryMemberRepository.findAllByMemberId(member.getId()));
         List<Category> categories = filterAndSort(rawCategories, categoryReadRequest.getFilters(), categoryReadRequest.getSort());
 
-        return CategoryResponsesV2.from(categories);
+        return CategoryResponsesV3.from(categories);
     }
 
     public CategoryNameResponses readAllCategoriesByDate(Member member, LocalDate currentDate) {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
@@ -31,6 +31,8 @@ public record CategoryDetailResponseV3(
         @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
+        @Schema(example = SwaggerExamples.CATEGORY_IS_SHARED)
+        boolean isShared,
         List<MemberDetailResponse> members,
         List<StaccatoResponse> staccatos
 ) {
@@ -44,6 +46,7 @@ public record CategoryDetailResponseV3(
                 category.getColor().getName(),
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
+                category.getIsShared(),
                 toMemberDetailResponses(category),
                 toStaccatoResponses(staccatos)
         );

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
@@ -31,7 +31,7 @@ public record CategoryDetailResponseV3(
         @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
-        List<MemberDetailResponse> mates,
+        List<MemberDetailResponse> members,
         List<StaccatoResponse> staccatos
 ) {
 
@@ -67,7 +67,7 @@ public record CategoryDetailResponseV3(
                 description,
                 startAt,
                 endAt,
-                toMemberResponses(mates),
+                toMemberResponses(members),
                 staccatos
         );
     }
@@ -81,7 +81,7 @@ public record CategoryDetailResponseV3(
                 categoryColor,
                 startAt,
                 endAt,
-                toMemberResponses(mates),
+                toMemberResponses(members),
                 staccatos
         );
     }

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
@@ -1,9 +1,12 @@
 package com.staccato.category.service.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.category.domain.Category;
+import com.staccato.category.domain.CategoryMember;
 import com.staccato.config.swagger.SwaggerExamples;
+import com.staccato.member.service.dto.response.MemberResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리 목록 조회 시 각각의 카테고리에 대한 응답 형식입니다.")
@@ -22,7 +25,10 @@ public record CategoryResponseV3(
         LocalDate startAt,
         @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        LocalDate endAt
+        LocalDate endAt,
+        List<MemberResponse> members,
+        @Schema(example = SwaggerExamples.STACCATO_COUNT)
+        Long staccatoCount
 ) {
     public CategoryResponseV3(Category category) {
         this(
@@ -31,8 +37,18 @@ public record CategoryResponseV3(
                 category.getTitle(),
                 category.getColor().getName(),
                 category.getTerm().getStartAt(),
-                category.getTerm().getEndAt()
+                category.getTerm().getEndAt(),
+                toMemberResponses(category.getCategoryMembers()),
+                //TODO: 스타카토 개수 실제 값 반영
+                0L
         );
+    }
+
+    private static List<MemberResponse> toMemberResponses(List<CategoryMember> categoryMembers) {
+        return categoryMembers.stream()
+                .map(CategoryMember::getMember)
+                .map(MemberResponse::new)
+                .toList();
     }
 
     public CategoryResponse toCategoryResponse() {

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
@@ -30,7 +30,7 @@ public record CategoryResponseV3(
         @Schema(example = SwaggerExamples.STACCATO_COUNT)
         Long staccatoCount
 ) {
-    public CategoryResponseV3(Category category) {
+    public CategoryResponseV3(Category category, long staccatoCount) {
         this(
                 category.getId(),
                 category.getThumbnailUrl(),
@@ -39,8 +39,7 @@ public record CategoryResponseV3(
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
                 toMemberResponses(category.getCategoryMembers()),
-                //TODO: 스타카토 개수 실제 값 반영
-                0L
+                staccatoCount
         );
     }
 

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
@@ -1,0 +1,58 @@
+package com.staccato.category.service.dto.response;
+
+import java.time.LocalDate;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.category.domain.Category;
+import com.staccato.config.swagger.SwaggerExamples;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리 목록 조회 시 각각의 카테고리에 대한 응답 형식입니다.")
+public record CategoryResponseV3(
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
+        Long categoryId,
+        @Schema(example = SwaggerExamples.IMAGE_URL)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String categoryThumbnailUrl,
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
+        String categoryTitle,
+        @Schema(example = SwaggerExamples.CATEGORY_COLOR)
+        String categoryColor,
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate startAt,
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate endAt
+) {
+    public CategoryResponseV3(Category category) {
+        this(
+                category.getId(),
+                category.getThumbnailUrl(),
+                category.getTitle(),
+                category.getColor().getName(),
+                category.getTerm().getStartAt(),
+                category.getTerm().getEndAt()
+        );
+    }
+
+    public CategoryResponse toCategoryResponse() {
+        return new CategoryResponse(
+                categoryId,
+                categoryThumbnailUrl,
+                categoryTitle,
+                startAt,
+                endAt
+        );
+    }
+
+    public CategoryResponseV2 toCategoryResponseV2() {
+        return new CategoryResponseV2(
+                categoryId,
+                categoryThumbnailUrl,
+                categoryTitle,
+                categoryColor,
+                startAt,
+                endAt
+        );
+    }
+}

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV2.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV2.java
@@ -1,9 +1,7 @@
 package com.staccato.category.service.dto.response;
 
 import java.util.List;
-
 import com.staccato.category.domain.Category;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리 목록 조회 시 반환 되는 응답 형식입니다.")
@@ -13,12 +11,6 @@ public record CategoryResponsesV2(
     public static CategoryResponsesV2 from(List<Category> categories) {
         return new CategoryResponsesV2(categories.stream()
                 .map(CategoryResponseV2::new)
-                .toList());
-    }
-
-    public CategoryResponses toCategoryResponses() {
-        return new CategoryResponses(categories.stream()
-                .map(CategoryResponseV2::toCategoryResponse)
                 .toList());
     }
 }

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV3.java
@@ -8,11 +8,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CategoryResponsesV3(
         List<CategoryResponseV3> categories
 ) {
-    public static CategoryResponsesV3 from(List<Category> categories) {
-        return new CategoryResponsesV3(categories.stream()
-                .map(CategoryResponseV3::new)
-                .toList());
-    }
 
     public CategoryResponses toCategoryResponses() {
         return new CategoryResponses(categories.stream()

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponsesV3.java
@@ -1,0 +1,28 @@
+package com.staccato.category.service.dto.response;
+
+import java.util.List;
+import com.staccato.category.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리 목록 조회 시 반환 되는 응답 형식입니다.")
+public record CategoryResponsesV3(
+        List<CategoryResponseV3> categories
+) {
+    public static CategoryResponsesV3 from(List<Category> categories) {
+        return new CategoryResponsesV3(categories.stream()
+                .map(CategoryResponseV3::new)
+                .toList());
+    }
+
+    public CategoryResponses toCategoryResponses() {
+        return new CategoryResponses(categories.stream()
+                .map(CategoryResponseV3::toCategoryResponse)
+                .toList());
+    }
+
+    public CategoryResponsesV2 toCategoryResponsesV2() {
+        return new CategoryResponsesV2(categories.stream()
+                .map(CategoryResponseV3::toCategoryResponseV2)
+                .toList());
+    }
+}

--- a/backend/src/main/java/com/staccato/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/staccato/config/OpenApiConfig.java
@@ -41,6 +41,7 @@ public class OpenApiConfig {
         return GroupedOpenApi.builder()
                 .group("V1 API")
                 .pathsToExclude("/v2/**")
+                .pathsToExclude("/v3/**")
                 .build();
     }
 
@@ -49,6 +50,14 @@ public class OpenApiConfig {
         return GroupedOpenApi.builder()
                 .group("V2 API")
                 .pathsToMatch("/v2/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi v3Api() {
+        return GroupedOpenApi.builder()
+                .group("V3 API")
+                .pathsToMatch("/v3/**")
                 .build();
     }
 }

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -28,4 +28,5 @@ public class SwaggerExamples {
     public static final String SHARE_LINK = "https://staccato.kr/share/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
     public static final String CATEGORY_COLOR = "PINK";
     public static final String CATEGORY_ROLE = "host";
+    public static final String STACCATO_COUNT = "42";
 }

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -29,4 +29,5 @@ public class SwaggerExamples {
     public static final String CATEGORY_COLOR = "PINK";
     public static final String CATEGORY_ROLE = "host";
     public static final String STACCATO_COUNT = "42";
+    public static final String CATEGORY_IS_SHARED = "false";
 }

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -58,4 +58,6 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
     @Modifying
     @Query("DELETE FROM Staccato s WHERE s.category.id = :categoryId")
     void deleteAllByCategoryIdInBulk(@Param("categoryId") Long categoryId);
+
+    long countAllByCategoryId(Long id);
 }

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -22,6 +22,7 @@ import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRe
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
+import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponse;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
@@ -182,7 +183,10 @@ class CategoryControllerTest extends ControllerTest {
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
                 .withTerm(null, null).build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(categoryWithTerm, 0),
+                new CategoryResponseV3(categoryWithoutTerm,0))
+        );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
@@ -218,8 +222,10 @@ class CategoryControllerTest extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category1 = CategoryFixtures.defaultCategory().build();
         Category category2 = CategoryFixtures.defaultCategory().build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
-
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(category1, 0),
+                new CategoryResponseV3(category2,0))
+        );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 
         // when & then

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -22,7 +22,7 @@ import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRe
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
-import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponse;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.exception.ExceptionResponse;
@@ -182,7 +182,7 @@ class CategoryControllerTest extends ControllerTest {
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
                 .withTerm(null, null).build();
-        CategoryResponsesV2 categoryResponses = CategoryResponsesV2.from(List.of(categoryWithTerm, categoryWithoutTerm));
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
@@ -218,7 +218,7 @@ class CategoryControllerTest extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category1 = CategoryFixtures.defaultCategory().build();
         Category category2 = CategoryFixtures.defaultCategory().build();
-        CategoryResponsesV2 categoryResponses = CategoryResponsesV2.from(List.of(category1, category2));
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
 
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -18,6 +18,7 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
+import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.category.CategoryFixtures;
@@ -177,8 +178,10 @@ class CategoryControllerV2Test extends ControllerTest {
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
                 .withTerm(null, null).build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
-        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(categoryWithTerm, 0),
+                new CategoryResponseV3(categoryWithoutTerm,0))
+        );        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
                     "categories": [
@@ -215,8 +218,10 @@ class CategoryControllerV2Test extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category1 = CategoryFixtures.defaultCategory().build();
         Category category2 = CategoryFixtures.defaultCategory().build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
-
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(category1, 0),
+                new CategoryResponseV3(category2,0))
+        );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 
         // when & then

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -18,7 +18,7 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequestV2;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
-import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.category.CategoryRequestV2Fixtures;
@@ -177,7 +177,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
                 .withTerm(null, null).build();
-        CategoryResponsesV2 categoryResponses = CategoryResponsesV2.from(List.of(categoryWithTerm, categoryWithoutTerm));
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
@@ -215,7 +215,7 @@ class CategoryControllerV2Test extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category1 = CategoryFixtures.defaultCategory().build();
         Category category2 = CategoryFixtures.defaultCategory().build();
-        CategoryResponsesV2 categoryResponses = CategoryResponsesV2.from(List.of(category1, category2));
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
 
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -199,7 +199,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryColor": "pink",
                     "startAt": "2024-01-01",
                     "endAt": "2024-12-31",
-                    "isShared": false,
+                    "isShared": true,
                     "members": [
                         {
                             "memberId": null,

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -199,6 +199,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryColor": "pink",
                     "startAt": "2024-01-01",
                     "endAt": "2024-12-31",
+                    "isShared": false,
                     "members": [
                         {
                             "memberId": null,

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -26,9 +26,12 @@ import org.springframework.http.MediaType;
 
 import com.staccato.ControllerTest;
 import com.staccato.category.domain.Category;
+import com.staccato.category.domain.Color;
 import com.staccato.category.service.dto.request.CategoryCreateRequest;
+import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.category.CategoryCreateRequestFixtures;
 import com.staccato.fixture.category.CategoryFixtures;
@@ -195,7 +198,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryColor": "pink",
                     "startAt": "2024-01-01",
                     "endAt": "2024-12-31",
-                    "mates": [
+                    "members": [
                         {
                             "memberId": null,
                             "nickname": "host",
@@ -251,7 +254,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryTitle": "categoryTitle",
                     "description": "categoryDescription",
                     "categoryColor": "pink",
-                    "mates": [
+                    "members": [
                         {
                             "memberId": null,
                             "nickname": "nickname",
@@ -275,5 +278,86 @@ class CategoryControllerV3Test extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedResponse));
+    }
+
+    @DisplayName("사용자가 모든 카테고리 목록을 조회하는 응답 직렬화에 성공한다.")
+    @Test
+    void readAllCategory() throws Exception {
+        // given
+        Member member = MemberFixtures.defaultMember().build();
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        Category categoryWithTerm = CategoryFixtures.defaultCategory()
+                .withColor(Color.PINK)
+                .withHost(member)
+                .withTerm(LocalDate.of(2024, 1, 1),
+                        LocalDate.of(2024, 12, 31)).build();
+        Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
+                .withColor(Color.BLUE)
+                .withHost(member)
+                .withTerm(null, null).build();
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
+        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
+        String expectedResponse = """
+                {
+                    "categories": [
+                        {
+                            "categoryId": null,
+                            "categoryTitle": "categoryTitle",
+                            "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
+                            "categoryColor": "pink",
+                            "startAt": "2024-01-01",
+                            "endAt": "2024-12-31",
+                            "members": [
+                                {
+                                    "memberId": null,
+                                    "nickname": "nickname",
+                                    "memberImageUrl": "https://example.com/memberImage.png"
+                                }
+                            ],
+                            "staccatoCount": 0
+                        },
+                        {
+                            "categoryId": null,
+                            "categoryTitle": "categoryTitle",
+                            "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
+                            "categoryColor": "blue",
+                            "members": [
+                                {
+                                    "memberId": null,
+                                    "nickname": "nickname",
+                                    "memberImageUrl": "https://example.com/memberImage.png"
+                                }
+                            ],
+                            "staccatoCount": 0
+                        }
+                    ]
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/v3/categories")
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedResponse));
+    }
+
+    @DisplayName("유효하지 않은 필터링 조건은 무시하고, 모든 카테고리 목록을 조회한다.")
+    @Test
+    void readAllCategoryIgnoringInvalidFilter() throws Exception {
+        // given
+        Member member = MemberFixtures.defaultMember().build();
+        when(authService.extractFromToken(anyString())).thenReturn(member);
+        Category category1 = CategoryFixtures.defaultCategory().build();
+        Category category2 = CategoryFixtures.defaultCategory().build();
+        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
+
+        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
+
+        // when & then
+        mockMvc.perform(get("/v3/categories")
+                        .header(HttpHeaders.AUTHORIZATION, "token")
+                        .param("filters", "invalid"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categories.size()").value(2));
     }
 }

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -31,6 +31,7 @@ import com.staccato.category.service.dto.request.CategoryCreateRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
+import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.category.CategoryCreateRequestFixtures;
@@ -295,7 +296,10 @@ class CategoryControllerV3Test extends ControllerTest {
                 .withColor(Color.BLUE)
                 .withHost(member)
                 .withTerm(null, null).build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(categoryWithTerm, categoryWithoutTerm));
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(categoryWithTerm, 0),
+                new CategoryResponseV3(categoryWithoutTerm,0))
+        );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
@@ -349,8 +353,10 @@ class CategoryControllerV3Test extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category1 = CategoryFixtures.defaultCategory().build();
         Category category2 = CategoryFixtures.defaultCategory().build();
-        CategoryResponsesV3 categoryResponses = CategoryResponsesV3.from(List.of(category1, category2));
-
+        CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
+                new CategoryResponseV3(category1, 0),
+                new CategoryResponseV3(category2,0))
+        );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 
         // when & then

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -162,4 +162,36 @@ class CategoryTest {
         // then
         assertThat(isDenied).isEqualTo(false);
     }
+/*
+    @DisplayName("처음 카테고리를 생성했을 때 스타카토는 0개이다.")
+    @Test
+    void createCategoryAndStaccatoCountIsZero() {
+        // given
+        Category category = Category.builder()
+                .title("category")
+                .isShared(false)
+                .color(Color.LIGHT_GRAY.getName())
+                .build();
+
+        // when
+        long result = category.getStaccatoCount();
+
+        // then
+        assertThat(result).isZero();
+    }
+
+    @DisplayName("카테고리를 수정해도, 스타카토 개수는 영향을 받지 않는다.")
+    @Test
+    void updateCategoryWithoutStaccatoCount() {
+        // given
+        Category category = Category.builder()
+                .title("category")
+                .isShared(false)
+                .color(Color.LIGHT_GRAY.getName())
+                .build();
+        category.increaseStaccatoCount();
+
+        // when
+
+    }*/
 }

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -215,7 +215,7 @@ class CategoryServiceTest extends ServiceSliceTest {
         // then
         assertAll(
                 () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.mates()).hasSize(1)
+                () -> assertThat(categoryDetailResponse.members()).hasSize(1)
         );
     }
 
@@ -239,7 +239,7 @@ class CategoryServiceTest extends ServiceSliceTest {
         // then
         assertAll(
                 () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.mates()).hasSize(2)
+                () -> assertThat(categoryDetailResponse.members()).hasSize(2)
         );
     }
 
@@ -258,7 +258,7 @@ class CategoryServiceTest extends ServiceSliceTest {
         // then
         assertAll(
                 () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.mates()).hasSize(1),
+                () -> assertThat(categoryDetailResponse.members()).hasSize(1),
                 () -> assertThat(categoryDetailResponse.startAt()).isNull(),
                 () -> assertThat(categoryDetailResponse.endAt()).isNull()
         );

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -24,7 +24,7 @@ import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
-import com.staccato.category.service.dto.response.CategoryResponsesV2;
+import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponse;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.category.service.dto.response.StaccatoResponse;
@@ -191,7 +191,7 @@ class CategoryServiceTest extends ServiceSliceTest {
         CategoryReadRequest categoryReadRequest = new CategoryReadRequest("false", null);
 
         // when
-        CategoryResponsesV2 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
+        CategoryResponsesV3 categoryResponses = categoryService.readAllCategories(member, categoryReadRequest);
 
         // then
         assertAll(

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -363,6 +363,30 @@ class CategoryServiceTest extends ServiceSliceTest {
         );
     }
 
+    @DisplayName("카테고리 목록 조회 시 각 카테고리에 해당하는 스타카토 개수가 포함된다.")
+    @Test
+    void readAllCategoriesContainsStaccatoCount() {
+        // given
+        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(member)
+                .buildAndSave(categoryRepository);
+
+        StaccatoFixtures.defaultStaccato().withCategory(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.defaultStaccato().withCategory(category).buildAndSave(staccatoRepository);
+
+        CategoryReadRequest request = new CategoryReadRequest(null, null);
+
+        // when
+        CategoryResponsesV3 categoryResponses = categoryService.readAllCategories(member, request);
+
+        // then
+        assertAll(
+                () -> assertThat(categoryResponses.categories()).hasSize(1),
+                () -> assertThat(categoryResponses.categories().get(0).staccatoCount()).isEqualTo(2L)
+        );
+    }
+
     @DisplayName("카테고리 정보를 기반으로, 카테고리를 수정한다.")
     @MethodSource("updateCategoryProvider")
     @ParameterizedTest

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
@@ -71,6 +71,7 @@ public class CategoryFixtures {
 
         public CategoryBuilder withGuests(Member... members) {
             this.guests.addAll(Arrays.asList(members));
+            this.isShared = false;
             return this;
         }
 

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
@@ -71,7 +71,7 @@ public class CategoryFixtures {
 
         public CategoryBuilder withGuests(Member... members) {
             this.guests.addAll(Arrays.asList(members));
-            this.isShared = false;
+            this.isShared = true;
             return this;
         }
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.staccato.RepositoryTest;
 import com.staccato.category.domain.Category;
@@ -263,5 +266,27 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 () -> assertThat(staccatos.size()).isEqualTo(2),
                 () -> assertThat(staccatos).containsExactly(staccato2, staccato1)
         );
+    }
+
+    @DisplayName("카테고리에 속한 스타카토의 개수을 조회한다.")
+    @ParameterizedTest
+    @ValueSource(ints = {0, 2})
+    void countAllByCategoryWhenZero(int staccatoCount) {
+        //given
+        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .buildAndSave(categoryRepository);
+        for (int count = 1; count <= staccatoCount; count++) {
+            StaccatoFixtures.defaultStaccato()
+                    .withCategory(category)
+                    .buildAndSave(staccatoRepository);
+        }
+
+        // when
+        long result = staccatoRepository.countAllByCategoryId(category.getId());
+
+        // then
+        assertThat(result).isEqualTo(result);
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #821

## 🚩 Summary
- 각 카테고리 응답에 함께하는 사람 목록 & 총 스타카토 개수 응답을  포함
- 함께하는 사람 목록에는 모든 사용자를 포함합니다. 몇 명을 표기할지는 디자인에 따라 클라이언트 측에서 구현합니다.

## 🛠️ Technical Concerns
- 총 스타카토 개수를 매번 조회하는 것(count 쿼리) 성능 부하가 크다고 하지만, 실행 계획을 살펴보았을 때 커버링 인덱스를 사용하기 때문에 `과연 성능 부하가 그렇게 클까?`하는 생각이 들었어요. 직접 확인해보고 싶은 욕심이 있어서 관련 내용은 이 pr에 추가해놓도록 하겠습니다.
- 전체 회의에서는 우선은 count 쿼리를 사용하는 방식으로 배포 후 추가 작업을 하는 것을 말씀드렸기에 우선 pr을 올렸습니다. 성능 테스트 및 반정규화 방식을 적용하는 것은 이번 스프린트 내에 진행하도록 해볼게요!

### 반정규화 VS count 쿼리
현재 카테고리에 속한 스타카토 개수는 **count 쿼리 방식**으로 구현했습니다.
커버링 인덱스를 활용하고 있기 때문에, 일반적인 count(*)에 비해 성능 부하는 크지 않을 것으로 '추측'했습니다.
다만 InnoDB는 MVCC 기반 스토리지 엔진이기 때문에, 커버링 인덱스를 타더라도 각 row에 대해 visibility check가 발생하며, 결과적으로 row 수가 많아질수록 성능은 선형 증가할 수 있습니다.
그럼에도 불구하고 일차적으로 count 쿼리를 선택한 이유는 다음과 같습니다:
- 현재 데이터 규모가 작아 성능 부하가 크지 않다
- 반정규화를 도입할 경우 정합성 유지를 위한 동시성 관리 전략이 필요하다
- 이에 따라 복잡도보다 단순성과 안정성을 우선시했다

물론 반정규화도 좋은 방안입니다. 반정규화 방식을 사용한다면, `@Version` 기반의 낙관적 락을 도입해 staccatoCount 갱신 충돌을 감지하는 방식으로 데이터 정합성 관리를 고려하고 있습니다.
다만, 낙관적 락 또한 다음과 같은 성능 병목 요인을 가질 수 있습니다:
- 다중 사용자가 동시에 스타카토를 생성할 경우 충돌 빈도가 증가하며, 롤백 및 재시도 비용이 발생
- flush 시점마다 버전 비교 및 JPA 내부 쿼리 발생 가능성
- 대량 트랜잭션 환경에서는 실제 TPS 감소로 이어질 수 있음

따라서 단순한 추론보다는 실측을 통해 판단하는 것이 바람직하다고 생각했고,이번 PR에서는 클라이언트 측 작업 진행을 위해 우선 count 기반 구현으로 배포 후, 후속으로 반정규화 vs count 방식에 대한 성능 테스트를 병행하여 더 나은 방식을 선택할 계획입니다.

## 🙂 To Reviewer


## 📋 To Do
