### PR TITLE
feat: 지도 기준 스타카토 목록 조회 API 응답 필드 추가 #912

### DIFF
--- a/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoLocationResponseV2.java
+++ b/backend/src/main/java/com/staccato/staccato/service/dto/response/StaccatoLocationResponseV2.java
@@ -1,6 +1,7 @@
 package com.staccato.staccato.service.dto.response;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.staccato.domain.Staccato;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -14,12 +15,22 @@ public record StaccatoLocationResponseV2(
         @Schema(example = SwaggerExamples.STACCATO_LATITUDE)
         BigDecimal latitude,
         @Schema(example = SwaggerExamples.STACCATO_LONGITUDE)
-        BigDecimal longitude
+        BigDecimal longitude,
+        @Schema(example = SwaggerExamples.STACCATO_TITLE)
+        String title,
+        @Schema(example = SwaggerExamples.STACCATO_VISITED_AT)
+        LocalDateTime visitedAt
 ) {
 
     public StaccatoLocationResponseV2(Staccato staccato) {
-        this(staccato.getId(), staccato.getColor().getName(), staccato.getSpot().getLatitude(), staccato.getSpot()
-                .getLongitude());
+        this(
+                staccato.getId(),
+                staccato.getColor().getName(),
+                staccato.getSpot().getLatitude(),
+                staccato.getSpot().getLongitude(),
+                staccato.getTitle().getTitle(),
+                staccato.getVisitedAt()
+        );
     }
 
     public StaccatoLocationResponse toStaccatoLocationResponse() {

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -46,7 +46,7 @@ class AuthControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(loginRequest))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("닉네임이 공백만 있거나, 빈 문자열이거나, null이면 400을 반환한다.")

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerV2Test.java
@@ -47,7 +47,7 @@ class AuthControllerV2Test extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(loginRequest))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse,true));
     }
 
     @DisplayName("닉네임이 공백만 있거나, 빈 문자열이거나, null이면 400을 반환한다.")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -100,7 +100,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("기간이 없는 카테고리를 생성하는 요청/응답의 역직렬화/직렬화에 성공한다.")
@@ -129,7 +129,7 @@ class CategoryControllerTest extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("사용자가 선택적으로 카테고리 정보를 입력하면, 새로운 카테고리를 생성한다.")
@@ -207,7 +207,7 @@ class CategoryControllerTest extends ControllerTest {
         mockMvc.perform(get("/categories")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("유효하지 않은 필터링 조건은 무시하고, 모든 카테고리 목록을 조회한다.")
@@ -257,7 +257,7 @@ class CategoryControllerTest extends ControllerTest {
                         .param("specificDate", LocalDate.now().toString())
                         .param("isPrivate", "false"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("specificDate 파라미터 없이 요청하면 예외가 발생한다.")
@@ -364,7 +364,7 @@ class CategoryControllerTest extends ControllerTest {
         mockMvc.perform(get("/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
 
@@ -412,7 +412,7 @@ class CategoryControllerTest extends ControllerTest {
         mockMvc.perform(get("/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("특정 카테고리에 속한 스타카토 목록 조회에 성공한다.")
@@ -461,7 +461,7 @@ class CategoryControllerTest extends ControllerTest {
                         .param("swLng", "123")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("적합한 경로변수와 데이터를 통해 스타카토 수정에 성공한다.")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -92,7 +92,7 @@ class CategoryControllerV2Test extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("기간이 없는 카테고리를 생성하는 요청/응답의 역직렬화/직렬화에 성공한다.")
@@ -122,7 +122,7 @@ class CategoryControllerV2Test extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("사용자가 선택적으로 카테고리 정보를 입력하면, 새로운 카테고리를 생성한다.")
@@ -202,7 +202,7 @@ class CategoryControllerV2Test extends ControllerTest {
         mockMvc.perform(get("/v2/categories")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("유효하지 않은 필터링 조건은 무시하고, 모든 카테고리 목록을 조회한다.")
@@ -271,7 +271,7 @@ class CategoryControllerV2Test extends ControllerTest {
         mockMvc.perform(get("/v2/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
 
@@ -320,7 +320,7 @@ class CategoryControllerV2Test extends ControllerTest {
         mockMvc.perform(get("/v2/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("적합한 경로변수와 데이터를 통해 스타카토 수정에 성공한다.")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -99,7 +99,7 @@ class CategoryControllerV3Test extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("기간이 없는 카테고리를 생성하는 요청/응답의 역직렬화/직렬화에 성공한다.")
@@ -130,7 +130,7 @@ class CategoryControllerV3Test extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/categories/1"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("사용자가 선택적으로 카테고리 정보를 입력하면, 새로운 카테고리를 생성한다.")
@@ -192,6 +192,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "startAt": "2024-01-01",
                     "endAt": "2024-12-31",
                     "isShared": true,
+                    "myRole":"host",
                     "members": [
                         {
                             "memberId": null,
@@ -221,7 +222,7 @@ class CategoryControllerV3Test extends ControllerTest {
         mockMvc.perform(get("/v3/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
 
@@ -248,6 +249,7 @@ class CategoryControllerV3Test extends ControllerTest {
                     "categoryTitle": "categoryTitle",
                     "description": "categoryDescription",
                     "categoryColor": "pink",
+                    "isShared": false,
                     "myRole": "host",
                     "members": [
                         {
@@ -272,7 +274,7 @@ class CategoryControllerV3Test extends ControllerTest {
         mockMvc.perform(get("/v3/categories/{categoryId}", categoryId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("사용자가 모든 카테고리 목록을 조회하는 응답 직렬화에 성공한다.")
@@ -354,7 +356,7 @@ class CategoryControllerV3Test extends ControllerTest {
         mockMvc.perform(get("/v3/categories")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("유효하지 않은 필터링 조건은 무시하고, 모든 카테고리 목록을 조회한다.")

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -128,7 +128,7 @@ public class CommentControllerTest extends ControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "token"))
             .andExpect(status().isOk())
-            .andExpect(content().json(expectedResponse));
+            .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("스타카토 식별자가 양수가 아닐 경우 댓글 읽기에 실패한다.")

--- a/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
+++ b/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
@@ -57,7 +57,7 @@ class InvitationControllerTest extends ControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invitationRequest))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("유효하지 않은 카테고리 식별자로 초대 요청 시 예외가 발생한다.")
@@ -146,7 +146,7 @@ class InvitationControllerTest extends ControllerTest {
         mockMvc.perform(get("/invitations/sent")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("초대 ID로 초대 요청을 수락한다.")
@@ -245,6 +245,6 @@ class InvitationControllerTest extends ControllerTest {
         mockMvc.perform(get("/invitations/received")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 }

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -48,7 +48,7 @@ class MemberControllerTest extends ControllerTest {
                         .param("excludeCategoryId", "0")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("요청 인자로 검색어가 없어도 예외가 발생하지 않는다.")
@@ -71,7 +71,7 @@ class MemberControllerTest extends ControllerTest {
                         .param("excludeCategoryId", "1")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("요청 인자로 카테고리 식별자가 없어도 예외가 발생하지 않는다.")
@@ -102,6 +102,6 @@ class MemberControllerTest extends ControllerTest {
                         .param("nickname", "스타")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 }

--- a/backend/src/test/java/com/staccato/member/controller/MyPageControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MyPageControllerTest.java
@@ -43,7 +43,7 @@ class MyPageControllerTest extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token")
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("마이페이지의 사용자 정보를 조회한다.")
@@ -65,6 +65,6 @@ class MyPageControllerTest extends ControllerTest {
         mockMvc.perform(get("/mypage")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 }

--- a/backend/src/test/java/com/staccato/member/controller/MyPageControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/member/controller/MyPageControllerV2Test.java
@@ -35,6 +35,6 @@ class MyPageControllerV2Test extends ControllerTest {
         mockMvc.perform(get("/v2/mypage")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 }

--- a/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
@@ -37,7 +37,7 @@ class NotificationControllerTest extends ControllerTest {
         mockMvc.perform(get("/notifications/exists")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("알림용 토큰을 등록합니다.")

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
@@ -202,7 +202,7 @@ class StaccatoControllerTest extends ControllerTest {
         mockMvc.perform(get("/staccatos")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("적합한 경로변수를 통해 스타카토 조회에 성공한다.")
@@ -241,7 +241,7 @@ class StaccatoControllerTest extends ControllerTest {
         mockMvc.perform(get("/staccatos/{staccatoId}", staccatoId)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("적합하지 않은 경로변수의 경우 스타카토 조회에 실패한다.")
@@ -369,7 +369,7 @@ class StaccatoControllerTest extends ControllerTest {
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isCreated())
                 .andExpect(header().string(HttpHeaders.LOCATION, "/staccatos/shared/" + "sample-token"))
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 
     @DisplayName("토큰으로 스타카토의 정보를 불러온다.")
@@ -430,6 +430,6 @@ class StaccatoControllerTest extends ControllerTest {
         mockMvc.perform(get("/staccatos/shared/{token}", token)
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())
-                .andExpect(content().json(expectedResponse));
+                .andExpect(content().json(expectedResponse, true));
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #912

## 🚩 Summary
- 전체 스타카토 목록 조회 API V2에 제목, 날짜 응답 필드를 추가

## 🛠️ Technical Concerns
- 컨트롤러 단위 테스트에서 응답 형식 관련 테스트를 다음과 같이 작성해왔습니다.
```
mockMvc.perform(get("/v3/categories/{categoryId}", categoryId)
                        .header(HttpHeaders.AUTHORIZATION, "token"))
                .andExpect(status().isOk())
                .andExpect(content().json(expectedResponse));
```
- `MockMvcResultMatcher.content.json` 기본 설정은 `LENIENT` 모드로, 존재하는 필드에 대해서만 일치 여부를 검증합니다. 
- 즉, 누락된 필드 존재함에도 테스트 통과합니다. 
- 이는 테스트 목적에 맞지 않으므로, STRICT 모드로 설정하여 모든 필드가 일치해야만 테스트가 통과하도록 강제했습니다.

## 🙂 To Reviewer
마지막 커밋은 테스트 STRICT 모드 변경 관련 커밋입니다! 전체 파일 변경으로 리뷰 시 참고해주세요:>


## 📋 To Do
