### PR TITLE
feat: FCM 알림 클릭 시 화면 이동 #936

### DIFF
--- a/android/Staccato_AN/app/src/main/AndroidManifest.xml
+++ b/android/Staccato_AN/app/src/main/AndroidManifest.xml
@@ -74,7 +74,28 @@
             android:name=".presentation.main.MainActivity"
             android:exported="true"
             android:screenOrientation="portrait"
-            android:windowSoftInputMode="adjustPan" />
+            android:windowSoftInputMode="adjustPan">
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="category"
+                    android:pathPattern="/.*"
+                    android:scheme="staccato" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:host="staccato"
+                    android:pathPattern="/.*"
+                    android:scheme="staccato" />
+            </intent-filter>
+
+        </activity>
 
         <activity
             android:name=".presentation.staccatoupdate.StaccatoUpdateActivity"

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/StaccatoApplication.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/StaccatoApplication.kt
@@ -5,7 +5,7 @@ import android.app.NotificationManager
 import androidx.appcompat.app.AppCompatDelegate
 import com.google.android.libraries.places.api.net.PlacesClient
 import com.on.staccato.data.PlacesClientProvider
-import com.on.staccato.presentation.common.notification.NotificationChannelType
+import com.on.staccato.presentation.common.notification.ChannelType
 import dagger.hilt.android.HiltAndroidApp
 
 @HiltAndroidApp
@@ -19,7 +19,7 @@ class StaccatoApplication : Application() {
 
     private fun registerNotificationChannel() {
         val manager = getSystemService(NotificationManager::class.java)
-        manager.createNotificationChannels(NotificationChannelType.getAllChannels(applicationContext))
+        manager.createNotificationChannels(ChannelType.getAllChannels(applicationContext))
     }
 
     companion object {

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/ChannelType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/ChannelType.kt
@@ -29,21 +29,8 @@ enum class ChannelType(
     ;
 
     companion object {
-        fun getAllChannels(context: Context): List<NotificationChannel> = NotificationChannelType.entries.map { it.toChannel(context) }
+        fun getAllChannels(context: Context): List<NotificationChannel> = ChannelType.entries.map { it.toChannel(context) }
 
-        fun toChannel(
-            context: Context,
-            title: String,
-        ): NotificationChannel =
-            when {
-                title.contains("님이 초대를 보냈어요") -> INVITATION.toChannel(context)
-                title.contains("님이 참여했어요") -> CATEGORY.toChannel(context)
-                title.contains("스타카토가 추가됐어요") -> CATEGORY.toChannel(context)
-                title.contains("님의 코멘트") -> COMMENT.toChannel(context)
-                else -> CATEGORY.toChannel(context)
-            }
-
-        private fun NotificationChannelType.toChannel(context: Context) =
-            NotificationChannel(id, context.getString(nameStringRes), importance)
+        fun ChannelType.toChannel(context: Context) = NotificationChannel(id, context.getString(nameStringRes), importance)
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/ChannelType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/ChannelType.kt
@@ -6,22 +6,22 @@ import android.content.Context
 import androidx.annotation.StringRes
 import com.on.staccato.R
 
-enum class NotificationChannelType(
+enum class ChannelType(
     val id: String,
     @StringRes val nameStringRes: Int,
     val importance: Int,
 ) {
-    Invitation(
+    INVITATION(
         id = "invitation",
         nameStringRes = R.string.channel_name_invitation,
         importance = NotificationManager.IMPORTANCE_HIGH,
     ),
-    Category(
+    CATEGORY(
         id = "category",
         nameStringRes = R.string.channel_name_category,
         importance = NotificationManager.IMPORTANCE_HIGH,
     ),
-    Comment(
+    COMMENT(
         id = "comment",
         nameStringRes = R.string.channel_name_comment,
         importance = NotificationManager.IMPORTANCE_HIGH,
@@ -36,11 +36,11 @@ enum class NotificationChannelType(
             title: String,
         ): NotificationChannel =
             when {
-                title.contains("님이 초대를 보냈어요") -> Invitation.toChannel(context)
-                title.contains("님이 참여했어요") -> Category.toChannel(context)
-                title.contains("스타카토가 추가됐어요") -> Category.toChannel(context)
-                title.contains("님의 코멘트") -> Comment.toChannel(context)
-                else -> Category.toChannel(context)
+                title.contains("님이 초대를 보냈어요") -> INVITATION.toChannel(context)
+                title.contains("님이 참여했어요") -> CATEGORY.toChannel(context)
+                title.contains("스타카토가 추가됐어요") -> CATEGORY.toChannel(context)
+                title.contains("님의 코멘트") -> COMMENT.toChannel(context)
+                else -> CATEGORY.toChannel(context)
             }
 
         private fun NotificationChannelType.toChannel(context: Context) =

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/NotificationType.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/NotificationType.kt
@@ -1,0 +1,13 @@
+package com.on.staccato.presentation.common.notification
+
+enum class NotificationType(val channelType: ChannelType) {
+    ACCEPT_INVITATION(ChannelType.INVITATION),
+    RECEIVE_INVITATION(ChannelType.CATEGORY),
+    STACCATO_CREATED(ChannelType.CATEGORY),
+    COMMENT_CREATED(ChannelType.COMMENT),
+    ;
+
+    companion object {
+        fun from(type: String): NotificationType? = entries.firstOrNull { it.name == type }
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoFirebaseMessagingService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoFirebaseMessagingService.kt
@@ -1,5 +1,7 @@
 package com.on.staccato.presentation.common.notification
 
+import android.content.Intent
+import com.google.firebase.messaging.Constants.MessageNotificationKeys
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.on.staccato.domain.repository.NotificationRepository
@@ -29,6 +31,16 @@ class StaccatoFirebaseMessagingService :
         }
     }
 
+    override fun handleIntent(intent: Intent?) {
+        val bundleWithoutNotification =
+            intent?.extras?.apply {
+                remove(MessageNotificationKeys.ENABLE_NOTIFICATION)
+                remove(ENABLE_NOTIFICATION)
+            }
+        intent?.replaceExtras(bundleWithoutNotification)
+        super.handleIntent(intent)
+    }
+
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
         val title = message.notification?.title
@@ -41,5 +53,9 @@ class StaccatoFirebaseMessagingService :
     override fun onDestroy() {
         _job?.cancel()
         super.onDestroy()
+    }
+
+    companion object {
+        const val ENABLE_NOTIFICATION = "gcm.notification.e"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoFirebaseMessagingService.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoFirebaseMessagingService.kt
@@ -5,6 +5,7 @@ import com.google.firebase.messaging.Constants.MessageNotificationKeys
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.on.staccato.domain.repository.NotificationRepository
+import com.on.staccato.presentation.common.notification.model.StaccatoNotification
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -43,11 +44,12 @@ class StaccatoFirebaseMessagingService :
 
     override fun onMessageReceived(message: RemoteMessage) {
         super.onMessageReceived(message)
-        val title = message.notification?.title
-        val body = message.notification?.body
-        if (title.isNullOrBlank() || body.isNullOrBlank()) return
-
-        staccatoNotificationManager.notify(title = title, body = body)
+        val data = message.data
+        if (data.isEmpty()) return
+        val typeValue = data[KEY_TYPE] ?: return
+        val type = NotificationType.from(typeValue) ?: return
+        val staccatoNotification = StaccatoNotification.from(type, data) ?: return
+        staccatoNotificationManager.notify(staccatoNotification)
     }
 
     override fun onDestroy() {
@@ -56,6 +58,7 @@ class StaccatoFirebaseMessagingService :
     }
 
     companion object {
-        const val ENABLE_NOTIFICATION = "gcm.notification.e"
+        private const val KEY_TYPE = "type"
+        private const val ENABLE_NOTIFICATION = "gcm.notification.e"
     }
 }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotification.kt
@@ -1,0 +1,86 @@
+package com.on.staccato.presentation.common.notification
+
+import com.on.staccato.presentation.common.notification.NotificationType.ACCEPT_INVITATION
+import com.on.staccato.presentation.common.notification.NotificationType.COMMENT_CREATED
+import com.on.staccato.presentation.common.notification.NotificationType.RECEIVE_INVITATION
+import com.on.staccato.presentation.common.notification.NotificationType.STACCATO_CREATED
+
+sealed interface StaccatoNotification {
+    val title: String
+    val body: String
+    val channelType: ChannelType
+
+    data class ReceiveInvitation(
+        override val channelType: ChannelType,
+        override val title: String,
+        override val body: String,
+    ) : StaccatoNotification
+
+    data class AcceptInvitation(
+        override val channelType: ChannelType,
+        override val title: String,
+        override val body: String,
+        val categoryId: Long,
+    ) : StaccatoNotification
+
+    data class StaccatoCreated(
+        override val channelType: ChannelType,
+        override val title: String,
+        override val body: String,
+        val staccatoId: Long,
+    ) : StaccatoNotification
+
+    data class CommentCreated(
+        override val channelType: ChannelType,
+        override val title: String,
+        override val body: String,
+        val staccatoId: Long,
+    ) : StaccatoNotification
+
+    companion object {
+        private const val KEY_TITLE = "title"
+        private const val KEY_BODY = "body"
+        private const val KEY_CATEGORY_ID = "categoryId"
+        private const val KEY_STACCATO_ID = "staccatoId"
+
+        fun from(
+            type: NotificationType,
+            data: Map<String, String>,
+        ): StaccatoNotification? {
+            val title = data[KEY_TITLE] ?: return null
+            val body = data[KEY_BODY] ?: return null
+            return when (type) {
+                RECEIVE_INVITATION ->
+                    ReceiveInvitation(
+                        channelType = type.channelType,
+                        title = title,
+                        body = body,
+                    )
+
+                ACCEPT_INVITATION ->
+                    AcceptInvitation(
+                        channelType = type.channelType,
+                        title = title,
+                        body = body,
+                        categoryId = data[KEY_CATEGORY_ID]?.toLongOrNull() ?: return null,
+                    )
+
+                COMMENT_CREATED ->
+                    CommentCreated(
+                        channelType = type.channelType,
+                        title = title,
+                        body = body,
+                        staccatoId = data[KEY_STACCATO_ID]?.toLongOrNull() ?: return null,
+                    )
+
+                STACCATO_CREATED ->
+                    StaccatoCreated(
+                        channelType = type.channelType,
+                        title = title,
+                        body = body,
+                        staccatoId = data[KEY_STACCATO_ID]?.toLongOrNull() ?: return null,
+                    )
+            }
+        }
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
@@ -26,7 +26,7 @@ class StaccatoNotificationManager
         ) {
             if (permissionLauncher.isNotificationUnavailable()) return
 
-            val channel = NotificationChannelType.toChannel(context, title)
+            val channel = ChannelType.toChannel(context, title)
             val notification = createNotification(channel, title, body)
             val notificationId = System.currentTimeMillis().toInt()
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
@@ -2,15 +2,12 @@ package com.on.staccato.presentation.common.notification
 
 import android.annotation.SuppressLint
 import android.app.NotificationChannel
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
-import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.on.staccato.R
 import com.on.staccato.presentation.common.notification.ChannelType.Companion.toChannel
-import com.on.staccato.presentation.login.LoginActivity
+import com.on.staccato.presentation.common.notification.model.StaccatoNotification
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
@@ -23,35 +20,21 @@ class StaccatoNotificationManager
         @SuppressLint("MissingPermission")
         fun notify(staccatoNotification: StaccatoNotification) {
             if (permissionLauncher.isNotificationUnavailable()) return
-
             val notificationId = System.currentTimeMillis().toInt()
             val channel = staccatoNotification.channelType.toChannel(context)
-            val notification = createNotification(channel, staccatoNotification.title, staccatoNotification.body)
+            val notification = createNotification(staccatoNotification, channel)
             NotificationManagerCompat.from(context).notify(notificationId, notification)
         }
 
         private fun createNotification(
+            notification: StaccatoNotification,
             channel: NotificationChannel,
-            title: String,
-            body: String,
         ) = NotificationCompat.Builder(context, channel.id)
             .setSmallIcon(R.mipmap.ic_launcher_round)
-            .setContentTitle(title)
-            .setContentText(body)
-            .setContentIntent(createActivityPendingIntent())
+            .setContentTitle(notification.title)
+            .setContentText(notification.body)
+            .setContentIntent(notification.createIntent(context))
             .setPriority(NotificationCompat.PRIORITY_HIGH)
             .setAutoCancel(true)
             .build()
-
-        private fun createActivityPendingIntent(): PendingIntent {
-            val intent = Intent(context, LoginActivity::class.java)
-            return PendingIntent.getActivity(context, 0, intent, pendingIntentFlags)
-        }
-
-        private val pendingIntentFlags =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            } else {
-                PendingIntent.FLAG_UPDATE_CURRENT
-            }
     }

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/StaccatoNotificationManager.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.on.staccato.R
+import com.on.staccato.presentation.common.notification.ChannelType.Companion.toChannel
 import com.on.staccato.presentation.login.LoginActivity
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -20,16 +21,12 @@ class StaccatoNotificationManager
         private val permissionLauncher: NotificationPermissionManager,
     ) {
         @SuppressLint("MissingPermission")
-        fun notify(
-            title: String,
-            body: String,
-        ) {
+        fun notify(staccatoNotification: StaccatoNotification) {
             if (permissionLauncher.isNotificationUnavailable()) return
 
-            val channel = ChannelType.toChannel(context, title)
-            val notification = createNotification(channel, title, body)
             val notificationId = System.currentTimeMillis().toInt()
-
+            val channel = staccatoNotification.channelType.toChannel(context)
+            val notification = createNotification(channel, staccatoNotification.title, staccatoNotification.body)
             NotificationManagerCompat.from(context).notify(notificationId, notification)
         }
 

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/AcceptInvitationNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/AcceptInvitationNotification.kt
@@ -1,0 +1,28 @@
+package com.on.staccato.presentation.common.notification.model
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import com.on.staccato.presentation.common.notification.ChannelType
+import com.on.staccato.presentation.common.notification.model.StaccatoNotification.Companion.pendingIntentFlags
+
+data class AcceptInvitationNotification(
+    override val channelType: ChannelType,
+    override val title: String,
+    override val body: String,
+    val categoryId: Long,
+) : StaccatoNotification {
+    override fun createIntent(context: Context): PendingIntent {
+        val deepLinkUri = "$CATEGORY_URI$categoryId".toUri()
+        val intent =
+            Intent(Intent.ACTION_VIEW, deepLinkUri).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+        return PendingIntent.getActivity(context, 0, intent, pendingIntentFlags)
+    }
+
+    companion object {
+        private const val CATEGORY_URI = "staccato://category/"
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/CommentCreatedNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/CommentCreatedNotification.kt
@@ -1,0 +1,30 @@
+package com.on.staccato.presentation.common.notification.model
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import com.on.staccato.presentation.common.notification.ChannelType
+import com.on.staccato.presentation.common.notification.model.StaccatoNotification.Companion.pendingIntentFlags
+
+data class CommentCreatedNotification(
+    override val channelType: ChannelType,
+    override val title: String,
+    override val body: String,
+    val staccatoId: Long,
+) : StaccatoNotification {
+    override fun createIntent(context: Context): PendingIntent {
+        val intent =
+            Intent(
+                Intent.ACTION_VIEW,
+                "$STACCATO_URI$staccatoId".toUri(),
+            ).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+        return PendingIntent.getActivity(context, 0, intent, pendingIntentFlags)
+    }
+
+    companion object {
+        private const val STACCATO_URI = "staccato://staccato/"
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/ReceiveInvitationNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/ReceiveInvitationNotification.kt
@@ -1,0 +1,30 @@
+package com.on.staccato.presentation.common.notification.model
+
+import android.app.PendingIntent
+import android.app.TaskStackBuilder
+import android.content.Context
+import android.content.Intent
+import com.on.staccato.presentation.common.notification.ChannelType
+import com.on.staccato.presentation.invitation.InvitationManagementActivity
+import com.on.staccato.presentation.main.MainActivity
+import com.on.staccato.presentation.mypage.MyPageActivity
+
+data class ReceiveInvitationNotification(
+    override val channelType: ChannelType,
+    override val title: String,
+    override val body: String,
+) : StaccatoNotification {
+    override fun createIntent(context: Context): PendingIntent {
+        val mainIntent = Intent(context, MainActivity::class.java)
+        val myPageIntent = Intent(context, MyPageActivity::class.java)
+        val invitationIntent = Intent(context, InvitationManagementActivity::class.java)
+
+        val pendingIntent =
+            TaskStackBuilder.create(context).apply {
+                addNextIntent(mainIntent)
+                addNextIntent(myPageIntent)
+                addNextIntent(invitationIntent)
+            }.getPendingIntent(0, StaccatoNotification.pendingIntentFlags)
+        return pendingIntent
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/StaccatoCreatedNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/StaccatoCreatedNotification.kt
@@ -1,0 +1,28 @@
+package com.on.staccato.presentation.common.notification.model
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.net.toUri
+import com.on.staccato.presentation.common.notification.ChannelType
+import com.on.staccato.presentation.common.notification.model.StaccatoNotification.Companion.pendingIntentFlags
+
+data class StaccatoCreatedNotification(
+    override val channelType: ChannelType,
+    override val title: String,
+    override val body: String,
+    val staccatoId: Long,
+) : StaccatoNotification {
+    override fun createIntent(context: Context): PendingIntent {
+        val deepLinkUri = "$STACCATO_URI$staccatoId".toUri()
+        val intent =
+            Intent(Intent.ACTION_VIEW, deepLinkUri).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+        return PendingIntent.getActivity(context, 0, intent, pendingIntentFlags)
+    }
+
+    companion object {
+        private const val STACCATO_URI = "staccato://staccato/"
+    }
+}

--- a/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/StaccatoNotification.kt
+++ b/android/Staccato_AN/app/src/main/java/com/on/staccato/presentation/common/notification/model/StaccatoNotification.kt
@@ -1,5 +1,10 @@
-package com.on.staccato.presentation.common.notification
+package com.on.staccato.presentation.common.notification.model
 
+import android.app.PendingIntent
+import android.content.Context
+import android.os.Build
+import com.on.staccato.presentation.common.notification.ChannelType
+import com.on.staccato.presentation.common.notification.NotificationType
 import com.on.staccato.presentation.common.notification.NotificationType.ACCEPT_INVITATION
 import com.on.staccato.presentation.common.notification.NotificationType.COMMENT_CREATED
 import com.on.staccato.presentation.common.notification.NotificationType.RECEIVE_INVITATION
@@ -10,38 +15,19 @@ sealed interface StaccatoNotification {
     val body: String
     val channelType: ChannelType
 
-    data class ReceiveInvitation(
-        override val channelType: ChannelType,
-        override val title: String,
-        override val body: String,
-    ) : StaccatoNotification
-
-    data class AcceptInvitation(
-        override val channelType: ChannelType,
-        override val title: String,
-        override val body: String,
-        val categoryId: Long,
-    ) : StaccatoNotification
-
-    data class StaccatoCreated(
-        override val channelType: ChannelType,
-        override val title: String,
-        override val body: String,
-        val staccatoId: Long,
-    ) : StaccatoNotification
-
-    data class CommentCreated(
-        override val channelType: ChannelType,
-        override val title: String,
-        override val body: String,
-        val staccatoId: Long,
-    ) : StaccatoNotification
+    fun createIntent(context: Context): PendingIntent
 
     companion object {
         private const val KEY_TITLE = "title"
         private const val KEY_BODY = "body"
         private const val KEY_CATEGORY_ID = "categoryId"
         private const val KEY_STACCATO_ID = "staccatoId"
+        val pendingIntentFlags =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
 
         fun from(
             type: NotificationType,
@@ -51,14 +37,14 @@ sealed interface StaccatoNotification {
             val body = data[KEY_BODY] ?: return null
             return when (type) {
                 RECEIVE_INVITATION ->
-                    ReceiveInvitation(
+                    ReceiveInvitationNotification(
                         channelType = type.channelType,
                         title = title,
                         body = body,
                     )
 
                 ACCEPT_INVITATION ->
-                    AcceptInvitation(
+                    AcceptInvitationNotification(
                         channelType = type.channelType,
                         title = title,
                         body = body,
@@ -66,7 +52,7 @@ sealed interface StaccatoNotification {
                     )
 
                 COMMENT_CREATED ->
-                    CommentCreated(
+                    CommentCreatedNotification(
                         channelType = type.channelType,
                         title = title,
                         body = body,
@@ -74,7 +60,7 @@ sealed interface StaccatoNotification {
                     )
 
                 STACCATO_CREATED ->
-                    StaccatoCreated(
+                    StaccatoCreatedNotification(
                         channelType = type.channelType,
                         title = title,
                         body = body,

--- a/android/Staccato_AN/app/src/main/res/navigation/bottom_navigation_graph.xml
+++ b/android/Staccato_AN/app/src/main/res/navigation/bottom_navigation_graph.xml
@@ -36,6 +36,14 @@
         android:label="fragment_category"
         tools:layout="@layout/fragment_category">
 
+        <argument
+            android:name="categoryId"
+            app:argType="long"
+            android:defaultValue="0L" />
+
+        <deepLink
+            app:uri="staccato://category/{categoryId}" />
+
         <action
             android:id="@+id/action_categoryFragment_to_staccatoFragment"
             app:destination="@id/staccatoFragment"
@@ -50,6 +58,16 @@
         android:id="@+id/staccatoFragment"
         android:name="com.on.staccato.presentation.staccato.StaccatoFragment"
         android:label="fragment_staccato"
-        tools:layout="@layout/fragment_staccato" />
+        tools:layout="@layout/fragment_staccato">
+
+        <argument
+            android:name="staccatoId"
+            app:argType="long"
+            android:defaultValue="0L" />
+
+        <deepLink
+            app:uri="staccato://staccato/{staccatoId}" />
+
+    </fragment>
 
 </navigation>

--- a/android/Staccato_AN/app/src/main/res/values/strings.xml
+++ b/android/Staccato_AN/app/src/main/res/values/strings.xml
@@ -46,7 +46,7 @@
     <string name="notification_permission_rationale_bullet">▪ 새로운 코멘트가 달렸을 때\n▪ 누군가 나를 카테고리에 초대했을 때\n▪ 공유 카테고리에 새로운 참여자가 생겼을 때\n▪ 공유 카테고리에 새로운 스타카토가 올라왔을 때</string>
     <string name="notification_permission_denial">알림 권한을 거부 하셨습니다.</string>
     <string name="channel_name_invitation">초대 알림</string>
-    <string name="channel_name_category">카테고리 알림</string>
+    <string name="channel_name_category">공동 카테고리 알림</string>
     <string name="channel_name_comment">댓글 알림</string>
 
     // MainActivity


### PR DESCRIPTION
## ⭐️ Issue Number
- #936 

## 🚩 Summary

| 초대 알림 (초대 관리 화면으로 이동) | 참여자 알림 (카테고리로 이동) |
| :---: | :---: | 
| <video src="https://github.com/user-attachments/assets/7a39298f-7844-4f7a-818e-1e7d1b8cf0bb"/> | <video src="https://github.com/user-attachments/assets/1ff5aecc-27f2-401e-a03a-687847330e64"/> |
| **새로운 스타카토 알림** (스타카토로 이동) | **새로운 댓글 알림** (스타카토로 이동) |
<video src="https://github.com/user-attachments/assets/28e53397-4224-4ef6-9300-cf997259cb8d"/> | <video src="https://github.com/user-attachments/assets/d7d44c76-e628-4b0a-9d96-cd872526af70"/>


## 🛠️ Technical Concerns
작성 중~!

## 📋 To Do
스타카토 화면으로 이동하는 경우, 해당 스타카토의 위치를 보여주다가 몇초 뒤 현위치로 이동합니다..😢
이 부분은 다른 PR에서 고쳐야 할 것 같아요!