### PR TITLE
fix: 누락된 이미지 업로드 시 용량 초과 오류 처리 추가 #895

### DIFF
--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ResponseHandler.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/data/network/ResponseHandler.kt
@@ -16,6 +16,7 @@ class ResponseHandler
         fun <T : Any> handleApiResponse(execute: () -> Response<T>): ApiResult<T> {
             return try {
                 val response: Response<T> = execute()
+                if (response.code() == 413) return ServerError(status = Status.Code(413), message = "10MB 이하의 사진만 업로드할 수 있어요!")
                 val body: T? = response.body()
 
                 when {


### PR DESCRIPTION
## ⭐️ Issue Number
- #895 

<br>

## 🚩 Summary
- 10MB를 초과하는 이미지에 대한 업로드 오류 처리가 누락되어, 해당 로직을 추가했습니다.

<br>

## 🙂 To Reviewer
- [x] @s6m1n 
- [x] @Junyoung-WON 

<br>

## 📋 To Do
