### PR TITLE
feat: fcmToken 값이 동일하면 최신 deviceId 값으로 업데이트 #972

### DIFF
--- a/backend/src/main/java/com/staccato/notification/domain/NotificationToken.java
+++ b/backend/src/main/java/com/staccato/notification/domain/NotificationToken.java
@@ -12,8 +12,10 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+
 import com.staccato.config.domain.BaseEntity;
 import com.staccato.member.domain.Member;
+
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -56,5 +58,9 @@ public class NotificationToken extends BaseEntity {
 
     public void updateToken(String token) {
         this.token = token;
+    }
+
+    public void updateDeviceId(String deviceId) {
+        this.deviceId = deviceId;
     }
 }

--- a/backend/src/main/java/com/staccato/notification/repository/NotificationTokenRepository.java
+++ b/backend/src/main/java/com/staccato/notification/repository/NotificationTokenRepository.java
@@ -2,7 +2,9 @@ package com.staccato.notification.repository;
 
 import java.util.List;
 import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import com.staccato.member.domain.Member;
 import com.staccato.notification.domain.DeviceType;
 import com.staccato.notification.domain.NotificationToken;
@@ -14,4 +16,6 @@ public interface NotificationTokenRepository extends JpaRepository<NotificationT
     List<NotificationToken> findByMemberIn(List<Member> members);
 
     void deleteAllByToken(String token);
+
+    Optional<NotificationToken> findByToken(String token);
 }

--- a/backend/src/main/java/com/staccato/notification/service/NotificationService.java
+++ b/backend/src/main/java/com/staccato/notification/service/NotificationService.java
@@ -50,8 +50,12 @@ public class NotificationService {
     }
 
     private void createNotificationToken(Member member, NotificationTokenRequest request) {
-        NotificationToken notificationToken = new NotificationToken(request.token(), member, request.toDeviceType(), request.deviceId());
-        notificationTokenRepository.save(notificationToken);
+        Optional<NotificationToken> notificationToken = notificationTokenRepository.findByToken(request.token());
+        notificationToken.ifPresentOrElse(
+                existingToken -> existingToken.updateDeviceId(request.deviceId()),
+                () -> notificationTokenRepository.save(
+                        new NotificationToken(request.token(), member, request.toDeviceType(), request.deviceId()))
+        );
     }
 
     public void sendInvitationAlert(Member inviter, Category category, List<Member> receivers) {


### PR DESCRIPTION
## ⭐️ Issue Number
- #972 

## 🚩 Summary

- fcmToken 값이 동일하다면, deviceId를 최신 값으로 업데이트

## 🛠️ Technical Concerns

* token은 TEXT 타입이기 때문에 DB에서 유니크 제약조건을 생성할 수 없습니다.
* 따라서 로직으로만 유일성을 챙겼는데, 이때 `findByToken` 메서드가 정말정말 만약에 두 개 이상의 데이터를 가져와서 에러가 발생되는 상황을 방지하도록 구현해야 하는지 잘 모르겠습니다. (지금은 데이터를 반드시 하나만 가져올 것이라 기대하고 `Optional<>`로 반환형을 설정해 놓았습니다.)
* DB에서 token 값이 동일한 데이터는 직접 운영 DB에 들어가 삭제 쿼리를 통해 삭제 완료했고, 코드가 잘 동작하기만 한다면 같은 토큰 값에 대해서 DB에 데이터가 두 개 이상 존재할 일이 없으니, 따로 처리하는 로직을 작성하지 않았습니다.

## 🙂 To Reviewer


## 📋 To Do
