### PR TITLE
fix: ErrorResponse 변환 오류 및 NetworkModule 순환 참조 문제 해결 #881

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCall.kt
@@ -4,47 +4,49 @@ import okhttp3.Request
 import okio.Timeout
 import retrofit2.Call
 import retrofit2.Response
+import javax.inject.Inject
 
-class ApiResultCall<T : Any>(
-    private val delegate: Call<T>,
-) : Call<ApiResult<T>> {
-    private val responseHandler = ResponseHandler()
+class ApiResultCall<T : Any>
+    @Inject
+    constructor(
+        private val delegate: Call<T>,
+        private val responseHandler: ResponseHandler,
+    ) : Call<ApiResult<T>> {
+        override fun enqueue(callback: retrofit2.Callback<ApiResult<T>>) {
+            delegate.enqueue(
+                object : retrofit2.Callback<T> {
+                    override fun onResponse(
+                        call: Call<T>,
+                        response: Response<T>,
+                    ) {
+                        val networkResult: ApiResult<T> = responseHandler.handleApiResponse { response }
+                        callback.onResponse(this@ApiResultCall, Response.success(networkResult))
+                    }
 
-    override fun enqueue(callback: retrofit2.Callback<ApiResult<T>>) {
-        delegate.enqueue(
-            object : retrofit2.Callback<T> {
-                override fun onResponse(
-                    call: Call<T>,
-                    response: Response<T>,
-                ) {
-                    val networkResult: ApiResult<T> = responseHandler.handleApiResponse { response }
-                    callback.onResponse(this@ApiResultCall, Response.success(networkResult))
-                }
+                    override fun onFailure(
+                        call: Call<T>,
+                        throwable: Throwable,
+                    ) {
+                        val exception = responseHandler.handleException<T>(throwable)
+                        callback.onResponse(this@ApiResultCall, Response.success(exception))
+                    }
+                },
+            )
+        }
 
-                override fun onFailure(
-                    call: Call<T>,
-                    throwable: Throwable,
-                ) {
-                    val exception = responseHandler.handleException<T>(throwable)
-                    callback.onResponse(this@ApiResultCall, Response.success(exception))
-                }
-            },
-        )
+        override fun execute(): Response<ApiResult<T>> = throw NotImplementedError()
+
+        override fun clone(): Call<ApiResult<T>> = ApiResultCall(delegate.clone(), responseHandler)
+
+        override fun isExecuted(): Boolean = delegate.isExecuted
+
+        override fun cancel() {
+            delegate.cancel()
+        }
+
+        override fun isCanceled(): Boolean = delegate.isCanceled
+
+        override fun request(): Request = delegate.request()
+
+        override fun timeout(): Timeout = delegate.timeout()
     }
-
-    override fun execute(): Response<ApiResult<T>> = throw NotImplementedError()
-
-    override fun clone(): Call<ApiResult<T>> = ApiResultCall(delegate.clone())
-
-    override fun isExecuted(): Boolean = delegate.isExecuted
-
-    override fun cancel() {
-        delegate.cancel()
-    }
-
-    override fun isCanceled(): Boolean = delegate.isCanceled
-
-    override fun request(): Request = delegate.request()
-
-    override fun timeout(): Timeout = delegate.timeout()
-}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapter.kt
@@ -3,11 +3,15 @@ package com.on.staccato.data.network
 import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type
+import javax.inject.Inject
 
-class ApiResultCallAdapter(
-    private val resultType: Type,
-) : CallAdapter<Type, Call<ApiResult<Type>>> {
-    override fun responseType(): Type = resultType
+class ApiResultCallAdapter
+    @Inject
+    constructor(
+        private val resultType: Type,
+        private val responseHandler: ResponseHandler,
+    ) : CallAdapter<Type, Call<ApiResult<Type>>> {
+        override fun responseType(): Type = resultType
 
-    override fun adapt(call: Call<Type>): Call<ApiResult<Type>> = ApiResultCall(call)
-}
+        override fun adapt(call: Call<Type>): Call<ApiResult<Type>> = ApiResultCall(call, responseHandler)
+    }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapterFactory.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ApiResultCallAdapterFactory.kt
@@ -5,24 +5,27 @@ import retrofit2.CallAdapter
 import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
+import javax.inject.Inject
 
-class ApiResultCallAdapterFactory : CallAdapter.Factory() {
-    override fun get(
-        returnType: Type,
-        annotations: Array<out Annotation>,
-        retrofit: Retrofit,
-    ): CallAdapter<*, *>? {
-        if (getRawType(returnType) != Call::class.java) {
-            return null
+class ApiResultCallAdapterFactory
+    @Inject
+    constructor(private val responseHandler: ResponseHandler) : CallAdapter.Factory() {
+        override fun get(
+            returnType: Type,
+            annotations: Array<out Annotation>,
+            retrofit: Retrofit,
+        ): CallAdapter<*, *>? {
+            if (getRawType(returnType) != Call::class.java) {
+                return null
+            }
+
+            val responseType = getParameterUpperBound(0, returnType as ParameterizedType)
+
+            if (getRawType(responseType) != ApiResult::class.java) {
+                return null
+            }
+
+            val resultType = getParameterUpperBound(0, responseType as ParameterizedType)
+            return ApiResultCallAdapter(resultType, responseHandler)
         }
-
-        val responseType = getParameterUpperBound(0, returnType as ParameterizedType)
-
-        if (getRawType(responseType) != ApiResult::class.java) {
-            return null
-        }
-
-        val resultType = getParameterUpperBound(0, responseType as ParameterizedType)
-        return ApiResultCallAdapter(resultType)
     }
-}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ErrorConverter.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ErrorConverter.kt
@@ -1,8 +1,23 @@
 package com.on.staccato.data.network
 
 import com.on.staccato.data.dto.ErrorResponse
+import kotlinx.serialization.json.Json
 import okhttp3.ResponseBody
+import javax.inject.Inject
 
-fun interface ErrorConverter {
-    fun convert(responseBody: ResponseBody): ErrorResponse
-}
+class ErrorConverter
+    @Inject
+    constructor(
+        private val json: Json,
+    ) {
+        fun convert(errorBody: ResponseBody): ErrorResponse =
+            runCatching {
+                json.decodeFromString<ErrorResponse>(errorBody.string())
+            }.getOrElse { throwable ->
+                throw IllegalArgumentException(EXCEPTION_CONVERT_ERROR_RESPONSE, throwable)
+            }
+
+        companion object {
+            private const val EXCEPTION_CONVERT_ERROR_RESPONSE = "errorBody를 변환할 수 없습니다."
+        }
+    }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ResponseHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ResponseHandler.kt
@@ -8,44 +8,45 @@ import retrofit2.Response
 import java.io.IOException
 import javax.inject.Inject
 
-class ResponseHandler {
+class ResponseHandler
     @Inject
-    lateinit var errorConverter: ErrorConverter
+    constructor(
+        private val errorConverter: ErrorConverter,
+    ) {
+        fun <T : Any> handleApiResponse(execute: () -> Response<T>): ApiResult<T> {
+            return try {
+                val response: Response<T> = execute()
+                val body: T? = response.body()
 
-    fun <T : Any> handleApiResponse(execute: () -> Response<T>): ApiResult<T> {
-        return try {
-            val response: Response<T> = execute()
-            val body: T? = response.body()
-
-            when {
-                response.isSuccessful && response.code() == CREATED -> Success(body as T)
-                response.isSuccessful && body != null -> Success(body)
-                else -> {
-                    val errorBody: ResponseBody =
-                        response.errorBody()
-                            ?: throw IllegalArgumentException(NOT_FOUND_ERROR_BODY)
-                    val errorResponse: ErrorResponse = errorConverter.convert(errorBody)
-                    ServerError(
-                        status = Status.Message(errorResponse.status),
-                        message = errorResponse.message,
-                    )
+                when {
+                    response.isSuccessful && response.code() == CREATED -> Success(body as T)
+                    response.isSuccessful && body != null -> Success(body)
+                    else -> {
+                        val errorBody: ResponseBody =
+                            response.errorBody()
+                                ?: throw IllegalArgumentException(NOT_FOUND_ERROR_BODY)
+                        val errorResponse: ErrorResponse = errorConverter.convert(errorBody)
+                        ServerError(
+                            status = Status.Message(errorResponse.status),
+                            message = errorResponse.message,
+                        )
+                    }
                 }
+            } catch (httpException: HttpException) {
+                ServerError(status = Status.Code(httpException.code()), message = httpException.message())
+            } catch (throwable: Throwable) {
+                handleException<T>(throwable)
             }
-        } catch (httpException: HttpException) {
-            ServerError(status = Status.Code(httpException.code()), message = httpException.message())
-        } catch (throwable: Throwable) {
-            handleException<T>(throwable)
-        }
-    }
-
-    fun <T : Any> handleException(throwable: Throwable) =
-        when (throwable) {
-            is IOException -> Exception.NetworkError<T>()
-            else -> Exception.UnknownError<T>()
         }
 
-    companion object {
-        private const val CREATED = 201
-        private const val NOT_FOUND_ERROR_BODY = "errorBody를 찾을 수 없습니다."
+        fun <T : Any> handleException(throwable: Throwable) =
+            when (throwable) {
+                is IOException -> Exception.NetworkError<T>()
+                else -> Exception.UnknownError<T>()
+            }
+
+        companion object {
+            private const val CREATED = 201
+            private const val NOT_FOUND_ERROR_BODY = "errorBody를 찾을 수 없습니다."
+        }
     }
-}

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/ApiResultCallAdapterTest.kt
@@ -6,6 +6,7 @@ import com.on.staccato.data.dto.ImagePostResponse
 import com.on.staccato.data.dto.PostResponse
 import com.on.staccato.data.network.ApiResult
 import com.on.staccato.data.network.Exception
+import com.on.staccato.data.network.ServerError
 import com.on.staccato.data.network.Success
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -77,8 +78,7 @@ class ApiResultCallAdapterTest {
         runTest {
             val actual: ApiResult<PostResponse> = fakeApiService.post(request = createInvalidRequest())
 
-            // TODO: ServerError 일 때 테스트가 통과하도록 수정 필요
-            assertThat(actual).isInstanceOf(Exception.UnknownError::class.java)
+            assertThat(actual).isInstanceOf(ServerError::class.java)
         }
     }
 
@@ -94,8 +94,7 @@ class ApiResultCallAdapterTest {
         runTest {
             val actual: ApiResult<PostResponse> = fakeApiService.post(request = createValidRequest())
 
-            // TODO: ServerError 일 때 테스트가 통과하도록 수정 필요
-            assertThat(actual).isInstanceOf(Exception.UnknownError::class.java)
+            assertThat(actual).isInstanceOf(ServerError::class.java)
         }
     }
 
@@ -111,8 +110,7 @@ class ApiResultCallAdapterTest {
         runTest {
             val actual: ApiResult<Unit> = fakeApiService.delete(id = 1)
 
-            // TODO: ServerError 일 때 테스트가 통과하도록 수정 필요
-            assertThat(actual).isInstanceOf(Exception.UnknownError::class.java)
+            assertThat(actual).isInstanceOf(ServerError::class.java)
         }
     }
 
@@ -128,8 +126,7 @@ class ApiResultCallAdapterTest {
         runTest {
             val actual: ApiResult<ImagePostResponse> = fakeApiService.postImage(imageFile = createFakeImageFile())
 
-            // TODO: ServerError 일 때 테스트가 통과하도록 수정 필요
-            assertThat(actual).isInstanceOf(Exception.UnknownError::class.java)
+            assertThat(actual).isInstanceOf(ServerError::class.java)
         }
     }
 
@@ -145,8 +142,7 @@ class ApiResultCallAdapterTest {
         runTest {
             val actual: ApiResult<PostResponse> = fakeApiService.post(request = createValidRequest())
 
-            // TODO: ServerError 일 때 테스트가 통과하도록 수정 필요
-            assertThat(actual).isInstanceOf(Exception.UnknownError::class.java)
+            assertThat(actual).isInstanceOf(ServerError::class.java)
         }
     }
 

--- a/android/Staccato_AN/app/src/test/java/com/on/staccato/data/MockWebServerProvider.kt
+++ b/android/Staccato_AN/app/src/test/java/com/on/staccato/data/MockWebServerProvider.kt
@@ -2,6 +2,8 @@ package com.on.staccato.data
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.on.staccato.data.network.ApiResultCallAdapterFactory
+import com.on.staccato.data.network.ErrorConverter
+import com.on.staccato.data.network.ResponseHandler
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.mockwebserver.MockResponse
@@ -9,15 +11,18 @@ import okhttp3.mockwebserver.MockWebServer
 import retrofit2.Retrofit
 
 fun buildRetrofitFor(mockWebServer: MockWebServer): Retrofit {
-    val jsonBuilder = Json { coerceInputValues = true }
+    val json = Json { coerceInputValues = true }
     val url = mockWebServer.url("/")
+
+    val errorConverter = ErrorConverter(json)
+    val responseHandler = ResponseHandler(errorConverter)
 
     return Retrofit.Builder()
         .baseUrl(url)
         .addConverterFactory(
-            jsonBuilder.asConverterFactory("application/json".toMediaType()),
+            json.asConverterFactory("application/json".toMediaType()),
         )
-        .addCallAdapterFactory(ApiResultCallAdapterFactory())
+        .addCallAdapterFactory(ApiResultCallAdapterFactory(responseHandler))
         .build()
 }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #881 

<br>

## 🎥 시연 영상
https://github.com/user-attachments/assets/133e0635-c2a4-4a19-bedc-a828a1c37058

<br>

## 🚩 Summary
- ErrorResponse 생성 방식 변경
- NetworkModule 순환 참조 문제 해결
- ApiResultCallAdapterTest 수정

<br>

## 🛠️ Technical Concerns

<br>

## 🙂 To Reviewer
정상 동작 여부를 ApiResultCallAdapterTest로 테스트 완료했습니다.
- [x] @s6m1n 
- [x] @Junyoung-WON 

<br>

## 📋 To Do
