### PR TITLE
feat: 알림 구성 변경 (Notification & Data 모두 전달) #938

### DIFF
--- a/backend/src/main/java/com/staccato/notification/service/FcmService.java
+++ b/backend/src/main/java/com/staccato/notification/service/FcmService.java
@@ -5,7 +5,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Executor;
 
-import org.hibernate.resource.transaction.LocalSynchronizationException;
 import org.springframework.stereotype.Service;
 
 import com.google.api.core.ApiFuture;
@@ -26,7 +25,6 @@ import com.staccato.notification.service.dto.message.PushMessage;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import software.amazon.awssdk.regions.servicemetadata.ApsServiceMetadata;
 
 @Trace
 @Slf4j
@@ -72,9 +70,10 @@ public class FcmService {
                 .setAndroidConfig(ANDROID_CONFIG)
                 .setApnsConfig(APNS_CONFIG)
                 .addAllTokens(tokens)
+                .setNotification(pushMessage.toNotification())
                 .putData("title", pushMessage.getTitle())
                 .putData("body", pushMessage.getBody())
-                .putAllData(Objects.requireNonNullElse(pushMessage.toMap(), Map.of()))
+                .putAllData(Objects.requireNonNullElse(pushMessage.toData(), Map.of()))
                 .build();
     }
 

--- a/backend/src/main/java/com/staccato/notification/service/FcmService.java
+++ b/backend/src/main/java/com/staccato/notification/service/FcmService.java
@@ -31,7 +31,6 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 @RequiredArgsConstructor
 public class FcmService {
-
     private static final int FCM_MULTICAST_LIMIT = 500;
     private static final String SEND_SUCCESS_LOG = "[FCM][전송 완료] ";
     private static final String SEND_FAIL_LOG = "[FCM][전송 실패] ";
@@ -71,8 +70,6 @@ public class FcmService {
                 .setApnsConfig(APNS_CONFIG)
                 .addAllTokens(tokens)
                 .setNotification(pushMessage.toNotification())
-                .putData("title", pushMessage.getTitle())
-                .putData("body", pushMessage.getBody())
                 .putAllData(Objects.requireNonNullElse(pushMessage.toData(), Map.of()))
                 .build();
     }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -1,10 +1,11 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
-import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 public class AcceptInvitationMessage extends PushMessage {
     private final String inviteeName;
     private final String categoryTitle;

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -5,40 +5,30 @@ import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
-public record AcceptInvitationMessage(
-        String categoryId,
-        String inviteeName,
-        String categoryTitle
-) implements PushMessage {
+public class AcceptInvitationMessage extends PushMessage {
+    private final String inviteeName;
+    private final String categoryTitle;
+    private final String categoryId;
+
     public AcceptInvitationMessage(Member invitee, Category category) {
-        this(String.valueOf(category.getId()), invitee.getNickname().getNickname(), category.getTitle().getTitle());
+        super(MessageType.ACCEPT_INVITATION);
+        this.inviteeName = invitee.getNickname().getNickname();
+        this.categoryTitle = category.getTitle().getTitle();
+        this.categoryId = String.valueOf(category.getId());
     }
 
     @Override
-    public Notification toNotification() {
-        return Notification.builder()
-                .setTitle(getTitle())
-                .setBody(getBody())
-                .build();
-    }
-
-    @Override
-    public Map<String, String> toData() {
-        return Map.of(
-                "title", getTitle(),
-                "body", getBody(),
-                "type", "ACCEPT_INVITATION",
-                "categoryId", categoryId
-        );
-    }
-
-    @Override
-    public String getTitle() {
+    protected String getTitle() {
         return String.format("%s님이 참여했어요", inviteeName);
     }
 
     @Override
-    public String getBody() {
+    protected String getBody() {
         return String.format("%s에서 환영해주세요!", categoryTitle);
+    }
+
+    @Override
+    protected Map<String, String> getAdditionalData() {
+        return Map.of("categoryId", categoryId);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -1,15 +1,19 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
-
 import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
 public record AcceptInvitationMessage(
-        Member invitee,
-        Category category
+        String categoryId,
+        String inviterName,
+        String categoryTitle
 ) implements PushMessage {
+    public AcceptInvitationMessage(Member invitee, Category category) {
+        this(String.valueOf(category.getId()), invitee.getNickname().getNickname(), category.getTitle().getTitle());
+    }
+
     @Override
     public Notification toNotification() {
         return Notification.builder()
@@ -24,17 +28,17 @@ public record AcceptInvitationMessage(
                 "title", getTitle(),
                 "body", getBody(),
                 "type", "ACCEPT_INVITATION",
-                "categoryId", String.valueOf(category.getId())
+                "categoryId", String.valueOf(categoryId)
         );
     }
 
     @Override
     public String getTitle() {
-        return String.format("%s님이 참여했어요", invitee.getNickname().getNickname());
+        return String.format("%s님이 참여했어요", inviterName);
     }
 
     @Override
     public String getBody() {
-        return String.format("%s에서 환영해주세요!", category.getTitle().getTitle());
+        return String.format("%s에서 환영해주세요!", categoryTitle);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -21,6 +21,8 @@ public record AcceptInvitationMessage(
     @Override
     public Map<String, String> toData() {
         return Map.of(
+                "title", getTitle(),
+                "body", getBody(),
                 "type", "ACCEPT_INVITATION",
                 "categoryId", String.valueOf(category.getId())
         );

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -2,6 +2,7 @@ package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
 
+import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
@@ -9,9 +10,16 @@ public record AcceptInvitationMessage(
         Member invitee,
         Category category
 ) implements PushMessage {
+    @Override
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(getTitle())
+                .setBody(getBody())
+                .build();
+    }
 
     @Override
-    public Map<String, String> toMap() {
+    public Map<String, String> toData() {
         return Map.of(
                 "type", "ACCEPT_INVITATION",
                 "categoryId", String.valueOf(category.getId())

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/AcceptInvitationMessage.java
@@ -7,7 +7,7 @@ import com.staccato.member.domain.Member;
 
 public record AcceptInvitationMessage(
         String categoryId,
-        String inviterName,
+        String inviteeName,
         String categoryTitle
 ) implements PushMessage {
     public AcceptInvitationMessage(Member invitee, Category category) {
@@ -28,13 +28,13 @@ public record AcceptInvitationMessage(
                 "title", getTitle(),
                 "body", getBody(),
                 "type", "ACCEPT_INVITATION",
-                "categoryId", String.valueOf(categoryId)
+                "categoryId", categoryId
         );
     }
 
     @Override
     public String getTitle() {
-        return String.format("%s님이 참여했어요", inviterName);
+        return String.format("%s님이 참여했어요", inviteeName);
     }
 
     @Override

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
@@ -1,18 +1,18 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
-
-import com.google.firebase.messaging.Notification;
 import com.staccato.comment.domain.Comment;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 public class CommentCreatedMessage extends PushMessage {
     private final String staccatoId;
     private final String commenterName;
     private final String commentContent;
 
-    public CommentCreatedMessage(Member commentCreator, Staccato staccato, Comment comment){
+    public CommentCreatedMessage(Member commentCreator, Staccato staccato, Comment comment) {
         super(MessageType.COMMENT_CREATED);
         this.commenterName = commentCreator.getNickname().getNickname();
         this.commentContent = comment.getContent();

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
@@ -2,6 +2,7 @@ package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
 
+import com.google.firebase.messaging.Notification;
 import com.staccato.comment.domain.Comment;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
@@ -11,9 +12,16 @@ public record CommentCreatedMessage(
         Staccato staccato,
         Comment comment
 ) implements PushMessage {
+    @Override
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(getTitle())
+                .setBody(getBody())
+                .build();
+    }
 
     @Override
-    public Map<String, String> toMap() {
+    public Map<String, String> toData() {
         return Map.of(
                 "type", "COMMENT_CREATED",
                 "staccatoId", String.valueOf(staccato.getId())

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
@@ -23,6 +23,8 @@ public record CommentCreatedMessage(
     @Override
     public Map<String, String> toData() {
         return Map.of(
+                "title", getTitle(),
+                "body", getBody(),
                 "type", "COMMENT_CREATED",
                 "staccatoId", String.valueOf(staccato.getId())
         );

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
@@ -8,10 +8,14 @@ import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 
 public record CommentCreatedMessage(
-        Member commentCreator,
-        Staccato staccato,
-        Comment comment
+        String staccatoId,
+        String commentCreatorName,
+        String commentContent
 ) implements PushMessage {
+    public CommentCreatedMessage(Member commentCreator, Staccato staccato, Comment comment){
+        this(String.valueOf(staccato.getId()), commentCreator.getNickname().getNickname(), comment.getContent());
+    }
+
     @Override
     public Notification toNotification() {
         return Notification.builder()
@@ -26,17 +30,17 @@ public record CommentCreatedMessage(
                 "title", getTitle(),
                 "body", getBody(),
                 "type", "COMMENT_CREATED",
-                "staccatoId", String.valueOf(staccato.getId())
+                "staccatoId", staccatoId
         );
     }
 
     @Override
     public String getTitle() {
-        return String.format("%s님의 코멘트", commentCreator.getNickname().getNickname());
+        return String.format("%s님의 코멘트", commentCreatorName);
     }
 
     @Override
     public String getBody() {
-        return comment.getContent();
+        return commentContent;
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/CommentCreatedMessage.java
@@ -7,40 +7,30 @@ import com.staccato.comment.domain.Comment;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 
-public record CommentCreatedMessage(
-        String staccatoId,
-        String commentCreatorName,
-        String commentContent
-) implements PushMessage {
+public class CommentCreatedMessage extends PushMessage {
+    private final String staccatoId;
+    private final String commenterName;
+    private final String commentContent;
+
     public CommentCreatedMessage(Member commentCreator, Staccato staccato, Comment comment){
-        this(String.valueOf(staccato.getId()), commentCreator.getNickname().getNickname(), comment.getContent());
+        super(MessageType.COMMENT_CREATED);
+        this.commenterName = commentCreator.getNickname().getNickname();
+        this.commentContent = comment.getContent();
+        this.staccatoId = String.valueOf(staccato.getId());
     }
 
     @Override
-    public Notification toNotification() {
-        return Notification.builder()
-                .setTitle(getTitle())
-                .setBody(getBody())
-                .build();
+    protected String getTitle() {
+        return String.format("%s님의 코멘트", commenterName);
     }
 
     @Override
-    public Map<String, String> toData() {
-        return Map.of(
-                "title", getTitle(),
-                "body", getBody(),
-                "type", "COMMENT_CREATED",
-                "staccatoId", staccatoId
-        );
-    }
-
-    @Override
-    public String getTitle() {
-        return String.format("%s님의 코멘트", commentCreatorName);
-    }
-
-    @Override
-    public String getBody() {
+    protected String getBody() {
         return commentContent;
+    }
+
+    @Override
+    protected Map<String, String> getAdditionalData() {
+        return Map.of("staccatoId", staccatoId);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/MessageType.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/MessageType.java
@@ -1,0 +1,14 @@
+package com.staccato.notification.service.dto.message;
+
+public enum MessageType {
+    ACCEPT_INVITATION,
+    RECEIVE_INVITATION,
+    STACCATO_CREATED,
+    COMMENT_CREATED;
+
+    public String type() {
+        return name();
+    }
+}
+
+

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
@@ -1,13 +1,15 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
+import com.google.firebase.messaging.Notification;
 
 public sealed interface PushMessage permits
         AcceptInvitationMessage,
         CommentCreatedMessage,
         ReceiveInvitationMessage,
         StaccatoCreatedMessage {
-    Map<String, String> toMap();
+    Notification toNotification();
+    Map<String, String> toData();
     String getTitle();
     String getBody();
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
@@ -2,7 +2,9 @@ package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
 import com.google.firebase.messaging.Notification;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode
 public abstract class PushMessage {
     private final MessageType messageType;
 

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/PushMessage.java
@@ -3,13 +3,34 @@ package com.staccato.notification.service.dto.message;
 import java.util.Map;
 import com.google.firebase.messaging.Notification;
 
-public sealed interface PushMessage permits
-        AcceptInvitationMessage,
-        CommentCreatedMessage,
-        ReceiveInvitationMessage,
-        StaccatoCreatedMessage {
-    Notification toNotification();
-    Map<String, String> toData();
-    String getTitle();
-    String getBody();
+public abstract class PushMessage {
+    private final MessageType messageType;
+
+    protected PushMessage(MessageType messageType) {
+        this.messageType = messageType;
+    }
+
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(getTitle())
+                .setBody(getBody())
+                .build();
+    }
+
+    public Map<String, String> toData() {
+        var data = new java.util.HashMap<String, String>();
+        data.put("title", getTitle());
+        data.put("body", getBody());
+        data.put("type", messageType.type());
+        data.putAll(getAdditionalData());
+        return data;
+    }
+
+    protected abstract String getTitle();
+
+    protected abstract String getBody();
+
+    protected Map<String, String> getAdditionalData() {
+        return Map.of();
+    }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
@@ -2,6 +2,7 @@ package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
 
+import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
@@ -9,9 +10,16 @@ public record ReceiveInvitationMessage(
         Member inviter,
         Category category
 ) implements PushMessage {
+    @Override
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(getTitle())
+                .setBody(getBody())
+                .build();
+    }
 
     @Override
-    public Map<String, String> toMap() {
+    public Map<String, String> toData() {
         return Map.of(
                 "type", "RECEIVE-INVITATION"
         );

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
@@ -6,39 +6,23 @@ import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
-public record ReceiveInvitationMessage(
-        String inviterName,
-        String categoryTitle
-) implements PushMessage {
-    public ReceiveInvitationMessage(Member inviter, Category category){
-        this(inviter.getNickname().getNickname(), category.getTitle().getTitle());
+public class ReceiveInvitationMessage extends PushMessage {
+    private final String inviterName;
+    private final String categoryTitle;
+
+    public ReceiveInvitationMessage(Member inviter, Category category) {
+        super(MessageType.RECEIVE_INVITATION);
+        this.inviterName = inviter.getNickname().getNickname();
+        this.categoryTitle = category.getTitle().getTitle();
     }
 
     @Override
-    public Notification toNotification() {
-        return Notification.builder()
-                .setTitle(getTitle())
-                .setBody(getBody())
-                .build();
-    }
-
-    @Override
-    public Map<String, String> toData() {
-        return Map.of(
-                "title", getTitle(),
-                "body", getBody(),
-                "type", "RECEIVE_INVITATION"
-        );
-    }
-
-    @Override
-    public String getTitle() {
+    protected String getTitle() {
         return String.format("%s님이 초대를 보냈어요", inviterName);
-
     }
 
     @Override
-    public String getBody() {
+    protected String getBody() {
         return categoryTitle;
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
@@ -1,11 +1,10 @@
 package com.staccato.notification.service.dto.message;
 
-import java.util.Map;
-
-import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 public class ReceiveInvitationMessage extends PushMessage {
     private final String inviterName;
     private final String categoryTitle;

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
@@ -7,9 +7,13 @@ import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 
 public record ReceiveInvitationMessage(
-        Member inviter,
-        Category category
+        String inviterName,
+        String categoryTitle
 ) implements PushMessage {
+    public ReceiveInvitationMessage(Member inviter, Category category){
+        this(inviter.getNickname().getNickname(), category.getTitle().getTitle());
+    }
+
     @Override
     public Notification toNotification() {
         return Notification.builder()
@@ -23,18 +27,18 @@ public record ReceiveInvitationMessage(
         return Map.of(
                 "title", getTitle(),
                 "body", getBody(),
-                "type", "RECEIVE-INVITATION"
+                "type", "RECEIVE_INVITATION"
         );
     }
 
     @Override
     public String getTitle() {
-        return String.format("%s님이 초대를 보냈어요", inviter.getNickname().getNickname());
+        return String.format("%s님이 초대를 보냈어요", inviterName);
 
     }
 
     @Override
     public String getBody() {
-        return category.getTitle().getTitle();
+        return categoryTitle;
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/ReceiveInvitationMessage.java
@@ -21,6 +21,8 @@ public record ReceiveInvitationMessage(
     @Override
     public Map<String, String> toData() {
         return Map.of(
+                "title", getTitle(),
+                "body", getBody(),
                 "type", "RECEIVE-INVITATION"
         );
     }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
@@ -2,6 +2,7 @@ package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
 
+import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
@@ -11,9 +12,16 @@ public record StaccatoCreatedMessage(
         Staccato staccato,
         Category category
 ) implements PushMessage {
+    @Override
+    public Notification toNotification() {
+        return Notification.builder()
+                .setTitle(getTitle())
+                .setBody(getBody())
+                .build();
+    }
 
     @Override
-    public Map<String, String> toMap() {
+    public Map<String, String> toData() {
         return Map.of(
                 "type", "STACCATO_CREATED",
                 "staccatoId", String.valueOf(staccato.getId())

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
@@ -1,17 +1,21 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
-
 import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 
 public record StaccatoCreatedMessage(
-        Member staccatoCreator,
-        Staccato staccato,
-        Category category
+        String staccatoId,
+        String staccatoCreatorName,
+        String categoryTitle
 ) implements PushMessage {
+    public StaccatoCreatedMessage(Member staccatoCreator, Staccato staccato, Category category) {
+        this(String.valueOf(staccato.getId()), staccatoCreator.getNickname().getNickname(), category.getTitle()
+                .getTitle());
+    }
+
     @Override
     public Notification toNotification() {
         return Notification.builder()
@@ -26,7 +30,7 @@ public record StaccatoCreatedMessage(
                 "title", getTitle(),
                 "body", getBody(),
                 "type", "STACCATO_CREATED",
-                "staccatoId", String.valueOf(staccato.getId())
+                "staccatoId", staccatoId
         );
     }
 
@@ -37,6 +41,6 @@ public record StaccatoCreatedMessage(
 
     @Override
     public String getBody() {
-        return String.format("%s님이 %s에 남긴 스타카토를 확인해보세요", staccatoCreator.getNickname().getNickname(), category.getTitle().getTitle());
+        return String.format("%s님이 %s에 남긴 스타카토를 확인해보세요", staccatoCreatorName, categoryTitle);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
@@ -6,41 +6,30 @@ import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 
-public record StaccatoCreatedMessage(
-        String staccatoId,
-        String staccatoCreatorName,
-        String categoryTitle
-) implements PushMessage {
-    public StaccatoCreatedMessage(Member staccatoCreator, Staccato staccato, Category category) {
-        this(String.valueOf(staccato.getId()), staccatoCreator.getNickname().getNickname(), category.getTitle()
-                .getTitle());
+public class StaccatoCreatedMessage extends PushMessage {
+    private final String staccatoId;
+    private final String staccatoCreatorName;
+    private final String categoryTitle;
+
+    public StaccatoCreatedMessage(Member creator, Staccato staccato, Category category) {
+        super(MessageType.STACCATO_CREATED);
+        this.staccatoCreatorName = creator.getNickname().getNickname();
+        this.categoryTitle = category.getTitle().getTitle();
+        this.staccatoId = String.valueOf(staccato.getId());
     }
 
     @Override
-    public Notification toNotification() {
-        return Notification.builder()
-                .setTitle(getTitle())
-                .setBody(getBody())
-                .build();
-    }
-
-    @Override
-    public Map<String, String> toData() {
-        return Map.of(
-                "title", getTitle(),
-                "body", getBody(),
-                "type", "STACCATO_CREATED",
-                "staccatoId", staccatoId
-        );
-    }
-
-    @Override
-    public String getTitle() {
+    protected String getTitle() {
         return "스타카토가 추가됐어요";
     }
 
     @Override
-    public String getBody() {
+    protected String getBody() {
         return String.format("%s님이 %s에 남긴 스타카토를 확인해보세요", staccatoCreatorName, categoryTitle);
+    }
+
+    @Override
+    protected Map<String, String> getAdditionalData() {
+        return Map.of("staccatoId", staccatoId);
     }
 }

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
@@ -23,6 +23,8 @@ public record StaccatoCreatedMessage(
     @Override
     public Map<String, String> toData() {
         return Map.of(
+                "title", getTitle(),
+                "body", getBody(),
                 "type", "STACCATO_CREATED",
                 "staccatoId", String.valueOf(staccato.getId())
         );

--- a/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
+++ b/backend/src/main/java/com/staccato/notification/service/dto/message/StaccatoCreatedMessage.java
@@ -1,11 +1,12 @@
 package com.staccato.notification.service.dto.message;
 
 import java.util.Map;
-import com.google.firebase.messaging.Notification;
 import com.staccato.category.domain.Category;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(callSuper = true)
 public class StaccatoCreatedMessage extends PushMessage {
     private final String staccatoId;
     private final String staccatoCreatorName;

--- a/backend/src/test/java/com/staccato/notification/service/FcmServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/FcmServiceTest.java
@@ -1,19 +1,12 @@
 package com.staccato.notification.service;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
-import static org.mockito.Mockito.when;
-
 import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-
 import com.google.api.core.ApiFuture;
 import com.google.firebase.messaging.BatchResponse;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -24,6 +17,11 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.notification.service.dto.message.PushMessage;
 import com.staccato.notification.service.dto.message.ReceiveInvitationMessage;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class FcmServiceTest {


### PR DESCRIPTION
## ⭐️ Issue Number
- #938

## 🚩 Summary
- Notification과 Data 모두 담도록 FcmService 변경
- toNotification()과 toData()로 캡슐화

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
