### PR TITLE
feat: 보낸 초대 목록 조회 시 식별자 응답 필드 포함하도록 추가

### DIFF
--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -32,4 +32,5 @@ public class SwaggerExamples {
     public static final String STACCATO_COUNT = "42";
     public static final String CATEGORY_IS_SHARED = "false";
     public static final String CATEGORY_MEMBER_COUNT = "11";
+    public static final String INVITATION_ID = "1";
 }

--- a/backend/src/main/java/com/staccato/invitation/service/dto/response/CategoryInvitationRequestedResponse.java
+++ b/backend/src/main/java/com/staccato/invitation/service/dto/response/CategoryInvitationRequestedResponse.java
@@ -6,6 +6,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "보낸 초대 목록에서 각 초대의 응답 형식입니다.")
 public record CategoryInvitationRequestedResponse(
+        @Schema(example = SwaggerExamples.INVITATION_ID)
+        Long invitationId,
         @Schema(example = SwaggerExamples.MEMBER_ID)
         Long inviteeId,
         @Schema(example = SwaggerExamples.MEMBER_NICKNAME)
@@ -19,6 +21,7 @@ public record CategoryInvitationRequestedResponse(
 ) {
     public CategoryInvitationRequestedResponse(CategoryInvitation categoryInvitation) {
         this(
+                categoryInvitation.getId(),
                 categoryInvitation.getInvitee().getId(),
                 categoryInvitation.getInvitee().getNickname().getNickname(),
                 categoryInvitation.getInvitee().getImageUrl(),

--- a/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
+++ b/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
@@ -111,14 +111,15 @@ class InvitationControllerTest extends ControllerTest {
 
         when(invitationService.readInvitations(any(Member.class)))
                 .thenReturn(new CategoryInvitationRequestedResponses(List.of(
-                        new CategoryInvitationRequestedResponse(2L, "초대한사람", "https://example.com/images/profile1.png", 10L, "여름 방학 여행"),
-                        new CategoryInvitationRequestedResponse(3L, "다른사용자", "https://example.com/images/profile2.png", 11L, "겨울 맛집 탐방")
+                        new CategoryInvitationRequestedResponse(1L, 2L, "초대한사람", "https://example.com/images/profile1.png", 10L, "여름 방학 여행"),
+                        new CategoryInvitationRequestedResponse(2L, 3L, "다른사용자", "https://example.com/images/profile2.png", 11L, "겨울 맛집 탐방")
                 )));
 
         String expectedResponse = """
                 {
                   "invitations": [
                     {
+                      "invitationId": 1,
                       "inviteeId": 2,
                       "inviteeNickname": "초대한사람",
                       "inviteeProfileImageUrl": "https://example.com/images/profile1.png",
@@ -126,6 +127,7 @@ class InvitationControllerTest extends ControllerTest {
                       "categoryTitle": "여름 방학 여행"
                     },
                     {
+                      "invitationId": 2,
                       "inviteeId": 3,
                       "inviteeNickname": "다른사용자",
                       "inviteeProfileImageUrl": "https://example.com/images/profile2.png",


### PR DESCRIPTION
## ⭐️ Issue Number
- #

## 🚩 Summary
- 보낸 초대 취소 시 식별자가 필요하므로 보낸 초대 목록 조회 응답 필드로 invitationId 추가

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
