### PR TITLE
fix: 안드로이드 CD 워크플로에서 앱 서명이 적용되지 않는 문제 해결 #890

### DIFF
--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo $GOOGLE_SERVICES_JSON > ./app/google-services.json
 
-      - name: Create Google Map API Keys
+      - name: Create Google Maps SDK Keys
         run: |
           echo $SECRETS_PROPERTIES > secrets.properties
           echo $LOCAL_DEFAULTS_PROPERTIES > local.defaults.properties

--- a/.github/workflows/android-cd.yml
+++ b/.github/workflows/android-cd.yml
@@ -6,6 +6,7 @@ on:
       - main
     types:
       - closed
+  workflow_dispatch:
 
 env:
   BASE_URL: ${{ secrets.BASE_URL }}
@@ -39,10 +40,6 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Create local.properties
-        run: |
-          touch local.properties
-
       - name: Set Base Url in local.properties
         run: |
           echo "base_url=\"$BASE_URL\"" >> local.properties
@@ -51,19 +48,16 @@ jobs:
         run: |
           echo $GOOGLE_SERVICES_JSON > ./app/google-services.json
 
-      - name: Create secrets.properties
+      - name: Create Google Map API Keys
         run: |
           echo $SECRETS_PROPERTIES > secrets.properties
-
-      - name: Create local.defaults.properties
-        run: |
           echo $LOCAL_DEFAULTS_PROPERTIES > local.defaults.properties
 
       - name: Create KeyStore File and Properties
         run: |
-          mkdir -p ./app/signing
-          echo "$UPLOAD_KEY_STORE_JKS" | base64 --decode > ./app/signing/upload_key_store.jks
-          echo "$KEY_STORE_PROPERTIES" > ./app/signing/keystore.properties
+          mkdir -p ./app/.signing
+          echo "$UPLOAD_KEY_STORE_JKS" | base64 --decode > ./app/.signing/upload_key_store.jks
+          echo "$KEY_STORE_PROPERTIES" > ./app/.signing/keystore.properties
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/android-ci-cd-dev.yml
+++ b/.github/workflows/android-ci-cd-dev.yml
@@ -37,35 +37,25 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Create local.properties
-        run: |
-          touch local.properties
-
-      - name: Set base_url in local.properties
+      - name: Set Base URL in local.properties
         run: |
           echo "base_url=\"$BASE_URL\"" >> local.properties
-
-      - name: Set dev_base_url in local.properties
-        run: |
           echo "dev_base_url=\"$DEV_BASE_URL\"" >> local.properties
 
       - name: Create google-services.json
         run: |
           echo $GOOGLE_SERVICES_JSON > ./app/google-services.json
 
-      - name: Create secrets.properties
+      - name: Create Google Map API Key
         run: |
           echo $SECRETS_PROPERTIES > secrets.properties
-
-      - name: Create local.defaults.properties
-        run: |
           echo $LOCAL_DEFAULTS_PROPERTIES > local.defaults.properties
 
-      - name: Create keyStore file and properties
+      - name: Create Key Store File and properties
         run: |
-          mkdir -p ./app/signing
-          echo "$UPLOAD_KEY_STORE_JKS" | base64 --decode > ./app/signing/upload_key_store.jks
-          echo "$KEY_STORE_PROPERTIES" > ./app/signing/keystore.properties
+          mkdir -p ./app/.signing
+          echo "$UPLOAD_KEY_STORE_JKS" | base64 --decode > ./app/.signing/upload_key_store.jks
+          echo "$KEY_STORE_PROPERTIES" > ./app/.signing/keystore.properties
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -83,7 +73,7 @@ jobs:
       - name: Upload APK to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1.7.0
         with:
-          appId: ${{secrets.FIREBASE_APP_ID}}
+          appId: ${{ secrets.FIREBASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}
           groups: staccato_tester
           file: android/Staccato_AN/app/build/outputs/apk/debug/app-debug.apk

--- a/.github/workflows/android-ci-cd-dev.yml
+++ b/.github/workflows/android-ci-cd-dev.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           echo $GOOGLE_SERVICES_JSON > ./app/google-services.json
 
-      - name: Create Google Map API Key
+      - name: Create Google Maps SDK Keys
         run: |
           echo $SECRETS_PROPERTIES > secrets.properties
           echo $LOCAL_DEFAULTS_PROPERTIES > local.defaults.properties


### PR DESCRIPTION
## ⭐️ Issue Number
- #890 

<br>

## 🚩 Summary
Release 빌드 과정에서 앱 서명이 적용되지 않아 업로드가 거부된 문제를 해결했습니다.
- 앱 서명 파일의 변경된 경로가 CD 워크플로에 반영되지 않아, Gradle이 서명 키, 암호 등을 찾지 못해 서명을 할 수 없었습니다.
- **파일 경로를 수정하여 앱 서명이 정상적으로 진행되도록 했습니다.**
- 워크플로에서 빌드에 필요한 파일을 생성하는 명령어를 정리했습니다.
<br>

## 🛠️ Technical Concerns
단지 혼자만의 고민입니다...! 아직 조금 더 알아보아야 할 것 같습니다.
- 앱 서명을 하는 동작이 Gradle 파일에 있어도 괜찮을까요?
  - Gradle은 작성한 코드(프로젝트)가 실행될 수 있도록 실행 파일을 빌드해주고, 이에 필요한 데이터를 관리하는 역할을 한다고 생각합니다.
  - **배포를 위해 앱 서명**을 하는 것은 **단순히 프로젝트를 실행할 수 있도록 빌드하는 것**과는 조금 다른 책임이라고 생각이 들었어요.
  - 그래서 서명을 하는 작업을 gradle이 아니라 프로젝트 외부(Github Action)에서 수행시키는 것을 고민하고 있습니다.
<br>

## 🙂 To Reviewer
- main 브랜치에 먼저 적용되어야 이후 배포에 Release 워크플로가 실행되어 자동 배포가 이루어질 수 있습니다!
- 빠른 확인과 승인 부탁드립니다!
  - [x] @s6m1n 
  - [x] @hxeyexn 
<br>

## 📋 To Do
- [ ] develop, main 브랜치에 빠르게 병합하기