### PR TITLE
refactor: 초대 동시성 관리 & 스타카토 동시성 관리 #837

### DIFF
--- a/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/staccato/exception/GlobalExceptionHandler.java
@@ -1,14 +1,13 @@
 package com.staccato.exception;
 
 import java.util.Optional;
-
 import jakarta.validation.ConstraintViolationException;
-
 import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.TransactionSystemException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -17,9 +16,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
-
 import com.staccato.config.log.LogForm;
-
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -119,6 +116,15 @@ public class GlobalExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.FORBIDDEN.toString(), e.getMessage());
         log.warn(LogForm.CUSTOM_EXCEPTION_LOGGING_FORM, exceptionResponse);
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    @ApiResponse(description = "낙관적 락 충돌 발생", responseCode = "409")
+    public ResponseEntity<ExceptionResponse> handleOptimisticLockingFailure(ObjectOptimisticLockingFailureException e) {
+        String exceptionMessage = "요청하신 데이터가 다른 요청에 의해 수정되었습니다. 새로고침 후 다시 시도해주세요.";
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.CONFLICT.toString(), exceptionMessage);
+        log.warn(LogForm.EXCEPTION_LOGGING_FORM, exceptionResponse, e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(exceptionResponse);
     }
 
     @ExceptionHandler(RuntimeException.class)

--- a/backend/src/main/java/com/staccato/invitation/domain/CategoryInvitation.java
+++ b/backend/src/main/java/com/staccato/invitation/domain/CategoryInvitation.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import com.staccato.category.domain.Category;
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.exception.StaccatoException;
@@ -43,6 +44,8 @@ public class CategoryInvitation extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private InvitationStatus status;
+    @Version
+    private Long version;
 
     public static CategoryInvitation invite(@NonNull Category category, @NonNull Member inviter, @NonNull Member invitee) {
         return new CategoryInvitation(category, inviter, invitee, InvitationStatus.REQUESTED);

--- a/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
+++ b/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
@@ -18,6 +18,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.PreRemove;
 import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Version;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.Color;
 import com.staccato.config.domain.BaseEntity;
@@ -54,6 +55,8 @@ public class Staccato extends BaseEntity {
     private Category category;
     @Embedded
     private StaccatoImages staccatoImages = new StaccatoImages();
+    @Version
+    private Long version;
 
     @Builder
     public Staccato(

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -65,11 +65,17 @@ image:
 
 management:
   server:
-    port: 8080
+    port: 9292
   endpoints:
     web:
       exposure:
-        include: info, health, metrics, env, beans, threaddump, loggers, prometheus
+        include: info, health, prometheus, beans, threaddump, loggers
+    jmx:
+      exposure:
+        exclude: "*"
+  endpoint:
+    health:
+      show-components: never
 
   metrics:
     distribution:

--- a/backend/src/test/java/com/staccato/util/TransactionExecutor.java
+++ b/backend/src/test/java/com/staccato/util/TransactionExecutor.java
@@ -1,0 +1,28 @@
+package com.staccato.util;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class TransactionExecutor {
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    public void executeInNewTransaction(Runnable task) {
+        TransactionTemplate txTemplate = new TransactionTemplate(transactionManager);
+        txTemplate.setPropagationBehavior(Propagation.REQUIRES_NEW.value());
+        txTemplate.executeWithoutResult(status -> task.run());
+    }
+
+    public void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #837 

## 🚩 Summary
- 우선은 회의에서 다루었듯이 낙관적락을 통해 단순하게 구성하였습니다. 추후에 더 다양한 방식으로 동시성을 시도해보면 좋을 것 같습니다.

## 🛠️ Technical Concerns
- 낙관적락을 통해 충돌이 발생하였을 때 던져지는 예외를 전역 예외에서 처리하고있는 형태인데, 이렇게 되었을때 관리가 단순하지만 예외 메세지를 커스텀하지 못한다는 단점이 존재합니다. 이에 대해 `AOP`를 통해 관리하는 방안과 새로운 `Facade` 서비스를 생성하는 방향 등이 생각이 났는데, 많은 의견 부탁드립니닷.
  - 낙관적락은 트랜잭션이 `commit`되는 시점에 버전 예외가 발생되기 때문에 `service` 메서드 내부에서는 `try-catch` 하지 못하는 문제로 인해 이와 같은 생각을 했습니당

## 🙂 To Reviewer


## 📋 To Do
