### PR TITLE
feat: 닉네임으로 검색 시 조건에 해당하는 사용자 제외하도록 구현 #853

### DIFF
--- a/backend/src/main/java/com/staccato/member/controller/MemberController.java
+++ b/backend/src/main/java/com/staccato/member/controller/MemberController.java
@@ -2,12 +2,14 @@ package com.staccato.member.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.member.domain.Member;
 import com.staccato.member.service.MemberService;
+import com.staccato.member.service.dto.request.MemberReadRequest;
 import com.staccato.member.service.dto.response.MemberResponses;
 import lombok.RequiredArgsConstructor;
 
@@ -19,9 +21,9 @@ public class MemberController implements MemberControllerDocs {
 
     @GetMapping("/search")
     public ResponseEntity<MemberResponses> readMembersByNickname(
-            @LoginMember Member member, @RequestParam(value = "nickname") String nickname
+            @LoginMember Member member, @ModelAttribute MemberReadRequest memberReadRequest
     ) {
-        MemberResponses memberResponses = memberService.readMembersByNickname(member, nickname);
+        MemberResponses memberResponses = memberService.readMembersByNickname(member, memberReadRequest);
         return ResponseEntity.ok(memberResponses);
     }
 }

--- a/backend/src/main/java/com/staccato/member/controller/MemberControllerDocs.java
+++ b/backend/src/main/java/com/staccato/member/controller/MemberControllerDocs.java
@@ -1,9 +1,9 @@
 package com.staccato.member.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.member.domain.Member;
+import com.staccato.member.service.dto.request.MemberReadRequest;
 import com.staccato.member.service.dto.response.MemberResponses;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,8 +17,8 @@ public interface MemberControllerDocs {
     @ApiResponses(value = {
             @ApiResponse(description = "카테고리 초대 성공", responseCode = "200")
     })
-    public ResponseEntity<MemberResponses> readMembersByNickname(
+    ResponseEntity<MemberResponses> readMembersByNickname(
             @Parameter(hidden = true) @LoginMember Member member,
-            @Parameter(description = "검색어", example = "닉네임") @RequestParam(value = "nickname") String nickname
+            @Parameter(description = "검색어와 검색 결과에서 제외할 카테고리 식별자로 필터링합니다. 검색어가 없다면 빈 배열을 반환합니다.") MemberReadRequest memberReadRequest
     );
 }

--- a/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
+++ b/backend/src/main/java/com/staccato/member/repository/MemberRepository.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import com.staccato.invitation.domain.InvitationStatus;
 import com.staccato.member.domain.Member;
 import com.staccato.member.domain.Nickname;
 
@@ -12,7 +15,29 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByCode(String code);
 
-    List<Member> findByNicknameNicknameContainsAndIdNot(String nickname, long memberId);
+    @Query("""
+                SELECT m FROM Member m
+                WHERE m.nickname.nickname LIKE CONCAT('%', :nickname, '%')
+                AND m.id <> :memberId
+                AND (
+                  :categoryId IS NULL OR (
+                    m.id NOT IN (
+                        SELECT ci.invitee.id FROM CategoryInvitation ci
+                        WHERE ci.category.id = :categoryId AND ci.status = :status
+                    )
+                    AND m.id NOT IN (
+                        SELECT cm.member.id FROM CategoryMember cm
+                        WHERE cm.category.id = :categoryId
+                    )
+                  )
+                )
+            """)
+    List<Member> findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+            @Param("nickname") String nickname,
+            @Param("memberId") long memberId,
+            @Param("categoryId") Long categoryId,
+            @Param("status") InvitationStatus status
+    );
 
     List<Member> findAllByIdIn(Set<Long> memberIds);
 }

--- a/backend/src/main/java/com/staccato/member/service/MemberService.java
+++ b/backend/src/main/java/com/staccato/member/service/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.staccato.exception.StaccatoException;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
+import com.staccato.member.service.dto.request.MemberReadRequest;
 import com.staccato.member.service.dto.response.MemberProfileImageResponse;
 import com.staccato.member.service.dto.response.MemberResponses;
 import lombok.RequiredArgsConstructor;
@@ -28,8 +29,9 @@ public class MemberService {
                 .orElseThrow(() -> new StaccatoException("요청하신 사용자 정보를 찾을 수 없어요."));
     }
 
-    public MemberResponses readMembersByNickname(Member member, String nickname) {
-        List<Member> members = memberRepository.findByNicknameNicknameContainsAndIdNot(nickname, member.getId());
+    public MemberResponses readMembersByNickname(Member member, MemberReadRequest memberReadRequest) {
+
+        List<Member> members = memberRepository.findByNicknameNicknameContainsAndIdNot(memberReadRequest.nickname(), member.getId());
         return MemberResponses.of(members);
     }
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
@@ -1,0 +1,13 @@
+package com.staccato.member.service.dto.request;
+
+import com.staccato.config.swagger.SwaggerExamples;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 조회 요청")
+public record MemberReadRequest(
+        @Schema(description = "검색어", example = SwaggerExamples.MEMBER_NICKNAME)
+        String nickname,
+        @Schema(description = "검색에서 제외 할 카테고리 식별자", example = SwaggerExamples.CATEGORY_ID)
+        long excludeCategoryId
+) {
+}

--- a/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
@@ -1,5 +1,6 @@
 package com.staccato.member.service.dto.request;
 
+import java.util.Objects;
 import com.staccato.config.swagger.SwaggerExamples;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,6 +9,9 @@ public record MemberReadRequest(
         @Schema(description = "검색어", example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
         @Schema(description = "검색에서 제외 할 카테고리 식별자", example = SwaggerExamples.CATEGORY_ID)
-        long excludeCategoryId
+        Long excludeCategoryId
 ) {
+        public String trimmedNickname() {
+                return nickname.trim();
+        }
 }

--- a/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponses.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/response/MemberResponses.java
@@ -11,4 +11,8 @@ public record MemberResponses(List<MemberResponse> members) {
                 .map(MemberResponse::new)
                 .toList());
     }
+
+    public static MemberResponses empty() {
+        return new MemberResponses(List.of());
+    }
 }

--- a/backend/src/test/java/com/staccato/fixture/member/MemberReadRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/member/MemberReadRequestFixtures.java
@@ -1,0 +1,29 @@
+package com.staccato.fixture.member;
+
+import com.staccato.member.service.dto.request.MemberReadRequest;
+
+public class MemberReadRequestFixtures {
+    public static MemberReadRequestBuilder defaultMemberReadRequest() {
+        return new MemberReadRequestBuilder()
+                .withNickname("member");
+    }
+
+    public static class MemberReadRequestBuilder {
+        private String nickname;
+        private Long excludeCategoryId;
+
+        public MemberReadRequestBuilder withNickname(String nickname) {
+            this.nickname = nickname;
+            return this;
+        }
+
+        public MemberReadRequestBuilder withExcludeCategoryId(Long excludeCategoryId) {
+            this.excludeCategoryId = excludeCategoryId;
+            return this;
+        }
+
+        public MemberReadRequest build() {
+            return new MemberReadRequest(nickname, excludeCategoryId);
+        }
+    }
+}

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -3,13 +3,8 @@ package com.staccato.member.controller;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.NullSource;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
 import com.staccato.ControllerTest;
-import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.member.service.dto.request.MemberReadRequest;
@@ -18,7 +13,6 @@ import com.staccato.member.service.dto.response.MemberResponses;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -53,20 +47,5 @@ class MemberControllerTest extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
                 .andExpect(content().json(expectedResponse));
-    }
-
-    @DisplayName("사용자가 닉네임으로 검색 시 입력한 잘못된 카테고리 식별자는 무시된다.")
-    @Test
-    void ignoreIfInvalidExcludeCategoryId() throws Exception {
-        // given
-        when(authService.extractFromToken(anyString())).thenReturn(any());
-        when(memberService.readMembersByNickname(any(Member.class), any(MemberReadRequest.class))).thenReturn(any());
-
-        // when & then
-        mockMvc.perform(get("/members/search")
-                        .param("nickname", "스타")
-                        .param("excludeCategoryId", "0")
-                        .header(HttpHeaders.AUTHORIZATION, "token"))
-                .andExpect(status().isOk());
     }
 }

--- a/backend/src/test/java/com/staccato/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/member/repository/MemberRepositoryTest.java
@@ -1,0 +1,148 @@
+package com.staccato.member.repository;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.staccato.RepositoryTest;
+import com.staccato.category.domain.Category;
+import com.staccato.category.repository.CategoryRepository;
+import com.staccato.fixture.category.CategoryFixtures;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.invitation.domain.CategoryInvitation;
+import com.staccato.invitation.domain.InvitationStatus;
+import com.staccato.invitation.repository.CategoryInvitationRepository;
+import com.staccato.member.domain.Member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MemberRepositoryTest extends RepositoryTest {
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private CategoryInvitationRepository categoryInvitationRepository;
+
+    private Member host;
+    private Member guest;
+    private Category category;
+
+    @BeforeEach
+    void init() {
+        host = MemberFixtures.defaultMember()
+                .withNickname("스타")
+                .buildAndSave(memberRepository);
+        guest = MemberFixtures.defaultMember()
+                .withNickname("스타카토")
+                .buildAndSave(memberRepository);
+        category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .buildAndSave(categoryRepository);
+    }
+
+    @DisplayName("주어진 문자열을 포함하는 닉네임으로 사용자 목록을 반환 시 본인은 제외한다.")
+    @Test
+    void readMembersByNicknameWithoutMember() {
+        // when
+        List<Member> result = memberRepository
+                .findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+                        "스타", host.getId(), null, InvitationStatus.REQUESTED
+                );
+
+        // then
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(guest)
+                .doesNotContain(host);
+    }
+
+    @DisplayName("주어진 문자열을 포함하는 닉네임으로 사용자 목록을 반환 시 주어진 카테고리에 속한 사용자는 제외한다.")
+    @Test
+    void readMembersByNicknameWithoutCategoryMember() {
+        // given
+        category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .withGuests(List.of(guest))
+                .buildAndSave(categoryRepository);
+        String keyword = guest.getNickname().getNickname();
+        Member searchedMember = MemberFixtures.defaultMember()
+                .withNickname("다른" + keyword)
+                .buildAndSave(memberRepository);
+
+        // when
+        List<Member> result = memberRepository.findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+                keyword, host.getId(), category.getId(), InvitationStatus.REQUESTED
+        );
+
+        // then
+        assertThat(result).hasSize(1)
+                .containsExactly(searchedMember);
+    }
+
+    @DisplayName("주어진 문자열을 포함하는 닉네임으로 사용자 목록을 반환 시 주어진 카테고리에 초대 요청을 받은 사용자는 제외한다.")
+    @Test
+    void readMembersByNicknameWithoutCategoryInvitation() {
+        // given
+        categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
+        String keyword = guest.getNickname().getNickname();
+        Member searchedMember = MemberFixtures.defaultMember()
+                .withNickname("다른" + keyword)
+                .buildAndSave(memberRepository);
+
+        // when
+        List<Member> result = memberRepository
+                .findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+                        keyword, host.getId(), category.getId(), InvitationStatus.REQUESTED
+                );
+
+        // then
+        assertThat(result).hasSize(1)
+                .containsExactly(searchedMember);
+    }
+
+    @DisplayName("대소문자를 구분하여 닉네임 검색이 가능하다.")
+    @Test
+    void readMembersByNicknameIgnoreCase() {
+        // given
+        Member upper = MemberFixtures.defaultMember()
+                .withNickname("STACCATO")
+                .buildAndSave(memberRepository);
+        Member lower = MemberFixtures.defaultMember()
+                .withNickname("staccato")
+                .buildAndSave(memberRepository);
+        String keyword = "staccato";
+
+        // when
+        List<Member> result = memberRepository
+                .findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+                        keyword, host.getId(), null, InvitationStatus.REQUESTED
+                );
+
+        // then
+        assertThat(result)
+                .extracting(Member::getId)
+                .containsExactlyInAnyOrder(lower.getId())
+                .doesNotContain(upper.getId());
+    }
+
+    @DisplayName("categoryId가 null이면 카테고리 관련 필터 없이 검색된다.")
+    @Test
+    void readMembersByNicknameWithNullCategoryId() {
+        // given
+        categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
+        String keyword = guest.getNickname().getNickname();
+
+        // when
+        List<Member> result = memberRepository
+                .findByNicknameNicknameContainsAndMemberIddNotAndCategoryNot(
+                        keyword, host.getId(), null, InvitationStatus.REQUESTED
+                );
+
+        // then
+        assertThat(result)
+                .hasSize(1)
+                .containsExactly(guest);
+    }
+}

--- a/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
@@ -5,10 +5,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import com.staccato.ServiceSliceTest;
+import com.staccato.category.domain.Category;
+import com.staccato.category.repository.CategoryRepository;
 import com.staccato.exception.StaccatoException;
+import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.fixture.member.MemberReadRequestFixtures;
+import com.staccato.invitation.domain.CategoryInvitation;
+import com.staccato.invitation.repository.CategoryInvitationRepository;
 import com.staccato.member.domain.Member;
 import com.staccato.member.repository.MemberRepository;
+import com.staccato.member.service.dto.request.MemberReadRequest;
 import com.staccato.member.service.dto.response.MemberProfileImageResponse;
 import com.staccato.member.service.dto.response.MemberResponse;
 import com.staccato.member.service.dto.response.MemberResponses;
@@ -23,6 +30,10 @@ class MemberServiceTest extends ServiceSliceTest {
     MemberService memberService;
     @Autowired
     MemberRepository memberRepository;
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    CategoryInvitationRepository categoryInvitationRepository;
 
     @DisplayName("주어진 이미지 경로로 사용자의 프로필 사진을 변경한다.")
     @Test
@@ -72,10 +83,13 @@ class MemberServiceTest extends ServiceSliceTest {
         Member member3 = MemberFixtures.defaultMember()
                 .withNickname("타스")
                 .buildAndSave(memberRepository);
+        String keyword = "스타";
+        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.defaultMemberReadRequest()
+                .withNickname(keyword)
+                .build();
 
         // when
-        String keyword = "스타";
-        MemberResponses result = memberService.readMembersByNickname(member, keyword);
+        MemberResponses result = memberService.readMembersByNickname(member, memberReadRequest);
 
         // then
         List<Long> resultIds = result.members().stream()
@@ -98,9 +112,13 @@ class MemberServiceTest extends ServiceSliceTest {
         Member member2 = MemberFixtures.defaultMember()
                 .withNickname("스타카토")
                 .buildAndSave(memberRepository);
-        // when
         String keyword = "스타";
-        MemberResponses result = memberService.readMembersByNickname(member, keyword);
+        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.defaultMemberReadRequest()
+                .withNickname(keyword)
+                .build();
+
+        // when
+        MemberResponses result = memberService.readMembersByNickname(member, memberReadRequest);
 
         // then
         List<Long> resultIds = result.members().stream()


### PR DESCRIPTION
## ⭐️ Issue Number
- #853 

## 🚩 Summary
- 요청을 보낸 사용자 뿐만 아니라, 조건으로 주어진 카테고리 식별자가 있다면 해당 카테고리에 속한/초대받은 사용자도 제외한다.
- 빈 문자열, 공백 문자열, null이 검색어로 들어오면 무조건 빈 문자열로 응답한다.
- 유효하지 않은 카테고리 식별자의 경우 무시된다.
- 검색어의 앞뒤 공백은 제거된다.

## 🛠️ Technical Concerns
- 애플리케이션 레벨에서 조건에 맞는 사용자를 제외하는 것과, 쿼리 레벨로 처리하는 것을 고민하다가 쿼리 레벨로 처리하기로 결정했습니다.
  - 애플리케이션에서 필터링할 경우, 전체 데이터를 모두 가져온 뒤 추가 연산이 필요해져 비효율적일 수 있다고 판단했습니다.
  - 특히 초대 요청 데이터가 많아질수록 이 비용은 커질 수 있고, 처음부터 쿼리 레벨에서 필요한 사용자만 조회하는 방향이 더 적합하다고 생각했습니다.
  - 또한, 현재는 검색 결과 수가 많지 않아 페이징이 필수는 아니지만, 향후 사용자 수 증가를 고려하면 페이징이 필요할 것이라고 판단했습니다. 
  - 만약, 페이징이 적용 되었을 때 애플리케이션 레벨에서 중간에 필터되면 페이지가 비게 되는 문제가 있습니다.
 
이러한 이유로 쿼리 레벨에서 처리하기로 결정했습니다. 폭포와 호티 의견도 궁금해요~

## 🙂 To Reviewer


## 📋 To Do
