### PR TITLE
fix: 필수값이 아닌 Long이 원시값으로 파싱 안되는 오류 수정

### DIFF
--- a/backend/src/main/java/com/staccato/member/service/MemberService.java
+++ b/backend/src/main/java/com/staccato/member/service/MemberService.java
@@ -67,8 +67,8 @@ public class MemberService {
         return Objects.isNull(nickname) || nickname.isBlank();
     }
 
-    private boolean hasNoCategoryToExclude(long categoryId) {
-        return categoryId <= 0;
+    private boolean hasNoCategoryToExclude(Long categoryId) {
+        return Objects.isNull(categoryId);
     }
 
     private MemberSearchResponse resolveSearchStatus(Member m, Set<Long> categoryMemberIds, Set<Long> inviteeIds) {

--- a/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
+++ b/backend/src/main/java/com/staccato/member/service/dto/request/MemberReadRequest.java
@@ -8,7 +8,7 @@ public record MemberReadRequest(
         @Schema(description = "검색어", example = SwaggerExamples.MEMBER_NICKNAME)
         String nickname,
         @Schema(description = "검색에서 제외 할 카테고리 식별자", example = SwaggerExamples.CATEGORY_ID)
-        long excludeCategoryId
+        Long excludeCategoryId
 ) {
     public String trimmedNickname() {
         return nickname.trim();

--- a/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
@@ -116,7 +116,7 @@ class MemberServiceTest extends ServiceSliceTest {
     void readMemberWithoutOneself() {
         // given
         Member me = MemberFixtures.defaultMember().withNickname("me").buildAndSave(memberRepository);
-        MemberReadRequest memberReadRequest = new MemberReadRequest("me", 0);
+        MemberReadRequest memberReadRequest = new MemberReadRequest("me", null);
 
         // when
         MemberSearchResponses result = memberService.readMembersByNickname(me, memberReadRequest);


### PR DESCRIPTION
## ⭐️ Issue Number

## 🚩 Summary
![image](https://github.com/user-attachments/assets/8c1938c9-ccbf-4d2a-a269-d26eda19a930)
- 컨트롤러 단위 테스트에서, 필수값이 아닌 Long 타입 요청 인자가 null로 전달되면 기본형 long으로는 바인딩이 되지 않음을 확인했습니다.
- 해당 API 구현 당시, 내부 DTO에서는 long 기본형을 사용하고 있었고, 이를 일관되게 유지하는 쪽으로 논의되었었습니다.

하지만 이번 PR에서는 다음과 같은 이유로 컨트롤러 요청 파라미터에는 래퍼 타입인 Long을 사용하는 방향으로 수정했습니다.

- 필수값이 아님을 명확하게 표현하기 위한 선택입니다!
  - long은 기본형이라 null을 받을 수 없고, 값이 없을 경우 자동으로 0으로 바인딩됩니다..
  - 그러나 0이라는 값은 실질적인 의미를 가질 수 있기 때문에, "값이 없는 상태"와 "0이라는 값이 전달된 상태"를 구분하는 데 모호함이 있다고 생각해요.
  - 따라서, Long은 null을 받을 수 있기 때문에, 해당 파라미터가 아예 전달되지 않았다는 사실을 명확하게 표현할 수 있다고 생각해요.

이러한 이유로, DTO에서의 타입 일관성(wrapper가 아닌 원시 타입을 사용)보다, API 표현의 명확성이 중요하다고 생각해서 Long 타입을 사용하는 방향으로 수정했습니다!

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
