### PR TITLE
feat: 알림 존재 여부 조회 API 구현 #877

### DIFF
--- a/backend/src/main/java/com/staccato/invitation/repository/CategoryInvitationRepository.java
+++ b/backend/src/main/java/com/staccato/invitation/repository/CategoryInvitationRepository.java
@@ -39,4 +39,6 @@ public interface CategoryInvitationRepository extends JpaRepository<CategoryInvi
     void deleteAllByCategoryIdInBulk(long categoryId);
 
     List<CategoryInvitation> findAllByCategoryIdAndInviteeInAndStatus(long categoryId, List<Member> members, InvitationStatus invitationStatus);
+
+    boolean existsByInviteeIdAndStatus(long inviteeId, InvitationStatus invitationStatus);
 }

--- a/backend/src/main/java/com/staccato/notification/controller/NotificationController.java
+++ b/backend/src/main/java/com/staccato/notification/controller/NotificationController.java
@@ -1,0 +1,26 @@
+package com.staccato.notification.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.staccato.config.auth.LoginMember;
+import com.staccato.member.domain.Member;
+import com.staccato.notification.controller.docs.NotificationControllerDocs;
+import com.staccato.notification.service.NotificationService;
+import com.staccato.notification.service.dto.response.NotificationExistResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController implements NotificationControllerDocs {
+    private final NotificationService notificationService;
+
+    @GetMapping("/exists")
+    public ResponseEntity<NotificationExistResponse> isExistNotifications(@LoginMember Member member) {
+        NotificationExistResponse response = notificationService.isExistNotifications(member);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/staccato/notification/controller/docs/NotificationControllerDocs.java
+++ b/backend/src/main/java/com/staccato/notification/controller/docs/NotificationControllerDocs.java
@@ -1,0 +1,15 @@
+package com.staccato.notification.controller.docs;
+
+import org.springframework.http.ResponseEntity;
+import com.staccato.config.auth.LoginMember;
+import com.staccato.member.domain.Member;
+import com.staccato.notification.service.dto.response.NotificationExistResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+
+public interface NotificationControllerDocs {
+    @Operation(summary = "알림 존재 여부 조회", description = "사용자에 대한 알림이 존재하는지 여부를 조회합니다.")
+    @ApiResponse(description = "알림 존재 여부 조회 성공", responseCode = "200")
+    ResponseEntity<NotificationExistResponse> isExistNotifications(@Parameter(hidden = true) @LoginMember Member member);
+}

--- a/backend/src/main/java/com/staccato/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/staccato/notification/service/NotificationService.java
@@ -14,7 +14,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationService {
+    private final CategoryInvitationRepository categoryInvitationRepository;
+
     public NotificationExistResponse isExistNotifications(Member member) {
-        return null;
+        boolean isExist = categoryInvitationRepository.existsByInviteeIdAndStatus(member.getId(), InvitationStatus.REQUESTED);
+        return new NotificationExistResponse(isExist);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/staccato/notification/service/NotificationService.java
@@ -1,0 +1,20 @@
+package com.staccato.notification.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.staccato.config.log.annotation.Trace;
+import com.staccato.invitation.domain.InvitationStatus;
+import com.staccato.invitation.repository.CategoryInvitationRepository;
+import com.staccato.member.domain.Member;
+import com.staccato.notification.service.dto.response.NotificationExistResponse;
+import lombok.RequiredArgsConstructor;
+
+@Trace
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationService {
+    public NotificationExistResponse isExistNotifications(Member member) {
+        return null;
+    }
+}

--- a/backend/src/main/java/com/staccato/notification/service/dto/response/NotificationExistResponse.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/response/NotificationExistResponse.java
@@ -1,0 +1,4 @@
+package com.staccato.notification.service.dto.response;
+
+public record NotificationExistResponse(boolean isExist) {
+}

--- a/backend/src/test/java/com/staccato/ControllerTest.java
+++ b/backend/src/test/java/com/staccato/ControllerTest.java
@@ -4,14 +4,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.staccato.auth.service.AuthService;
+import com.staccato.category.service.CategoryService;
 import com.staccato.comment.service.CommentService;
 import com.staccato.image.service.ImageService;
 import com.staccato.invitation.service.InvitationService;
 import com.staccato.member.service.MemberService;
-import com.staccato.category.service.CategoryService;
+import com.staccato.notification.service.NotificationService;
 import com.staccato.staccato.service.StaccatoService;
 import com.staccato.staccato.service.StaccatoShareService;
 
@@ -37,4 +37,6 @@ public abstract class ControllerTest {
     protected StaccatoShareService staccatoShareService;
     @MockBean
     protected InvitationService invitationService;
+    @MockBean
+    protected NotificationService notificationService;
 }

--- a/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,43 @@
+package com.staccato.notification.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
+import com.staccato.ControllerTest;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.member.domain.Member;
+import com.staccato.notification.service.NotificationService;
+import com.staccato.notification.service.dto.response.NotificationExistResponse;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class NotificationControllerTest extends ControllerTest {
+    @Autowired
+    private NotificationService notificationService;
+
+    @DisplayName("사용자에 대한 알림이 존재하는지 조회한다.")
+    @Test
+    void readMyPage() throws Exception {
+        // given
+        Member member = MemberFixtures.defaultMember().build();
+        when(authService.extractFromToken(anyString())).thenReturn(member);
+        when(notificationService.isExistNotifications(any(Member.class))).thenReturn(new NotificationExistResponse(true));
+        String expectedResponse = """
+                {
+                	"isExist": true
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/notifications/exists")
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedResponse));
+    }
+}

--- a/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
@@ -1,0 +1,57 @@
+package com.staccato.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import com.staccato.ServiceSliceTest;
+import com.staccato.category.domain.Category;
+import com.staccato.category.repository.CategoryRepository;
+import com.staccato.fixture.category.CategoryFixtures;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.invitation.domain.CategoryInvitation;
+import com.staccato.invitation.repository.CategoryInvitationRepository;
+import com.staccato.member.domain.Member;
+import com.staccato.member.repository.MemberRepository;
+import com.staccato.notification.service.dto.response.NotificationExistResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NotificationServiceTest extends ServiceSliceTest {
+    @Autowired
+    private NotificationService notificationService;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private CategoryInvitationRepository categoryInvitationRepository;
+
+    @DisplayName("받은 초대 목록이 존재한다면, 알림이 존재한다.")
+    @Test
+    void isExistNotifications() {
+        // given
+        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.defaultCategory().withHost(host).buildAndSave(categoryRepository);
+        categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
+
+        // when
+        NotificationExistResponse result = notificationService.isExistNotifications(guest);
+
+        // then
+        assertThat(result.isExist()).isTrue();
+    }
+
+    @DisplayName("받은 초대 목록이 존재하지 않는다면, 알림이 존재하지 않는다.")
+    @Test
+    void isNotExistNotifications() {
+        // given
+        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+
+        // when
+        NotificationExistResponse result = notificationService.isExistNotifications(guest);
+
+        // then
+        assertThat(result.isExist()).isFalse();
+    }
+}


### PR DESCRIPTION
## ⭐️ Issue Number
- #877 

## 🚩 Summary
- 홈 화면 진입 시 알림 존재 여부를 확인할 수 있는 API를 `/notifications/exists` 경로로 구현했습니다.
- 현재는 받은 초대 목록 기준으로 알림의 존재 여부를 판단하지만, 이는 구현 방식(HOW)에 해당하며 클라이언트가 궁금한 것은 "알림이 존재하는가?"라는 목적(WHAT)이기 때문에 URI에는 포함하지 않았습니다.

## 🛠️ Technical Concerns
- 현재 알림 종류는 받은 초대만 존재하지만, 앞으로 버전 업데이트 알림, 참여 알림 등 다양한 종류가 추가될 수 있으므로, **알림이라는 추상 개념을 기준으로 한 Notification 도메인**을 분리해 관리합니다.
   - 알림 기능에 문제가 생겼을 때 다른 도메인에 영향을 주지 않아야 하며, 이는 알림이 하나의 독립된 문제 영역임을 의미합니다. 
  - 도메인은 반드시 영속화되는 엔티티일 필요는 없으며, 우리가 해결하고자 하는 문제의 중심 단위라는 점에서 Notification은 하나의 독립된 도메인이라고 생각해요.
- FCM이 도입되면 알림 존재 여부 판단 로직은 현재처럼 DB 기반이 아닌 푸시 메시지 기반 등으로 변경될 수 있습니다. 따라서 지금의 `초대 목록 기준 존재 여부 확인`은 내부 구현에 해당하며 외부에는 노출하지 않는 것이 적절하다고 생각했어요!
- 향후 알림 종류별로 개별 API가 필요해질 경우, 그때 명확하게 분리된 엔드포인트(`/notifications/invitations/exists` 등)를 제공하고자 합니다. 현재는 임시적으로 홈화면에서의 알림 존재여부 조회 & 마이 페이지 내 카테고리 초대 관리에 대한 알림 존재 여부 조회 모두 해당 API를 사용하고자 합니다.

## 🙂 To Reviewer


## 📋 To Do
