### PR TITLE
refactor: 함께하는 사람들 정렬 기준 변경 #850

### DIFF
--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -148,7 +148,7 @@ public class Category extends BaseEntity {
                 .filter(cm -> cm.isOwnedBy(member))
                 .findFirst()
                 .orElseThrow(ForbiddenException::new);
-        return categoryMember.isGuest();
+        return categoryMember.isRoleGuest();
     }
 
     public boolean isNotSameTitle(CategoryTitle title) {

--- a/backend/src/main/java/com/staccato/category/domain/CategoryMember.java
+++ b/backend/src/main/java/com/staccato/category/domain/CategoryMember.java
@@ -59,7 +59,15 @@ public class CategoryMember extends BaseEntity {
         return Objects.equals(this.member, member);
     }
 
-    public boolean isGuest() {
+    public boolean isRoleGuest() {
         return role.isGuest();
+    }
+
+    public boolean isRoleHost() {
+        return role.isHost();
+    }
+
+    public boolean isMember(Member other) {
+        return this.member.equals(other);
     }
 }

--- a/backend/src/main/java/com/staccato/category/domain/Role.java
+++ b/backend/src/main/java/com/staccato/category/domain/Role.java
@@ -15,4 +15,8 @@ public enum Role {
     boolean isGuest() {
         return this == Role.GUEST;
     }
+
+    public boolean isHost() {
+        return this == Role.HOST;
+    }
 }

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3.java
@@ -2,9 +2,11 @@ package com.staccato.category.service.dto.response;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.staccato.category.domain.Category;
+import com.staccato.category.domain.CategoryMember;
 import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 import com.staccato.member.service.dto.response.MemberResponse;
@@ -51,13 +53,17 @@ public record CategoryDetailResponseV3(
                 category.getTerm().getEndAt(),
                 category.getIsShared(),
                 category.getRoleOfMember(member).getRole(),
-                toMemberDetailResponses(category),
+                toMemberDetailResponses(category, member),
                 toStaccatoResponses(staccatos)
         );
     }
 
-    private static List<MemberDetailResponse> toMemberDetailResponses(Category category) {
+    private static List<MemberDetailResponse> toMemberDetailResponses(Category category, Member currentMember) {
         return category.getCategoryMembers().stream()
+                .sorted(Comparator
+                        .comparing((CategoryMember cm) -> cm.isRoleHost() ? 0 : cm.isMember(currentMember) ? 1 : 2)
+                        .thenComparing(CategoryMember::getCreatedAt)
+                )
                 .map(MemberDetailResponse::new)
                 .toList();
     }

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -2,6 +2,8 @@ package com.staccato.category.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -28,6 +30,7 @@ import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponse;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
+import com.staccato.category.service.dto.response.MemberDetailResponse;
 import com.staccato.category.service.dto.response.StaccatoResponse;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.exception.ForbiddenException;
@@ -317,6 +320,47 @@ class CategoryServiceTest extends ServiceSliceTest {
                         .containsExactly(
                                 thirdStaccato.getId(), secondStaccato.getId(), firstStaccato.getId())
         );
+    }
+
+    @DisplayName("특정 카테고리를 조회하면 함께하는 사람들은 1. 방장(HOST) 2. 본인 3. 카테고리에 추가된 순서를 기준으로 정렬된다.")
+    @Test
+    void readCategoryByIdOrderByMembers() {
+        // given
+        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+        Member guest1 = MemberFixtures.defaultMember().withNickname("guest1").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
+        Member guestSelf = MemberFixtures.defaultMember().withNickname("guestSelf").buildAndSave(memberRepository);
+
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .withGuests(List.of(guest2, guestSelf, guest1))
+                .buildAndSave(categoryRepository);
+
+        // when
+        CategoryDetailResponseV3 responseV3 = categoryService.readCategoryById(category.getId(), guestSelf);
+
+        List<Long> actualMemberIds = responseV3.members().stream()
+                .map(MemberDetailResponse::memberId)
+                .toList();
+
+        // then
+        List<Long> expectedMemberIds = new ArrayList<>(List.of(
+                host.getId(),
+                guestSelf.getId(),
+                guest1.getId(),
+                guest2.getId()));
+
+        CategoryMember categoryMember1 = category.getCategoryMembers().stream()
+                .filter(cm -> cm.getMember().equals(guest1))
+                .findFirst().orElseThrow();
+        CategoryMember categoryMember2 = category.getCategoryMembers().stream()
+                .filter(cm -> cm.getMember().equals(guest2))
+                .findFirst().orElseThrow();
+        if (categoryMember1.getCreatedAt().isAfter(categoryMember2.getCreatedAt())) {
+            Collections.swap(expectedMemberIds, 2, 3);
+        }
+
+        assertThat(actualMemberIds).isEqualTo(expectedMemberIds);
     }
 
     @DisplayName("존재하지 않는 카테고리를 조회하려고 할 경우 예외가 발생한다.")


### PR DESCRIPTION
## ⭐️ Issue Number
- #850 

## 🚩 Summary

* 함께하는 사람들 조회 API 정렬 기준을 변경합니다.
* 정렬 기준: 방장 첫 번째 + 본인 두 번째 + 나머지 카테고리에 참여한 순서

## 🛠️ Technical Concerns


## 🙂 To Reviewer

* 테스트에서 `createdAt`에 따라 정렬된 객체들의 순서로 `expected`를 구성해야 하는데, List로 순서를 전달하긴 하지만 저장 과정에서 순서가 섞일 경우를 우려하여, 직접 `createdAt`을 꺼내서 확인한 다음 `expected`를 구성했습니다.

## 📋 To Do
