### PR TITLE
feat: 행위 대상자에게는 알림이 가지 않도록 수정 #915

### DIFF
--- a/backend/src/main/java/com/staccato/notification/listener/NotificationEventListener.java
+++ b/backend/src/main/java/com/staccato/notification/listener/NotificationEventListener.java
@@ -42,7 +42,12 @@ public class NotificationEventListener {
         Category category = event.category();
         if (category.getIsShared()) {
             List<Member> existingMembers = categoryMemberRepository.findAllMembersByCategoryId(category.getId());
-            notificationService.sendNewStaccatoAlert(event.creator(), event.category(), existingMembers);
+
+            List<Member> targetMembers = existingMembers.stream()
+                    .filter(member -> !member.equals(event.creator()))
+                    .toList();
+
+            notificationService.sendNewStaccatoAlert(event.creator(), event.category(), targetMembers);
         }
     }
 

--- a/backend/src/main/java/com/staccato/notification/listener/NotificationEventListener.java
+++ b/backend/src/main/java/com/staccato/notification/listener/NotificationEventListener.java
@@ -59,7 +59,9 @@ public class NotificationEventListener {
         Category category = event.category();
         if (category.getIsShared()) {
             List<Member> existingMembers = categoryMemberRepository.findAllMembersByCategoryId(category.getId());
-            notificationService.sendNewCommentAlert(event.commenter(), event.comment(), existingMembers);
+            List<Member> targetMembers = excludeSelf(existingMembers, event.commenter());
+
+            notificationService.sendNewCommentAlert(event.commenter(), event.comment(), targetMembers);
         }
     }
 

--- a/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerSliceTest.java
+++ b/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerSliceTest.java
@@ -1,0 +1,68 @@
+package com.staccato.notification.listener;
+
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.staccato.category.domain.Category;
+import com.staccato.category.repository.CategoryMemberRepository;
+import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.member.domain.Member;
+import com.staccato.notification.service.NotificationService;
+import com.staccato.staccato.service.dto.event.StaccatoCreatedEvent;
+
+@ExtendWith(MockitoExtension.class)
+public class NotificationEventListenerSliceTest {
+
+    @Mock
+    CategoryMemberRepository categoryMemberRepository;
+    @Mock
+    NotificationService notificationService;
+    @InjectMocks
+    private NotificationEventListener listener;
+
+    @DisplayName("스타카토를 만든 멤버에게는 새로운 스타카토 알림을 보내지 않는다.")
+    @Test
+    void handleNewStaccatoShouldExcludeCreator() {
+        // given
+        Member creator = MemberFixtures.defaultMember()
+                .withNickname("creator").build();
+        Member member1 = MemberFixtures.defaultMember()
+                .withNickname("member1").build();
+        Member member2 = MemberFixtures.defaultMember()
+                .withNickname("member2").build();
+
+        Category sharedCategory = mock(Category.class);
+        when(sharedCategory.getIsShared()).thenReturn(true);
+        when(sharedCategory.getId()).thenReturn(1L);
+        when(categoryMemberRepository.findAllMembersByCategoryId(1L))
+                .thenReturn(List.of(creator, member1, member2));
+
+        StaccatoCreatedEvent event = new StaccatoCreatedEvent(creator, sharedCategory);
+
+        // when
+        listener.handleNewStaccato(event);
+
+        // then
+        verify(notificationService).sendNewStaccatoAlert(
+                eq(creator),
+                eq(sharedCategory),
+                argThat(targets ->
+                        targets.size() == 2 &&
+                        !targets.contains(creator) &&
+                        targets.containsAll(List.of(member1, member2))
+                )
+        );
+    }
+}

--- a/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
@@ -115,7 +115,7 @@ class NotificationEventListenerTest extends ServiceSliceTest {
                 verify(notificationService, times(1))
                         .sendNewCommentAlert(eq(host),
                                 argThat(comment -> comment.getContent().equals(commentRequest.content())),
-                                argThat(m -> m.containsAll(List.of(guest, guest2, host))))
+                                argThat(m -> m.containsAll(List.of(guest, guest2))))
         );
     }
 


### PR DESCRIPTION
## ⭐️ Issue Number
- #915 

## 🚩 Summary

* 공동카테고리 초대 수락 시 -> `~님이 참여했어요, ~에서 환영해주세요!` -> 초대 수락한 본인을 알림 대상에서 제외
* 공동카테고리에 스타카토 추가 시 -> `스타카토가 추가됐어요, ~님이 ~에 남긴 스타카토를 확인해보세요` -> 스타카토를 추가한 본인을 알림 대상에서 제외
* 공동카테고리에 댓글 작성 시 -> `~님의 코멘트, {코멘트 내용}` -> 댓글을 작성한 본인을 알림 대상에서 제외

## 🛠️ Technical Concerns


## 🙂 To Reviewer

* 아래 메서드를 만들면서, `List<Member>`를 `Members`라는 일급 컬렉션으로 만들고 해당 클래스에 책임을 위임해도 괜찮겠다고 생각했으나, 일단 그냥 구현했습니다.

  ```java
  // NotificationEventListenr.java
  private List<Member> excludeSelf(List<Member> members, Member self) {
      return members.stream()
              .filter(member -> !member.equals(self))
              .toList();
  }
  ```

* 멤버의 포함 여부만 테스트하면 되기 때문에, `Mockito`를 사용한 `SliceTest`로 작성했습니다.

## 📋 To Do
