### PR TITLE
fix: 공동카테고리 스타카토 수정이 안 되는 버그 #855

### DIFF
--- a/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
+++ b/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
@@ -115,6 +115,10 @@ public class Staccato extends BaseEntity {
         }
     }
 
+    public boolean hasDifferentCategoryFrom(Category targetCategory) {
+        return !category.equals(targetCategory);
+    }
+
     @PrePersist
     @PreUpdate
     @PreRemove

--- a/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
+++ b/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
@@ -74,7 +74,9 @@ public class StaccatoService {
         Category targetCategory = getCategoryById(staccatoRequest.categoryId());
         targetCategory.validateOwner(member);
 
-        staccato.validateCategoryChangeable(targetCategory);
+        if (staccato.hasDifferentCategoryFrom(targetCategory)) {
+            staccato.validateCategoryChangeable(targetCategory);
+        }
 
         Staccato newStaccato = staccatoRequest.toStaccato(targetCategory);
         List<StaccatoImage> existingImages = staccato.existingImages();


### PR DESCRIPTION
## ⭐️ Issue Number
- #855 

## 🚩 Summary

- 스타카토 정보를 수정할 때, 다른 정보 수정도 개인->개인을 제외하면 전부 실행되지 않도록 막혀있었습니다.
- 따라서, 공동카테고리 안의 스타카토의 다른 정보(카테고리ID가 아닌 정보)를 수정할 때 공동->공동로 인식해버려서 실행을 막아버리는 올바르지 않은 상황이 생겼습니다.
- 스타카토의 카테고리ID가 변했을 때만, 카테고리 이동 유형(개인/공동) 검증을 하도록 수정했습니다.

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
