### PR TITLE
fix: 스타카토 수정 화면 카테고리 클릭 시 앱이 터지는 버그2 #857

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -51,19 +51,17 @@ fun TextView.setSelectedCategory(
 
 @BindingAdapter("dateTimeWithAmPm")
 fun TextView.setDateTimeWithAmPm(dateTime: LocalDateTime?) {
-    if (dateTime == null)
-        {
-            text = resources.getString(R.string.staccato_creation_loading_visitedAt)
-            setTextColor(resources.getColor(R.color.gray3, null))
-            isClickable = false
-            isFocusable = false
-        } else
-        {
-            text = dateTime.let(::getFormattedLocalDateTime)
-            setTextColor(resources.getColor(R.color.staccato_black, null))
-            isClickable = true
-            isFocusable = true
-        }
+    if (dateTime == null) {
+        text = resources.getString(R.string.staccato_creation_loading_visitedAt)
+        setTextColor(resources.getColor(R.color.gray3, null))
+        isClickable = false
+        isFocusable = false
+    } else {
+        text = dateTime.let(::getFormattedLocalDateTime)
+        setTextColor(resources.getColor(R.color.staccato_black, null))
+        isClickable = true
+        isFocusable = true
+    }
 }
 
 @BindingAdapter(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/bindingadapter/TextBindingAdapter.kt
@@ -51,10 +51,19 @@ fun TextView.setSelectedCategory(
 
 @BindingAdapter("dateTimeWithAmPm")
 fun TextView.setDateTimeWithAmPm(dateTime: LocalDateTime?) {
-    text = dateTime?.let(::getFormattedLocalDateTime) ?: EMPTY_TEXT
-    setTextColor(resources.getColor(R.color.staccato_black, null))
-    isClickable = true
-    isFocusable = true
+    if (dateTime == null)
+        {
+            text = resources.getString(R.string.staccato_creation_loading_visitedAt)
+            setTextColor(resources.getColor(R.color.gray3, null))
+            isClickable = false
+            isFocusable = false
+        } else
+        {
+            text = dateTime.let(::getFormattedLocalDateTime)
+            setTextColor(resources.getColor(R.color.staccato_black, null))
+            isClickable = true
+            isFocusable = true
+        }
 }
 
 @BindingAdapter(

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -130,8 +130,10 @@ class StaccatoUpdateViewModel
 
         fun fetchTargetData(staccatoId: Long) {
             viewModelScope.launch {
-                fetchStaccatoBy(staccatoId)
-                fetchCategoryCandidates()
+                val staccatoJob = launch { fetchStaccatoBy(staccatoId) }
+                val categoryCandidatesJob = launch { fetchCategoryCandidates() }
+                staccatoJob.join()
+                categoryCandidatesJob.join()
                 initializeSelectableCategories()
             }
         }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/staccatoupdate/viewmodel/StaccatoUpdateViewModel.kt
@@ -122,6 +122,20 @@ class StaccatoUpdateViewModel
             }
         }
 
+        override fun selectCategory(position: Int) {
+            selectableCategories.value?.categoryCandidates?.get(position)?.let {
+                _selectedCategory.value = it
+            }
+        }
+
+        fun fetchTargetData(staccatoId: Long) {
+            viewModelScope.launch {
+                fetchStaccatoBy(staccatoId)
+                fetchCategoryCandidates()
+                initializeSelectableCategories()
+            }
+        }
+
         fun getCurrentLocation() {
             _isCurrentLocationLoading.postValue(true)
             val currentLocation: Task<Location> = locationRepository.getCurrentLocation()
@@ -130,18 +144,8 @@ class StaccatoUpdateViewModel
             }
         }
 
-        override fun selectCategory(position: Int) {
-            _selectedCategory.value =
-                selectableCategories.value?.categoryCandidates?.get(position) ?: return
-        }
-
         fun selectVisitedAt(visitedAt: LocalDateTime) {
             _selectedVisitedAt.value = visitedAt
-        }
-
-        fun fetchTargetData(staccatoId: Long) {
-            fetchCategoryCandidates()
-            fetchStaccatoBy(staccatoId)
         }
 
         fun selectNewPlace(
@@ -200,6 +204,7 @@ class StaccatoUpdateViewModel
             _selectableCategories.value = filteredCategories
             _selectedCategory.value =
                 filteredCategories.findByIdOrFirst(selectedCategory.value?.categoryId)
+                    ?: return
         }
 
         fun updateStaccato(staccatoId: Long) {
@@ -233,18 +238,24 @@ class StaccatoUpdateViewModel
             }
         }
 
-        private fun fetchStaccatoBy(staccatoId: Long) {
-            viewModelScope.launch {
-                staccatoRepository.getStaccato(staccatoId = staccatoId)
-                    .onSuccess { staccato ->
-                        staccatoTitle.set(staccato.staccatoTitle)
-                        _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
-                        initializePlaceBy(staccato)
-                        selectVisitedAt(staccato.visitedAt)
-                        initCategory(staccato)
-                    }.onException(::handleInitializeException)
-                    .onServerError(::handleServerError)
-            }
+        private suspend fun fetchCategoryCandidates() {
+            timelineRepository.getCategoryCandidates()
+                .onSuccess { categoryCandidates ->
+                    _categoryCandidates.value = categoryCandidates
+                }.onException(::handleCategoryCandidatesException)
+                .onServerError(::handleServerError)
+        }
+
+        private suspend fun fetchStaccatoBy(staccatoId: Long) {
+            staccatoRepository.getStaccato(staccatoId = staccatoId)
+                .onSuccess { staccato ->
+                    staccatoTitle.set(staccato.staccatoTitle)
+                    _currentPhotos.value = createPhotosByUrls(staccato.staccatoImageUrls)
+                    selectVisitedAt(staccato.visitedAt)
+                    initializePlaceBy(staccato)
+                    initializeSelectedCategory(staccato)
+                }.onException(::handleInitializeException)
+                .onServerError(::handleServerError)
         }
 
         private fun initializePlaceBy(staccato: Staccato) {
@@ -257,7 +268,7 @@ class StaccatoUpdateViewModel
             )
         }
 
-        private fun initCategory(staccato: Staccato) {
+        private fun initializeSelectedCategory(staccato: Staccato) {
             _selectedCategory.value =
                 CategoryCandidate(
                     staccato.categoryId,
@@ -265,17 +276,11 @@ class StaccatoUpdateViewModel
                     staccato.startAt,
                     staccato.endAt,
                 )
-            _selectableCategories.value =
-                categoryCandidates.value?.filterBy(staccato.visitedAt.toLocalDate())
         }
 
-        private fun fetchCategoryCandidates() {
-            viewModelScope.launch {
-                timelineRepository.getCategoryCandidates()
-                    .onSuccess { categoryCandidates ->
-                        _categoryCandidates.value = categoryCandidates
-                    }.onException(::handleCategoryCandidatesException)
-                    .onServerError(::handleServerError)
+        private fun initializeSelectableCategories() {
+            selectedVisitedAt.value?.toLocalDate()?.let { visitedAt ->
+                _selectableCategories.value = categoryCandidates.value?.filterBy(visitedAt)
             }
         }
 

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -132,6 +132,7 @@
     <string name="staccato_creation_empty_address">"장소를 선택하면 상세 주소가 나타나요"</string>
     <string name="staccato_creation_address">상세 주소</string>
     <string name="staccato_creation_category_selection">카테고리 선택</string>
+    <string name="staccato_creation_loading_visitedAt">날짜와 시간을 불러오고 있어요</string>
     <string name="staccato_creation_no_category_in_this_date">선택하신 날짜에는 카테고리가 없어요</string>
     <string name="staccato_creation_no_category">스타카토를 남길 수 있는 카테고리가 없어요</string>
     <string name="staccato_creation_toolbar_subtitle">기억하고 싶은 순간을 남겨 보세요!</string>


### PR DESCRIPTION
## ⭐️ Issue Number
- #857 

## 🚩 Summary

- [x] 초기 데이터 조회에 성공한 후에 선택 가능한 카테고리 목록을 업데이트하도록 순서 보장
- [x] visitedAt이 비어있을 때 '날짜 및 시간 선택'의 터치가 무시되도록 바인딩 어댑터 수정

## 첫번째 작업

### 기존 수정화면 플로우
1. `스타카토` 조회 요청, `카테고리 후보` 조회 요청이 각 코루틴에서 병렬로 실행됨. (각 요청의 완료 순서 보장 X)
2. 이 때 조회된 `스타카토`의 `visitedAt`을 기준으로, 조회된 `카테고리 후보`들 중 선택 가능한 카테고리를 필터링
3. 필터링 결과를 `selectableCategories` LiveData에 저장

### 예외가 발생하는 경우
아직 `카테고리 후보`가 불러와지지 않은 상태에서 아래 코드(2번의 필터링에 해당)를 수행하면 `selectableCategories`에 null이 들어감.
따라서 카테고리 선택란을 터치했을 때 `NullPointerException`이 발생하던 것!
```kotlin
  _selectableCategories.value = categoryCandidates.value?.filterBy(staccato.visitedAt.toLocalDate())
```

### 해결
모두 불러와진 뒤 카테고리 선택하도록 순서 보장
```kotlin
fun fetchTargetData(staccatoId: Long) {
    viewModelScope.launch { // 최상위 코루틴
        val staccatoJob = launch { fetchStaccatoBy(staccatoId) } // 자식 코루틴 1 - 스타카토 조회 요청
        val categoryCandidatesJob = launch { fetchCategoryCandidates() } // 자식 코루틴 2 - 카테고리 후보 조회 요청
        staccatoJob.join()
        categoryCandidatesJob.join()
        initializeSelectableCategories() // join으로 모든 자식 코루틴이 완료된 후 실행되도록 순서 보장
    }
}
```
> 교훈 : 코루틴의 구조화된 동시성을 잘~ 고려해 설계할 것 . . .

## 두번째 작업
https://github.com/user-attachments/assets/1081515b-9513-40d5-bf85-636a7e881514
> 스타카토 수정 시 네트워크가 느린 상황을 가정하여, 초기 데이터를 불러오는 모든 작업에 5초의 delay를 걸었을 때
초기 데이터가 없는 상황에 '일시 선택란'과 '카테고리 선택란'을 터치해도 앱이 터지지 않는 영상
