### PR TITLE
feat: 스타카토 생성자/수정자 필드 추가 #891

### DIFF
--- a/backend/src/main/java/com/staccato/notification/infrastructure/FcmConfig.java
+++ b/backend/src/main/java/com/staccato/notification/infrastructure/FcmConfig.java
@@ -6,6 +6,7 @@ import jakarta.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
@@ -14,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @Slf4j
+@Profile("!test")
 public class FcmConfig {
 
     private static final String SUCCESS_LOG = "[FCM][연결 성공] ";

--- a/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
+++ b/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
@@ -54,6 +54,36 @@ public class Staccato extends BaseEntity {
     private Category category;
     @Embedded
     private StaccatoImages staccatoImages = new StaccatoImages();
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "created_by", nullable = false, updatable = false)
+    private Member createdBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "modified_by", nullable = false)
+    private Member modifiedBy;
+
+    public static Staccato create(
+            LocalDateTime visitedAt,
+            String title,
+            String placeName,
+            String address,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            List<String> staccatoImageUrls,
+            Category category,
+            Member auditor
+    ) {
+        return new Staccato(
+                visitedAt,
+                title,
+                placeName,
+                address,
+                latitude,
+                longitude,
+                new StaccatoImages(staccatoImageUrls),
+                category,
+                auditor,
+                auditor);
+    }
 
     @Builder
     public Staccato(
@@ -64,7 +94,9 @@ public class Staccato extends BaseEntity {
             @NonNull BigDecimal latitude,
             @NonNull BigDecimal longitude,
             @NonNull StaccatoImages staccatoImages,
-            @NonNull Category category
+            @NonNull Category category,
+            @NonNull Member createdBy,
+            @NonNull Member modifiedBy
     ) {
         validateIsWithinCategoryTerm(visitedAt, category);
         this.visitedAt = visitedAt.truncatedTo(ChronoUnit.SECONDS);
@@ -72,6 +104,8 @@ public class Staccato extends BaseEntity {
         this.spot = new Spot(placeName, address, latitude, longitude);
         this.staccatoImages.addAll(staccatoImages, this);
         this.category = category;
+        this.createdBy = createdBy;
+        this.modifiedBy = modifiedBy;
     }
 
     private void validateIsWithinCategoryTerm(LocalDateTime visitedAt, Category category) {
@@ -86,6 +120,7 @@ public class Staccato extends BaseEntity {
         this.spot = newStaccato.getSpot();
         this.staccatoImages.update(newStaccato.staccatoImages, this);
         this.category = newStaccato.getCategory();
+        this.modifiedBy = newStaccato.getModifiedBy();
     }
 
     public String thumbnailUrl() {

--- a/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
+++ b/backend/src/main/java/com/staccato/staccato/domain/Staccato.java
@@ -54,12 +54,10 @@ public class Staccato extends BaseEntity {
     private Category category;
     @Embedded
     private StaccatoImages staccatoImages = new StaccatoImages();
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "created_by", nullable = false, updatable = false)
-    private Member createdBy;
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "modified_by", nullable = false)
-    private Member modifiedBy;
+    @Column(nullable = false)
+    private Long createdBy;
+    @Column(nullable = false)
+    private Long modifiedBy;
 
     public static Staccato create(
             LocalDateTime visitedAt,
@@ -81,8 +79,8 @@ public class Staccato extends BaseEntity {
                 longitude,
                 new StaccatoImages(staccatoImageUrls),
                 category,
-                auditor,
-                auditor);
+                auditor.getId(),
+                auditor.getId());
     }
 
     @Builder
@@ -95,8 +93,8 @@ public class Staccato extends BaseEntity {
             @NonNull BigDecimal longitude,
             @NonNull StaccatoImages staccatoImages,
             @NonNull Category category,
-            @NonNull Member createdBy,
-            @NonNull Member modifiedBy
+            Long createdBy,
+            Long modifiedBy
     ) {
         validateIsWithinCategoryTerm(visitedAt, category);
         this.visitedAt = visitedAt.truncatedTo(ChronoUnit.SECONDS);

--- a/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
+++ b/backend/src/main/java/com/staccato/staccato/service/StaccatoService.java
@@ -40,7 +40,7 @@ public class StaccatoService {
     public StaccatoIdResponse createStaccato(StaccatoRequest staccatoRequest, Member member) {
         Category category = getCategoryById(staccatoRequest.categoryId());
         category.validateOwner(member);
-        Staccato staccato = staccatoRequest.toStaccato(category);
+        Staccato staccato = staccatoRequest.toStaccato(category, member);
 
         staccatoRepository.save(staccato);
         eventPublisher.publishEvent(new StaccatoCreatedEvent(member, category));
@@ -81,7 +81,7 @@ public class StaccatoService {
             staccato.validateCategoryChangeable(targetCategory);
         }
 
-        Staccato newStaccato = staccatoRequest.toStaccato(targetCategory);
+        Staccato newStaccato = staccatoRequest.toStaccato(targetCategory, member);
         List<StaccatoImage> existingImages = staccato.existingImages();
         removeExistingImages(existingImages);
         staccato.update(newStaccato);

--- a/backend/src/main/java/com/staccato/staccato/service/dto/request/StaccatoRequest.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/request/StaccatoRequest.java
@@ -1,6 +1,7 @@
 package com.staccato.staccato.service.dto.request;
 
 import com.staccato.config.swagger.SwaggerExamples;
+import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -10,12 +11,10 @@ import java.util.Objects;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 
 import org.springframework.format.annotation.DateTimeFormat;
 
 import com.staccato.category.domain.Category;
-import com.staccato.staccato.domain.StaccatoImages;
 
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -55,16 +54,17 @@ public record StaccatoRequest(
         }
     }
 
-    public Staccato toStaccato(Category category) {
-        return Staccato.builder()
-                .visitedAt(visitedAt)
-                .title(staccatoTitle)
-                .placeName(placeName)
-                .latitude(latitude)
-                .longitude(longitude)
-                .address(address)
-                .category(category)
-                .staccatoImages(new StaccatoImages(staccatoImageUrls))
-                .build();
+    public Staccato toStaccato(Category category, Member creator) {
+        return Staccato.create(
+                visitedAt,
+                staccatoTitle,
+                placeName,
+                address,
+                latitude,
+                longitude,
+                staccatoImageUrls,
+                category,
+                creator
+        );
     }
 }

--- a/backend/src/main/resources/db/migration-test/V8__create_staccato_auditor.sql
+++ b/backend/src/main/resources/db/migration-test/V8__create_staccato_auditor.sql
@@ -1,0 +1,19 @@
+-- add created_by, modified_by column
+ALTER TABLE staccato
+    ADD COLUMN created_by BIGINT,
+ADD COLUMN modified_by BIGINT;
+
+-- set existing staccato's created_by, modified_by with category host's id
+UPDATE staccato s
+    JOIN (
+    SELECT cm.category_id, cm.member_id
+    FROM category_member cm
+    WHERE cm.role = 'HOST'
+    ) host_cm ON s.category_id = host_cm.category_id
+    SET s.created_by = host_cm.member_id,
+        s.modified_by = host_cm.member_id;
+
+-- add not null constraint
+ALTER TABLE staccato
+    MODIFY created_by BIGINT NOT NULL,
+    MODIFY modified_by BIGINT NOT NULL;

--- a/backend/src/main/resources/db/migration/V18__create_staccato_auditor.sql
+++ b/backend/src/main/resources/db/migration/V18__create_staccato_auditor.sql
@@ -1,0 +1,19 @@
+-- add created_by, modified_by column
+ALTER TABLE staccato
+    ADD COLUMN created_by BIGINT,
+ADD COLUMN modified_by BIGINT;
+
+-- set existing staccato's created_by, modified_by with category host's id
+UPDATE staccato s
+    JOIN (
+    SELECT cm.category_id, cm.member_id
+    FROM category_member cm
+    WHERE cm.role = 'HOST'
+    ) host_cm ON s.category_id = host_cm.category_id
+    SET s.created_by = host_cm.member_id,
+        s.modified_by = host_cm.member_id;
+
+-- add not null constraint
+ALTER TABLE staccato
+    MODIFY created_by BIGINT NOT NULL,
+    MODIFY modified_by BIGINT NOT NULL;

--- a/backend/src/test/java/com/staccato/ContainerBaseTest.java
+++ b/backend/src/test/java/com/staccato/ContainerBaseTest.java
@@ -1,9 +1,11 @@
 package com.staccato;
 
+import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.MySQLContainer;
 
+@Import({FcmTestConfig.class})
 public abstract class ContainerBaseTest {
 
     private static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0")

--- a/backend/src/test/java/com/staccato/FcmTestConfig.java
+++ b/backend/src/test/java/com/staccato/FcmTestConfig.java
@@ -1,0 +1,14 @@
+package com.staccato;
+
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+@TestConfiguration
+public class FcmTestConfig {
+    @Bean
+    public FirebaseMessaging firebaseMessaging() {
+        return Mockito.mock(FirebaseMessaging.class);
+    }
+}

--- a/backend/src/test/java/com/staccato/ServiceSliceTest.java
+++ b/backend/src/test/java/com/staccato/ServiceSliceTest.java
@@ -7,6 +7,6 @@ import com.staccato.util.DatabaseCleanerExtension;
 
 @ExtendWith(DatabaseCleanerExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@Import({ServiceTestConfig.class, FcmTestConfig.class})
+@Import({ServiceTestConfig.class})
 public abstract class ServiceSliceTest {
 }

--- a/backend/src/test/java/com/staccato/ServiceSliceTest.java
+++ b/backend/src/test/java/com/staccato/ServiceSliceTest.java
@@ -7,6 +7,6 @@ import com.staccato.util.DatabaseCleanerExtension;
 
 @ExtendWith(DatabaseCleanerExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
-@Import({ServiceTestConfig.class})
+@Import({ServiceTestConfig.class, FcmTestConfig.class})
 public abstract class ServiceSliceTest {
 }

--- a/backend/src/test/java/com/staccato/ServiceTestConfig.java
+++ b/backend/src/test/java/com/staccato/ServiceTestConfig.java
@@ -1,17 +1,12 @@
 package com.staccato;
 
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Bean;
-import com.google.firebase.messaging.FirebaseMessaging;
 import com.staccato.image.infrastructure.FakeS3ObjectClient;
 import com.staccato.image.infrastructure.S3ObjectClient;
 
 @TestConfiguration
 public class ServiceTestConfig {
-    @MockBean
-    private FirebaseMessaging firebaseMessaging;
-
     @Bean
     public S3ObjectClient cloudStorageClient() {
         return new FakeS3ObjectClient();

--- a/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
@@ -4,9 +4,8 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
-
 import com.staccato.category.domain.Category;
-import com.staccato.staccato.domain.Feeling;
+import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Spot;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.domain.StaccatoImages;
@@ -28,6 +27,8 @@ public class StaccatoFixtures {
         Spot spot;
         Category category;
         StaccatoImages staccatoImages = new StaccatoImages(List.of());
+        Member createdBy;
+        Member modifiedBy;
 
         public StaccatoBuilder withVisitedAt(LocalDateTime visitedAt) {
             this.visitedAt = visitedAt.truncatedTo(ChronoUnit.SECONDS);
@@ -54,9 +55,15 @@ public class StaccatoFixtures {
             return this;
         }
 
+        public StaccatoBuilder withCreator(Member auditor) {
+            this.createdBy = auditor;
+            this.modifiedBy = auditor;
+            return this;
+        }
+
         public Staccato build() {
             return new Staccato(visitedAt, title, spot.getPlaceName(), spot.getAddress(), spot.getLatitude(),
-                    spot.getLongitude(), staccatoImages, category);
+                    spot.getLongitude(), staccatoImages, category, createdBy, modifiedBy);
         }
 
         public Staccato buildAndSave(StaccatoRepository repository) {

--- a/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
@@ -17,7 +17,9 @@ public class StaccatoFixtures {
         return new StaccatoBuilder()
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .withTitle("staccatoTitle")
-                .withSpot(BigDecimal.ZERO.setScale(14), BigDecimal.ZERO.setScale(14));
+                .withSpot(BigDecimal.ZERO.setScale(14), BigDecimal.ZERO.setScale(14))
+                .withCreatedBy(1L)
+                .withModifiedBy(1L);
     }
 
     public static class StaccatoBuilder {
@@ -27,8 +29,8 @@ public class StaccatoFixtures {
         Spot spot;
         Category category;
         StaccatoImages staccatoImages = new StaccatoImages(List.of());
-        Member createdBy;
-        Member modifiedBy;
+        Long createdBy;
+        Long modifiedBy;
 
         public StaccatoBuilder withVisitedAt(LocalDateTime visitedAt) {
             this.visitedAt = visitedAt.truncatedTo(ChronoUnit.SECONDS);
@@ -56,8 +58,18 @@ public class StaccatoFixtures {
         }
 
         public StaccatoBuilder withCreator(Member auditor) {
-            this.createdBy = auditor;
-            this.modifiedBy = auditor;
+            this.createdBy = auditor.getId();
+            this.modifiedBy = auditor.getId();
+            return this;
+        }
+
+        public StaccatoBuilder withCreatedBy(Long createdBy) {
+            this.createdBy = createdBy;
+            return this;
+        }
+
+        public StaccatoBuilder withModifiedBy(Long modifiedBy) {
+            this.modifiedBy = modifiedBy;
             return this;
         }
 

--- a/backend/src/test/java/com/staccato/flyway/FlywayTest.java
+++ b/backend/src/test/java/com/staccato/flyway/FlywayTest.java
@@ -1,25 +1,102 @@
 package com.staccato.flyway;
 
+import java.util.Map;
+import javax.sql.DataSource;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import com.staccato.ContainerBaseTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 @AutoConfigureTestDatabase(replace = Replace.NONE)
-@TestPropertySource(properties = {"spring.config.location = classpath:application-test.yml"})
+@TestPropertySource(properties = {
+        "spring.config.location=classpath:application-test.yml",
+        "spring.flyway.enabled=false" // Flyway 자동 실행 방지
+})
 @ActiveProfiles("test")
 public class FlywayTest extends ContainerBaseTest {
+    public static final String FLYWAY_SCRIPT_PATH = "classpath:db/migration-test";
+
+    @Autowired
+    DataSource dataSource;
+
+    @BeforeEach
+    void setUp() {
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations(FLYWAY_SCRIPT_PATH)
+                .cleanDisabled(false)
+                .load();
+        flyway.clean();
+    }
 
     @Test
     void contextLoads_whenFlywayMigrationsApplied() {
-        // ✅ 아무 것도 하지 않아도 됨
-        // 이 테스트가 통과하면:
-        // - Flyway 마이그레이션이 모두 성공적으로 적용됨
-        // - 컨텍스트 로딩에 실패하지 않음
-        // - 따라서 마이그레이션에 문제가 없음을 보장
+        // given
+        Flyway flyway = Flyway.configure()
+                .dataSource(dataSource)
+                .locations(FLYWAY_SCRIPT_PATH)
+                .load();
+
+        // when & then
+        assertThatNoException().isThrownBy(flyway::migrate);
+    }
+
+    @DisplayName("V8__create_staccato_auditor 마이그레이션 성공 테스트: staccato가 속한 category host의 논리적 삭제 여부와 상관 없이 created_by/modified_by로 세팅한다.")
+    @Test
+    void shouldAddAuditorFieldsAndSetHostAsDefault() throws Exception {
+        // given
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(FLYWAY_SCRIPT_PATH)
+                .target("7")
+                .load()
+                .migrate();
+
+        JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+        jdbcTemplate.update("INSERT INTO member (id, nickname, code, is_deleted) VALUES (?, ?, ?, ?)",
+                1L, "host", java.util.UUID.randomUUID().toString(), true);
+        jdbcTemplate.update("INSERT INTO member (id, nickname, code, is_deleted) VALUES (?, ?, ?, ?)",
+                2L, "guest", java.util.UUID.randomUUID().toString(), false);
+        jdbcTemplate.update("INSERT INTO category (id, title, is_shared) VALUES (?, ?, ?)",
+                1L, "테스트", false);
+        jdbcTemplate.update("INSERT INTO category_member (category_id, member_id, role) VALUES (?, ?, 'HOST')",
+                1L, 1L);
+        jdbcTemplate.update("INSERT INTO category_member (category_id, member_id, role) VALUES (?, ?, 'GUEST')",
+                1L, 2L);
+        jdbcTemplate.update("""
+            INSERT INTO staccato (id, visited_at, category_id, title, place_name, address, latitude, longitude, feeling)
+            VALUES (?, NOW(), ?, '제목', '장소', '주소', 0.0, 0.0, 'NOTHING')
+        """, 1L, 1L);
+
+        // when
+        Flyway.configure()
+                .dataSource(dataSource)
+                .locations(FLYWAY_SCRIPT_PATH)
+                .load()
+                .migrate();
+
+        // then
+        Map<String, Object> result = jdbcTemplate.queryForMap(
+                "SELECT created_by, modified_by FROM staccato WHERE id = ?", 1L
+        );
+
+        assertAll(
+                () -> assertThat(result.get("created_by")).isEqualTo(1L),
+                () -> assertThat(result.get("modified_by")).isEqualTo(1L)
+        );
     }
 }

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
@@ -258,4 +258,83 @@ class StaccatoTest {
                         .hasMessage("개인 카테고리 간에만 스타카토를 옮길 수 있어요.")
         );
     }
+
+    @DisplayName("Staccato 생성 시 생성자/수정자는 생성한 사람으로 만들어진다.")
+    @Test
+    void createdAndModifiedBySameWhenCreated() {
+        // given
+        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(creator)
+                .build();
+
+        // when
+        Staccato staccato = Staccato.create(
+                LocalDateTime.of(2025, 1, 1, 12, 0),
+                "첫 방문",
+                "장소명",
+                "주소",
+                BigDecimal.ONE,
+                BigDecimal.ONE,
+                List.of("https://image.url/1.jpg"),
+                category,
+                creator
+        );
+
+        // then
+        assertAll(
+                () -> assertThat(staccato.getCreatedBy()).isEqualTo(creator),
+                () -> assertThat(staccato.getModifiedBy()).isEqualTo(creator)
+        );
+    }
+
+    @DisplayName("Staccato update 시 createdBy는 변경되지 않는다.")
+    @Test
+    void createdByDoesNotChangeOnUpdate() {
+        // given
+        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
+        Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
+        Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
+
+        Staccato original = StaccatoFixtures.defaultStaccato()
+                .withCategory(category)
+                .withCreator(creator)
+                .build();
+
+        Staccato updateData = StaccatoFixtures.defaultStaccato()
+                .withCategory(category)
+                .withCreator(updater)
+                .build();
+
+        // when
+        original.update(updateData);
+
+        // then
+        assertThat(original.getCreatedBy()).isEqualTo(creator);
+    }
+
+    @DisplayName("Staccato update 시 modifiedBy는 최근 수정자로 갱신된다.")
+    @Test
+    void modifiedByChangesOnUpdate() {
+        // given
+        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
+        Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
+        Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
+
+        Staccato original = StaccatoFixtures.defaultStaccato()
+                .withCategory(category)
+                .withCreator(creator)
+                .build();
+
+        Staccato updateData = StaccatoFixtures.defaultStaccato()
+                .withCategory(category)
+                .withCreator(updater)
+                .build();
+
+        // when
+        original.update(updateData);
+
+        // then
+        assertThat(original.getModifiedBy()).isEqualTo(updater);
+    }
 }

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
@@ -266,6 +266,7 @@ class StaccatoTest {
         Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(creator)
+                .withTerm(null, null)
                 .build();
 
         // when
@@ -283,8 +284,8 @@ class StaccatoTest {
 
         // then
         assertAll(
-                () -> assertThat(staccato.getCreatedBy()).isEqualTo(creator),
-                () -> assertThat(staccato.getModifiedBy()).isEqualTo(creator)
+                () -> assertThat(staccato.getCreatedBy()).isEqualTo(creator.getId()),
+                () -> assertThat(staccato.getModifiedBy()).isEqualTo(creator.getId())
         );
     }
 
@@ -310,7 +311,7 @@ class StaccatoTest {
         original.update(updateData);
 
         // then
-        assertThat(original.getCreatedBy()).isEqualTo(creator);
+        assertThat(original.getCreatedBy()).isEqualTo(creator.getId());
     }
 
     @DisplayName("Staccato update 시 modifiedBy는 최근 수정자로 갱신된다.")
@@ -335,6 +336,6 @@ class StaccatoTest {
         original.update(updateData);
 
         // then
-        assertThat(original.getModifiedBy()).isEqualTo(updater);
+        assertThat(original.getModifiedBy()).isEqualTo(updater.getId());
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #891

## 🚩 Summary
- 스타카토는 연관관계 매핑 없이 생성자/수정자 식별자를 필드로 가짐
- flyway 스크립트에서는 존재하는 데이터들에 대해서 생성자/수정자 정보를 host 기준으로 세팅하도록 작성 (테스트로 성공 확인)

## 🛠️ Technical Concerns
### createdDate, modifiedDate에 대한 고민 및 결론 공유
createdDate와 modifiedDate를 DB 의존적으로 작성(TIMESTAMP DEFAULT CURRENT_TIMESTAMP (ON UPDATE)) 시
- 장점: JPA 의존도 낮춤. JPA AUditing 기능을 제대로 이해하지 않음으로 인한 문제 발생 가능성 낮춤
- 단점: dirty checking 안됨, DB 의존성 높음(벤더, 버전), java에서는 null이게 됨 -> 테스트 어려움

따라서 현행 유지
### createdBy, modifiedBy 설계 과정 공유 - 연관관계 매핑 X
공동 카테고리에서의 스타카토는 생성자의 카테고리 나감 여부/서비스 탈퇴 여부 관계 없이 유지 예정
따라서, 데이터 무결성보다는 유연성을 더 중요하게 생각하여 연관관계 없이 id로 저장
**추후에 생성자/수정자 조회 니즈가 있다면, 존재하지 않는 id, 카테고리를 나간 사용자는 어떻게 처리하나요?**
`Member.unknown()`과 같은 정펙메로 `nickname=알수없음, profile=null`과 같은 방식으로 처리하는 방향을 생각해봄.
**스타카토 권한이 생성자 중심으로 바뀐다면?**
그래도 생성자의 카테고리 나감 여부 관계 없이 스타카토는 남기는 방향을 유지하지 않을까?🤔막연하게 생각
따라서, 생성자 중심 권한 부여 니즈가 생긴다면, 연관관계 매핑 대신 `@Column(updatable=false)`와 같은 방식으로 처리하여 수정 쿼리에는 `createdBy` 필드가 포함되지 않도록 일종의 방지선을 만드는 것을 고민해봄.

### createdBy, modifiedBy 설계 과정 공유 - 책임 분리에 대한 고민
현재는 staccato에서만 필요함, 따라서 staccato 내부 필드로 선언하여 명시적으로 작성
추후에 중복이 많아져 책임 분리가 필요해진다면, `AuditorHandler`를 분리하는 것을 고려
```
@Component
public class AuditorHandler {

    public void applyAuthor(Auditable target, Member actor) {
        if(target.getCreatedBy == null){
            return;
        }
        target.setCreatedBy(actor);
        target.setModifiedBy(actor);
    }

    public void applyModifier(Auditable target, Member actor) {
        target.setModifiedBy(actor);
    }
}
```
이렇게 작성자/수정자 세팅 로직을 별도의 컴포넌트로 위임하여 필요할 때마다 staccato.setCreatedBy(member)/staccato.setModifiedBy(member) 를 직접 호출 시 발생 가능한 중복/휴먼 에러 방지
Auditor가 필요한 객체는 Auditable 인터페이스를 구현
```
public interface Auditable {
    void setCreatedBy(Member member);
    void setModifiedBy(Member member);
}
@Entity
public class Staccato extends BaseEntity implements Auditable {

    @ManyToOne(fetch = FetchType.LAZY)
    private Member createdBy;

    @ManyToOne(fetch = FetchType.LAZY)
    private Member modifiedBy;

    @Override
    public void setCreatedBy(Member member) {
        this.createdBy = member;
    }

    @Override
    public void setModifiedBy(Member member) {
        this.modifiedBy = member;
    }
}
```
서비스 코드에서는 AuditorHandler를 통해 Auditor 설정
```
@Service
@RequiredArgsConstructor
public class StaccatoService {

    private final AuditorHandler auditorHandler;

    public void createStaccato(CreateStaccatoRequest request, Member creator) {
        Staccato staccato = new Staccato(...);

        auditorHandler.applyAuthor(staccato, creator);

        staccatoRepository.save(staccato);
    }

    public void updateStaccato(Long id, UpdateStaccatoRequest request, Member modifier) {
        Staccato staccato = findByIdOrThrow(id);

        staccato.changeContent(request.getContent());
        auditorHandler.applyModifier(staccato, modifier);
    }
}
```
이와 같은 방식으로 추후 여러 객체에서 auditor 관리가 필요하다면 중복 제거/일관성/확장성/타입 안정성/테스트 용이성을 누릴 수 있다고 생각

하지만 결국 프레임워크 기능에 의존하지 않는 이상, 필요한 모든 서비스 로직에서 auditingHandler를 직접 호출해야한다는 점에서는 트레이드 오프가 있다고 생각

### flyway 테스트
- 특정 스크립트에서 시나리오 기반 테스트 해보고 싶은 니즈 생김 (테이블에 대한 변화로 기존 데이터 세팅이 따라오는 경우)
- 따라서 flyway 스크립트 자동 실행 대신, 직접 Flyway 메서드를 호출하여 실행하는 방식으로 테스트 방식 변경
- 테스트 격리를 위해 beforeEach로 flyway.clean 수행

## 🙂 To Reviewer


## 📋 To Do
