### PR TITLE
fix: 누락된 isShared 필드 추가

### DIFF
--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
@@ -26,6 +26,8 @@ public record CategoryResponseV3(
         @Schema(example = SwaggerExamples.CATEGORY_END_AT)
         @JsonInclude(JsonInclude.Include.NON_NULL)
         LocalDate endAt,
+        @Schema(example = SwaggerExamples.CATEGORY_IS_SHARED)
+        boolean isShared,
         List<MemberResponse> members,
         @Schema(example = SwaggerExamples.STACCATO_COUNT)
         Long staccatoCount
@@ -38,6 +40,7 @@ public record CategoryResponseV3(
                 category.getColor().getName(),
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
+                category.getIsShared(),
                 toMemberResponses(category.getCategoryMembers()),
                 staccatoCount
         );

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -312,6 +312,7 @@ class CategoryControllerV3Test extends ControllerTest {
                             "categoryColor": "pink",
                             "startAt": "2024-01-01",
                             "endAt": "2024-12-31",
+                            "isShared": false,
                             "members": [
                                 {
                                     "memberId": null,
@@ -326,6 +327,7 @@ class CategoryControllerV3Test extends ControllerTest {
                             "categoryTitle": "categoryTitle",
                             "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
                             "categoryColor": "blue",
+                            "isShared": false,
                             "members": [
                                 {
                                     "memberId": null,


### PR DESCRIPTION
## ⭐️ Issue Number
- #

## 🚩 Summary
- 카테고리 목록 조회 V3 API에서 각 카테고리의 공동 카테고리 여부(isShared)를 누락하여 추가했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
