### PR TITLE
feat: 공동카테고리에 함께하는 사람이 추가되면, 카테고리의 updatedAt 갱신 #928

### DIFF
--- a/backend/src/main/java/com/staccato/category/domain/Category.java
+++ b/backend/src/main/java/com/staccato/category/domain/Category.java
@@ -117,6 +117,8 @@ public class Category extends BaseEntity {
                     .build();
             categoryMembers.add(categoryMember);
         });
+
+        setUpdatedAt(LocalDateTime.now());
     }
 
     public void update(Category updatedCategory, List<Staccato> staccatos) {

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -219,6 +219,27 @@ class CategoryTest {
         }
     }
 
+    @DisplayName("GUEST가 추가되면, 카테고리의 updatedAt이 갱신된다.")
+    @Test
+    void changeUpdatedAtWhenAddGuest() {
+        // given
+        Member host = MemberFixtures.defaultMember().withNickname("host").build();
+        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
+        Category category = CategoryFixtures.defaultCategory()
+                .withHost(host)
+                .build();
+
+        LocalDateTime beforeUpdatedAt = category.getUpdatedAt();
+
+        // when
+        category.addGuests(List.of(guest));
+
+        // then
+        LocalDateTime afterUpdatedAt = category.getUpdatedAt();
+
+        assertThat(beforeUpdatedAt).isBefore(afterUpdatedAt);
+    }
+
 /*
     @DisplayName("처음 카테고리를 생성했을 때 스타카토는 0개이다.")
     @Test


### PR DESCRIPTION
## ⭐️ Issue Number
- #928 

## 🚩 Summary

- 공동카테고리에 함께하는 사람이 추가되면, 해당 카테고리의 updatedAt 갱신
- 함께하는 사람이 삭제되는 경우는 갱신하지 않습니다. 

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
