### PR TITLE
refactor: 카테고리 API 응답 수정 #836

### DIFF
--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -162,6 +162,10 @@ public class Category extends BaseEntity {
                 .orElseThrow(ForbiddenException::new);
     }
 
+    public long getCategoryMemberCount() {
+        return categoryMembers.size();
+    }
+
 /*    public void increaseStaccatoCount() {
         staccatoCount = staccatoCount + 1;
     }

--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -135,11 +135,11 @@ public class Category extends BaseEntity {
     }
 
     public boolean isGuest(Member member) {
-        return categoryMembers.stream()
-                .filter(categoryMember -> categoryMember.isOwnedBy(member))
+        CategoryMember categoryMember = categoryMembers.stream()
+                .filter(cm -> cm.isOwnedBy(member))
                 .findFirst()
-                .map(CategoryMember::isGuest)
-                .orElse(false);
+                .orElseThrow(ForbiddenException::new);
+        return categoryMember.isGuest();
     }
 
     public boolean isNotSameTitle(String title) {

--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -16,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import com.staccato.config.domain.BaseEntity;
+import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
@@ -152,6 +152,14 @@ public class Category extends BaseEntity {
 
     public void changeColor(Color color) {
         this.color = color;
+    }
+
+    public Role getRoleOfMember(Member member) {
+        return categoryMembers.stream()
+                .filter(categoryMember -> categoryMember.isOwnedBy(member))
+                .findFirst()
+                .map(CategoryMember::getRole)
+                .orElseThrow(ForbiddenException::new);
     }
 
 /*    public void increaseStaccatoCount() {

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -94,7 +94,8 @@ public class CategoryService {
                 .orElseThrow(() -> new StaccatoException("요청하신 카테고리를 찾을 수 없어요."));
         validateReadPermission(category, member);
         List<Staccato> staccatos = staccatoRepository.findAllByCategoryIdOrdered(categoryId);
-        return new CategoryDetailResponseV3(category, staccatos);
+
+        return new CategoryDetailResponseV3(category, staccatos, member);
     }
 
     public CategoryStaccatoLocationResponses readAllStaccatoByCategory(

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
@@ -6,6 +6,7 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.category.domain.Category;
 import com.staccato.config.swagger.SwaggerExamples;
+import com.staccato.member.domain.Member;
 import com.staccato.member.service.dto.response.MemberResponse;
 import com.staccato.staccato.domain.Staccato;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -33,11 +34,13 @@ public record CategoryDetailResponseV3(
         LocalDate endAt,
         @Schema(example = SwaggerExamples.CATEGORY_IS_SHARED)
         boolean isShared,
+        @Schema(example = SwaggerExamples.CATEGORY_ROLE)
+        String myRole,
         List<MemberDetailResponse> members,
         List<StaccatoResponse> staccatos
 ) {
 
-    public CategoryDetailResponseV3(Category category, List<Staccato> staccatos) {
+    public CategoryDetailResponseV3(Category category, List<Staccato> staccatos, Member member) {
         this(
                 category.getId(),
                 category.getThumbnailUrl(),
@@ -47,6 +50,7 @@ public record CategoryDetailResponseV3(
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
                 category.getIsShared(),
+                category.getRoleOfMember(member).getRole(),
                 toMemberDetailResponses(category),
                 toStaccatoResponses(staccatos)
         );

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryResponseV3.java
@@ -28,10 +28,15 @@ public record CategoryResponseV3(
         LocalDate endAt,
         @Schema(example = SwaggerExamples.CATEGORY_IS_SHARED)
         boolean isShared,
+        @Schema(example = SwaggerExamples.CATEGORY_MEMBER_COUNT)
+        long totalMemberCount,
         List<MemberResponse> members,
         @Schema(example = SwaggerExamples.STACCATO_COUNT)
         Long staccatoCount
 ) {
+
+    public static final int MEMBER_VIEW_COUNT = 3;
+
     public CategoryResponseV3(Category category, long staccatoCount) {
         this(
                 category.getId(),
@@ -41,6 +46,7 @@ public record CategoryResponseV3(
                 category.getTerm().getStartAt(),
                 category.getTerm().getEndAt(),
                 category.getIsShared(),
+                category.getCategoryMemberCount(),
                 toMemberResponses(category.getCategoryMembers()),
                 staccatoCount
         );
@@ -48,6 +54,7 @@ public record CategoryResponseV3(
 
     private static List<MemberResponse> toMemberResponses(List<CategoryMember> categoryMembers) {
         return categoryMembers.stream()
+                .limit(MEMBER_VIEW_COUNT)
                 .map(CategoryMember::getMember)
                 .map(MemberResponse::new)
                 .toList();

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -30,4 +30,5 @@ public class SwaggerExamples {
     public static final String CATEGORY_ROLE = "host";
     public static final String STACCATO_COUNT = "42";
     public static final String CATEGORY_IS_SHARED = "false";
+    public static final String CATEGORY_MEMBER_COUNT = "11";
 }

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -185,7 +185,7 @@ class CategoryControllerTest extends ControllerTest {
                 .withTerm(null, null).build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
-                new CategoryResponseV3(categoryWithoutTerm,0))
+                new CategoryResponseV3(categoryWithoutTerm, 0))
         );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
@@ -224,7 +224,7 @@ class CategoryControllerTest extends ControllerTest {
         Category category2 = CategoryFixtures.defaultCategory().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
-                new CategoryResponseV3(category2,0))
+                new CategoryResponseV3(category2, 0))
         );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 
@@ -290,7 +290,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -340,7 +340,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -180,8 +180,9 @@ class CategoryControllerV2Test extends ControllerTest {
                 .withTerm(null, null).build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
-                new CategoryResponseV3(categoryWithoutTerm,0))
-        );        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
+                new CategoryResponseV3(categoryWithoutTerm, 0))
+        );
+        when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
                 {
                     "categories": [
@@ -220,7 +221,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Category category2 = CategoryFixtures.defaultCategory().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
-                new CategoryResponseV3(category2,0))
+                new CategoryResponseV3(category2, 0))
         );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 
@@ -243,7 +244,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -294,7 +295,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -1,20 +1,8 @@
 package com.staccato.category.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,7 +11,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
 import com.staccato.ControllerTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.Color;
@@ -40,6 +27,17 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class CategoryControllerV3Test extends ControllerTest {
 
@@ -188,7 +186,7 @@ class CategoryControllerV3Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), host);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -247,7 +245,7 @@ class CategoryControllerV3Test extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato));
+        CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
@@ -256,6 +254,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryTitle": "categoryTitle",
                     "description": "categoryDescription",
                     "categoryColor": "pink",
+                    "myRole": "host",
                     "members": [
                         {
                             "memberId": null,
@@ -299,7 +298,7 @@ class CategoryControllerV3Test extends ControllerTest {
                 .withTerm(null, null).build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
-                new CategoryResponseV3(categoryWithoutTerm,0))
+                new CategoryResponseV3(categoryWithoutTerm, 0))
         );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
         String expectedResponse = """
@@ -358,7 +357,7 @@ class CategoryControllerV3Test extends ControllerTest {
         Category category2 = CategoryFixtures.defaultCategory().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
-                new CategoryResponseV3(category2,0))
+                new CategoryResponseV3(category2, 0))
         );
         when(categoryService.readAllCategories(any(Member.class), any(CategoryReadRequest.class))).thenReturn(categoryResponses);
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -182,7 +182,9 @@ class CategoryControllerV3Test extends ControllerTest {
         Member host = MemberFixtures.defaultMember().withNickname("host").build();
         Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
         when(authService.extractFromToken(anyString())).thenReturn(host);
-        Category category = CategoryFixtures.defaultCategory().withHost(host).withGuests(guest).build();
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .withGuests(guest).build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
@@ -285,16 +287,20 @@ class CategoryControllerV3Test extends ControllerTest {
     @Test
     void readAllCategory() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member host = MemberFixtures.defaultMember().withNickname("host").build();
+        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
+        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").build();
+        Member guest3 = MemberFixtures.defaultMember().withNickname("guest3").build();
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category categoryWithTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.PINK)
-                .withHost(member)
+                .withHost(host)
+                .withGuests(guest, guest2, guest3)
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
-                .withHost(member)
+                .withHost(host)
                 .withTerm(null, null).build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
@@ -311,11 +317,22 @@ class CategoryControllerV3Test extends ControllerTest {
                             "categoryColor": "pink",
                             "startAt": "2024-01-01",
                             "endAt": "2024-12-31",
-                            "isShared": false,
+                            "isShared": true,
+                            "totalMemberCount": 4,
                             "members": [
                                 {
                                     "memberId": null,
-                                    "nickname": "nickname",
+                                    "nickname": "host",
+                                    "memberImageUrl": "https://example.com/memberImage.png"
+                                },
+                                {
+                                    "memberId": null,
+                                    "nickname": "guest",
+                                    "memberImageUrl": "https://example.com/memberImage.png"
+                                },
+                                {
+                                    "memberId": null,
+                                    "nickname": "guest2",
                                     "memberImageUrl": "https://example.com/memberImage.png"
                                 }
                             ],
@@ -327,10 +344,11 @@ class CategoryControllerV3Test extends ControllerTest {
                             "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
                             "categoryColor": "blue",
                             "isShared": false,
+                            "totalMemberCount": 1,
                             "members": [
                                 {
                                     "memberId": null,
-                                    "nickname": "nickname",
+                                    "nickname": "host",
                                     "memberImageUrl": "https://example.com/memberImage.png"
                                 }
                             ],

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -1,21 +1,19 @@
 package com.staccato.category.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import com.staccato.exception.StaccatoException;
 import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CategoryTest {
     @DisplayName("카테고리 생성 시 제목에는 앞뒤 공백이 잘린다.")
@@ -162,6 +160,7 @@ class CategoryTest {
         // then
         assertThat(isDenied).isEqualTo(false);
     }
+
 /*
     @DisplayName("처음 카테고리를 생성했을 때 스타카토는 0개이다.")
     @Test

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -641,4 +641,26 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .isInstanceOf(ForbiddenException.class)
                 .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
     }
+
+    @DisplayName("카테고리에 포함된 멤버의 역할을 반환한다.")
+    @Test
+    void getRoleOfMemberReturnsRole() {
+        // given
+        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .withGuests(guest)
+                .buildAndSave(categoryRepository);
+
+        // when
+        Role hostRole = category.getRoleOfMember(host);
+        Role guestRole = category.getRoleOfMember(guest);
+
+        // then
+        assertAll(
+                () -> assertThat(hostRole).isEqualTo(Role.HOST),
+                () -> assertThat(guestRole).isEqualTo(Role.GUEST)
+        );
+    }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #836 

## 🚩 Summary
- 특정 카테고리 조회 시 요청한 사용자의 역할(`myRole`)을 응답 필드로 함께 반환합니다.
- 카테고리 목록 조회 시 모든 함께하는 사람 목록을 반환하지 않고, 최대 3명의 목록과 함께 총 함께하는 사람 수를 응답 필드로 추가하여 반환합니다.

## 🛠️ Technical Concerns
- 일부 사용자만 반환하는 것은 뷰의 요구사항일 뿐더러, 이를 위해 쿼리를 분리 (limit 3 조회 + count 조회)하는 것은 오히려 DB 부하를 증가시키는 방향이라고 생각했습니다. 따라서, 기존대로 fetch join으로 모든 categoryMember를 가져오되, dto에서 `size()`와 stream 연산에서 `limit(n)`을 사용하여 요구사항에 맞는 응답을 구성하도록 구현했습니다.

## 🙂 To Reviewer


## 📋 To Do
