### PR TITLE
feat: 카테고리 내 스타카토 목록 조회 시 페이지네이션 및 API 분리 #966

### DIFF
--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -2,11 +2,9 @@ package com.staccato.category.controller;
 
 import java.net.URI;
 import java.time.LocalDate;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,9 +17,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
 import com.staccato.category.controller.docs.CategoryControllerDocs;
 import com.staccato.category.service.CategoryService;
+import com.staccato.category.service.StaccatoCursor;
 import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
@@ -37,7 +35,6 @@ import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -94,6 +94,17 @@ public class CategoryController implements CategoryControllerDocs {
         return ResponseEntity.ok().body(categoryStaccatoLocationResponses);
     }
 
+    @GetMapping("/{categoryId}/staccatos")
+    public ResponseEntity<CategoryStaccatoResponses> readStaccatosByCategory(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
+            @Validated @ModelAttribute CategoryStaccatoPaginationRequest categoryStaccatoPaginationRequest
+    ) {
+        CategoryStaccatoResponses categoryStaccatoResponses = categoryService.readStaccatosByCategory(
+                member, categoryId, categoryStaccatoPaginationRequest);
+        return ResponseEntity.ok().body(categoryStaccatoResponses);
+    }
+
     @PutMapping("/{categoryId}")
     public ResponseEntity<Void> updateCategory(
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -98,10 +98,14 @@ public class CategoryController implements CategoryControllerDocs {
     public ResponseEntity<CategoryStaccatoResponses> readStaccatosByCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
-            @Validated @ModelAttribute CategoryStaccatoPaginationRequest categoryStaccatoPaginationRequest
+            @RequestParam(required = false) String cursor,
+            @RequestParam(defaultValue = "10")
+            @Min(value = 1, message = "limit는 1 이상, 100 이하여야 합니다.")
+            @Max(value = 100, message = "limit는 1 이상, 100 이하여야 합니다.")
+            int limit
     ) {
         CategoryStaccatoResponses categoryStaccatoResponses = categoryService.readStaccatosByCategory(
-                member, categoryId, categoryStaccatoPaginationRequest);
+                member, categoryId, cursor, limit);
         return ResponseEntity.ok().body(categoryStaccatoResponses);
     }
 

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -84,7 +84,7 @@ public class CategoryController implements CategoryControllerDocs {
     }
 
     @GetMapping("/{categoryId}/staccatos/locations")
-    public ResponseEntity<CategoryStaccatoLocationResponses> readAllStaccatoLocationByCategory(
+    public ResponseEntity<CategoryStaccatoLocationResponses> readStaccatoLocationsByCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.time.LocalDate;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,7 @@ import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
+import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
 import com.staccato.config.auth.LoginMember;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.member.domain.Member;
@@ -79,7 +81,7 @@ public class CategoryController implements CategoryControllerDocs {
     public ResponseEntity<CategoryDetailResponse> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryId, member);
         return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponse());
     }
 
@@ -89,7 +91,7 @@ public class CategoryController implements CategoryControllerDocs {
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest
     ) {
-        CategoryStaccatoLocationResponses categoryStaccatoLocationResponses = categoryService.readAllLocationStaccatoByCategory(
+        CategoryStaccatoLocationResponses categoryStaccatoLocationResponses = categoryService.readStaccatoLocationsByCategory(
                 member, categoryId, categoryStaccatoLocationRangeRequest);
         return ResponseEntity.ok().body(categoryStaccatoLocationResponses);
     }

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -89,7 +89,7 @@ public class CategoryController implements CategoryControllerDocs {
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest
     ) {
-        CategoryStaccatoLocationResponses categoryStaccatoLocationResponses = categoryService.readAllStaccatoByCategory(
+        CategoryStaccatoLocationResponses categoryStaccatoLocationResponses = categoryService.readAllLocationStaccatoByCategory(
                 member, categoryId, categoryStaccatoLocationRangeRequest);
         return ResponseEntity.ok().body(categoryStaccatoLocationResponses);
     }

--- a/backend/src/main/java/com/staccato/category/controller/CategoryController.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryController.java
@@ -83,8 +83,8 @@ public class CategoryController implements CategoryControllerDocs {
         return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponse());
     }
 
-    @GetMapping("/{categoryId}/staccatos")
-    public ResponseEntity<CategoryStaccatoLocationResponses> readAllStaccatoByCategory(
+    @GetMapping("/{categoryId}/staccatos/locations")
+    public ResponseEntity<CategoryStaccatoLocationResponses> readAllStaccatoLocationByCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV2.java
@@ -59,7 +59,7 @@ public class CategoryControllerV2 implements CategoryControllerV2Docs {
     public ResponseEntity<CategoryDetailResponseV2> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryId, member);
         return ResponseEntity.ok(categoryDetailResponse.toCategoryDetailResponseV2());
     }
 

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV3.java
@@ -46,7 +46,7 @@ public class CategoryControllerV3 implements CategoryControllerV3Docs {
     public ResponseEntity<CategoryDetailResponseV3> readCategory(
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryId, member);
         return ResponseEntity.ok(categoryDetailResponse);
     }
 

--- a/backend/src/main/java/com/staccato/category/controller/CategoryControllerV4.java
+++ b/backend/src/main/java/com/staccato/category/controller/CategoryControllerV4.java
@@ -1,0 +1,33 @@
+package com.staccato.category.controller;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.staccato.category.controller.docs.CategoryControllerV4Docs;
+import com.staccato.category.service.CategoryService;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV4;
+import com.staccato.config.auth.LoginMember;
+import com.staccato.config.log.annotation.Trace;
+import com.staccato.member.domain.Member;
+import lombok.RequiredArgsConstructor;
+
+@Trace
+@Validated
+@RestController
+@RequestMapping("/v4/categories")
+@RequiredArgsConstructor
+public class CategoryControllerV4 implements CategoryControllerV4Docs {
+    private final CategoryService categoryService;
+
+    @GetMapping("/{categoryId}")
+    public ResponseEntity<CategoryDetailResponseV4> readCategory(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId) {
+        CategoryDetailResponseV4 categoryDetailResponse = categoryService.readCategoryById(categoryId, member);
+        return ResponseEntity.ok(categoryDetailResponse);
+    }
+}

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
@@ -9,7 +9,6 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
-
 import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
@@ -37,17 +36,17 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 생성 성공", responseCode = "201"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 필수 값(카테고리 제목)이 누락되었을 때
-                                        
+                    
                     (2) 날짜 형식(yyyy-MM-dd)이 잘못되었을 때
-                                        
+                    
                     (3) 제목이 공백 포함 30자를 초과했을 때
-                                        
+                    
                     (4) 내용이 공백 포함 500자를 초과했을 때
-                                        
+                    
                     (5) 기간 설정이 잘못되었을 때 (시작 날짜와 끝날짜 중 하나만 설정할 수 없음)
-                                        
+                    
                     (6) 이미 존재하는 카테고리 이름일 때
                     """,
                     responseCode = "400")
@@ -68,9 +67,9 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 목록 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 입력받은 특정 날짜가 유효하지 않을 때
-                                        
+                    
                     (2) 입력받은 개인 카테고리 여부가 유효하지 않을 때
                     """, responseCode = "400")
     })
@@ -89,9 +88,9 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 존재하지 않는 카테고리을 조회하려고 했을 때
-                                        
+                    
                     (2) Path Variable 형식이 잘못되었을 때
                     """,
                     responseCode = "400")
@@ -105,9 +104,9 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 내 스타카토 위치 목록 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 존재하지 않는 카테고리을 조회하려고 했을 때
-                                        
+                    
                     (2) Path Variable 형식이 잘못되었을 때
                     
                     (3) 위도는 -90.0 이상 90.0 이하, 경도는 -180.0 이상 180.0 이하여야 함
@@ -126,9 +125,9 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 존재하지 않는 카테고리을 조회하려고 했을 때
-                                        
+                    
                     (2) Path Variable 형식이 잘못되었을 때
                     """,
                     responseCode = "400")
@@ -136,7 +135,10 @@ public interface CategoryControllerDocs {
     ResponseEntity<CategoryStaccatoResponses> readStaccatosByCategory(
             @Parameter(hidden = true) Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
-            @Parameter(description = "다음 페이지를 위한 커서, 요청 시 주어진 값이 없다면 첫 페이지를 조회합니다.", example = SwaggerExamples.PAGINATION_CURSOR) String cursor,
+            @Parameter(description = """
+                    다음 페이지를 위한 커서, 요청 시 주어진 값이 없다면 첫 페이지를 조회합니다.
+                    커서는 구분자(|)를 기준으로 Base64로 인코딩하여 `id|visitedAt|createdAt`순으로 값을 구성합니다.
+                    """, example = SwaggerExamples.PAGINATION_CURSOR) String cursor,
             @Parameter(description = "조회할 데이터 수(기본: 10, 최소: 1, 최대: 100)", example = SwaggerExamples.PAGINATION_LIMIT)
             @Min(value = 1, message = "limit는 1 이상, 100 이하여야 합니다.")
             @Max(value = 100, message = "limit는 1 이상, 100 이하여야 합니다.")
@@ -148,21 +150,21 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 수정 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 필수 값(카테고리 제목)이 누락되었을 때
-                                        
+                    
                     (2) 날짜 형식(yyyy-MM-dd)이 잘못되었을 때
-                                        
+                    
                     (3) 제목이 공백 포함 30자를 초과했을 때
-                                        
+                    
                     (4) 내용이 공백 포함 500자를 초과했을 때
-                                        
+                    
                     (5) 기간 설정이 잘못되었을 때
-                                        
+                    
                     (6) 변경하려는 카테고리 기간이 이미 존재하는 스타카토를 포함하지 않을 때
-                                        
+                    
                     (7) 수정하려는 카테고리이 존재하지 않을 때
-                                        
+                    
                     (8) Path Variable 형식이 잘못되었을 때
                     """,
                     responseCode = "400")
@@ -177,13 +179,13 @@ public interface CategoryControllerDocs {
             @ApiResponse(description = "카테고리 색상 수정 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
-                                        
+                    
                     (1) 필수 값(카테고리 색상)이 누락되었을 때
-                                        
+                    
                     (2) 색상 설정이 잘못되었을 때
-                                        
+                    
                     (3) 수정하려는 카테고리이 존재하지 않을 때
-                                        
+                    
                     (4) Path Variable 형식이 잘못되었을 때
                     """,
                     responseCode = "400")

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
@@ -4,15 +4,23 @@ import java.time.LocalDate;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
+import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
+import com.staccato.category.service.dto.request.CategoryStaccatoPaginationRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponses;
+import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
+import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
+import com.staccato.config.auth.LoginMember;
 import com.staccato.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -90,6 +98,26 @@ public interface CategoryControllerDocs {
     ResponseEntity<CategoryDetailResponse> readCategory(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "카테고리 ID", example = "1") @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId);
+
+    @Operation(summary = "카테고리 내 스타카토 위치 목록 조회", description = "사용자의 카테고리 내 스타카토 위치 목록을 조회합니다. 위경도 기준 범위 기반 조회를 제공합니다")
+    @ApiResponses(value = {
+            @ApiResponse(description = "카테고리 내 스타카토 위치 목록 조회 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                                        
+                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                                        
+                    (2) Path Variable 형식이 잘못되었을 때
+                    
+                    (3) 위도는 -90.0 이상 90.0 이하, 경도는 -180.0 이상 180.0 이하여야 함
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<CategoryStaccatoLocationResponses> readStaccatoLocationsByCategory(
+            @LoginMember Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
+            @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest
+    );
 
     @Operation(summary = "카테고리 수정", deprecated = true, description = "카테고리 정보(썸네일, 제목, 내용, 기간)를 수정합니다.")
     @ApiResponses(value = {

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
@@ -137,7 +137,7 @@ public interface CategoryControllerDocs {
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Parameter(description = """
                     다음 페이지를 위한 커서, 요청 시 주어진 값이 없다면 첫 페이지를 조회합니다.
-                    커서는 구분자(|)를 기준으로 Base64로 인코딩하여 `id|visitedAt|createdAt`순으로 값을 구성합니다.
+                    커서는 구분자(|)를 기준으로 Base64로 인코딩하여 `id|visitedAt`순으로 값을 구성합니다.
                     """, example = SwaggerExamples.PAGINATION_CURSOR) String cursor,
             @Parameter(description = "조회할 데이터 수(기본: 10, 최소: 1, 최대: 100)", example = SwaggerExamples.PAGINATION_LIMIT)
             @Min(value = 1, message = "limit는 1 이상, 100 이하여야 합니다.")

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
@@ -83,13 +83,13 @@ public interface CategoryControllerDocs {
             boolean isPrivate
     );
 
-    @Operation(summary = "카테고리 조회", deprecated = true, description = "사용자의 카테고리을 조회합니다.")
+    @Operation(summary = "카테고리 조회", deprecated = true, description = "사용자의 카테고리를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
                     
-                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    (1) 존재하지 않는 카테고리를 조회하려고 했을 때
                     
                     (2) Path Variable 형식이 잘못되었을 때
                     """,
@@ -109,7 +109,7 @@ public interface CategoryControllerDocs {
                     
                     (2) Path Variable 형식이 잘못되었을 때
                     
-                    (3) 위도는 -90.0 이상 90.0 이하, 경도는 -180.0 이상 180.0 이하여야 함
+                    (3) 위도 또는 경도 값이 유효한 범위를 벗어났을 때 (위도: -90.0 이상 90.0 이하, 경도: -180.0 이상 180.0 이하)
                     """,
                     responseCode = "400")
     })
@@ -195,7 +195,7 @@ public interface CategoryControllerDocs {
             @Parameter(required = true) @Valid CategoryColorRequest categoryColorRequest,
             @Parameter(hidden = true) Member member);
 
-    @Operation(summary = "카테고리 삭제", description = "사용자의 카테고리을 삭제합니다.")
+    @Operation(summary = "카테고리 삭제", description = "사용자의 카테고리를 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "카테고리 삭제 성공", responseCode = "200"),
             @ApiResponse(description = "Path Variable 형식이 잘못되었을 때 발생", responseCode = "400")

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerDocs.java
@@ -2,6 +2,7 @@ package com.staccato.category.controller.docs;
 
 import java.time.LocalDate;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -13,7 +14,6 @@ import com.staccato.category.service.dto.request.CategoryColorRequest;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
-import com.staccato.category.service.dto.request.CategoryStaccatoPaginationRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponse;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
@@ -21,6 +21,7 @@ import com.staccato.category.service.dto.response.CategoryResponses;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
 import com.staccato.config.auth.LoginMember;
+import com.staccato.config.swagger.SwaggerExamples;
 import com.staccato.member.domain.Member;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -117,6 +118,29 @@ public interface CategoryControllerDocs {
             @LoginMember Member member,
             @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
             @Validated @ModelAttribute CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest
+    );
+
+    @Operation(summary = "카테고리 내 스타카토 목록 조회", description = "사용자의 카테고리 내 스타카토 목록을 조회합니다.")
+    @ApiResponse(description = "스타카토 목록 조회 성공", responseCode = "200")
+    @ApiResponses(value = {
+            @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                                        
+                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                                        
+                    (2) Path Variable 형식이 잘못되었을 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<CategoryStaccatoResponses> readStaccatosByCategory(
+            @Parameter(hidden = true) Member member,
+            @PathVariable @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId,
+            @Parameter(description = "다음 페이지를 위한 커서, 요청 시 주어진 값이 없다면 첫 페이지를 조회합니다.", example = SwaggerExamples.PAGINATION_CURSOR) String cursor,
+            @Parameter(description = "조회할 데이터 수(기본: 10, 최소: 1, 최대: 100)", example = SwaggerExamples.PAGINATION_LIMIT)
+            @Min(value = 1, message = "limit는 1 이상, 100 이하여야 합니다.")
+            @Max(value = 100, message = "limit는 1 이상, 100 이하여야 합니다.")
+            int limit
     );
 
     @Operation(summary = "카테고리 수정", deprecated = true, description = "카테고리 정보(썸네일, 제목, 내용, 기간)를 수정합니다.")

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV2Docs.java
@@ -52,13 +52,13 @@ public interface CategoryControllerV2Docs {
             @Parameter(description = "정렬 기준은 생략하거나 유효하지 않은 값에 대해서는 최근 수정 순(UPDATED)이 기본 정렬로 적용됩니다. 필터링 조건은 생략하거나 유효하지 않은 값이 들어오면 적용되지 않습니다.") CategoryReadRequest categoryReadRequest
     );
 
-    @Operation(summary = "카테고리 조회", deprecated = true, description = "사용자의 카테고리을 조회합니다.")
+    @Operation(summary = "카테고리 조회", deprecated = true, description = "사용자의 카테고리를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
                                         
-                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    (1) 존재하지 않는 카테고리를 조회하려고 했을 때
                                         
                     (2) Path Variable 형식이 잘못되었을 때
                     """,

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV3Docs.java
@@ -41,13 +41,13 @@ public interface CategoryControllerV3Docs {
             @Parameter(required = true) @Valid CategoryCreateRequest categoryCreateRequest,
             @Parameter(hidden = true) Member member);
 
-    @Operation(summary = "카테고리 조회", description = "사용자의 카테고리을 조회합니다.")
+    @Operation(summary = "카테고리 조회", description = "사용자의 카테고리를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
                     <발생 가능한 케이스>
                     
-                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    (1) 존재하지 않는 카테고리를 조회하려고 했을 때
                     
                     (2) Path Variable 형식이 잘못되었을 때
                     """,

--- a/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV4Docs.java
+++ b/backend/src/main/java/com/staccato/category/controller/docs/CategoryControllerV4Docs.java
@@ -1,0 +1,30 @@
+package com.staccato.category.controller.docs;
+
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV4;
+import com.staccato.member.domain.Member;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Category V4", description = "Category API V4")
+public interface CategoryControllerV4Docs {
+    @Operation(summary = "카테고리 조회", description = "사용자의 카테고리을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(description = "카테고리 조회 성공", responseCode = "200"),
+            @ApiResponse(description = """
+                    <발생 가능한 케이스>
+                    
+                    (1) 존재하지 않는 카테고리을 조회하려고 했을 때
+                    
+                    (2) Path Variable 형식이 잘못되었을 때
+                    """,
+                    responseCode = "400")
+    })
+    ResponseEntity<CategoryDetailResponseV4> readCategory(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "카테고리 ID", example = "1") @Min(value = 1L, message = "카테고리 식별자는 양수로 이루어져야 합니다.") long categoryId);
+}

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -120,6 +120,14 @@ public class CategoryService {
         return CategoryStaccatoLocationResponses.of(staccatos);
     }
 
+    public CategoryStaccatoResponses readStaccatosByCategory(
+            Member member,
+            long categoryId,
+            CategoryStaccatoPaginationRequest categoryStaccatoPaginationRequest
+    ) {
+        return null;
+    }
+
     @Transactional
     public void updateCategory(CategoryUpdateRequest categoryUpdateRequest, Long categoryId, Member member) {
         Category originCategory = getCategoryById(categoryId);

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -25,7 +25,6 @@ import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.config.log.annotation.Trace;
-import com.staccato.exception.ForbiddenException;
 import com.staccato.exception.StaccatoException;
 import com.staccato.invitation.repository.CategoryInvitationRepository;
 import com.staccato.member.domain.Member;
@@ -105,7 +104,7 @@ public class CategoryService {
         return new CategoryDetailResponseV3(category, staccatos, member);
     }
 
-    public CategoryStaccatoLocationResponses readAllStaccatoByCategory(
+    public CategoryStaccatoLocationResponses readAllLocationStaccatoByCategory(
             Member member, long categoryId, CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest) {
         Category category = getCategoryById(categoryId);
         category.validateOwner(member);

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -123,7 +123,8 @@ public class CategoryService {
     public CategoryStaccatoResponses readStaccatosByCategory(
             Member member,
             long categoryId,
-            CategoryStaccatoPaginationRequest categoryStaccatoPaginationRequest
+            String cursor,
+            int limit
     ) {
         return null;
     }

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -4,10 +4,8 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.CategoryMember;
 import com.staccato.category.repository.CategoryMemberRepository;
@@ -33,7 +31,6 @@ import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.repository.StaccatoImageRepository;
 import com.staccato.staccato.repository.StaccatoRepository;
-
 import lombok.RequiredArgsConstructor;
 
 @Trace
@@ -134,7 +131,7 @@ public class CategoryService {
             Member member,
             long categoryId,
             String cursor,
-            int limit
+            Integer limit
     ) {
         return null;
     }

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -18,11 +18,13 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
 import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV4;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
 import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
+import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
 import com.staccato.comment.repository.CommentRepository;
 import com.staccato.config.log.annotation.Trace;
 import com.staccato.exception.StaccatoException;
@@ -95,7 +97,7 @@ public class CategoryService {
         return sort.apply(categories);
     }
 
-    public CategoryDetailResponseV3 readCategoryById(long categoryId, Member member) {
+    public CategoryDetailResponseV3 readCategoryWithStaccatosById(long categoryId, Member member) {
         Category category = categoryRepository.findWithCategoryMembersById(categoryId)
                 .orElseThrow(() -> new StaccatoException("요청하신 카테고리를 찾을 수 없어요."));
         category.validateOwner(member);
@@ -104,7 +106,15 @@ public class CategoryService {
         return new CategoryDetailResponseV3(category, staccatos, member);
     }
 
-    public CategoryStaccatoLocationResponses readAllLocationStaccatoByCategory(
+    public CategoryDetailResponseV4 readCategoryById(long categoryId, Member member) {
+        Category category = categoryRepository.findWithCategoryMembersById(categoryId)
+                .orElseThrow(() -> new StaccatoException("요청하신 카테고리를 찾을 수 없어요."));
+        category.validateOwner(member);
+
+        return new CategoryDetailResponseV4(category, member);
+    }
+
+    public CategoryStaccatoLocationResponses readStaccatoLocationsByCategory(
             Member member, long categoryId, CategoryStaccatoLocationRangeRequest categoryStaccatoLocationRangeRequest) {
         Category category = getCategoryById(categoryId);
         category.validateOwner(member);

--- a/backend/src/main/java/com/staccato/category/service/CategoryService.java
+++ b/backend/src/main/java/com/staccato/category/service/CategoryService.java
@@ -145,7 +145,7 @@ public class CategoryService {
         if (cursor.isEmpty()) {
             return staccatoRepository.findFirstPageByCategoryId(categoryId, limit);
         }
-        return staccatoRepository.findStaccatosByCategoryIdAfterCursor(categoryId, cursor.id(), cursor.visitedAt(), cursor.createdAt(), limit);
+        return staccatoRepository.findStaccatosByCategoryIdAfterCursor(categoryId, cursor.id(), cursor.visitedAt(), limit);
     }
 
     private StaccatoCursor getNextCursor(List<Staccato> staccatos) {

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -15,11 +15,15 @@ public record StaccatoCursor(
 ) {
     private static final StaccatoCursor EMPTY = new StaccatoCursor(-1L, null, null);
     private static final String DELIMITER = "\\|";
-    private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
     private static final int ARGUMENTS_COUNT = 3;
     private static final int ID_INDEX = 0;
     private static final int VISITED_AT_INDEX = 1;
     private static final int CREATED_AT_INDEX = 2;
+
+    public StaccatoCursor(Staccato staccato) {
+        this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
+    }
 
     public static StaccatoCursor fromEncoded(String encodedCursor) {
         if (Objects.isNull(encodedCursor) || encodedCursor.isBlank()) {
@@ -44,10 +48,6 @@ public record StaccatoCursor(
 
     public static StaccatoCursor empty() {
         return EMPTY;
-    }
-
-    public StaccatoCursor(Staccato staccato) {
-        this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
     }
 
     public boolean isEmpty() {

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -1,0 +1,46 @@
+package com.staccato.category.service;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import com.staccato.exception.StaccatoException;
+
+public record StaccatoCursor(
+        long id,
+        LocalDateTime visitedAt,
+        LocalDateTime createdAt
+) {
+    private static final String DELIMITER = "\\|";
+    private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+    public static final int ARGUMENTS_COUNT = 3;
+    public static final int ID_INDEX = 0;
+    public static final int VISITED_AT_INDEX = 1;
+    public static final int CREATED_AT_INDEX = 2;
+
+    public static StaccatoCursor fromEncoded(String encodedCursor) {
+        try {
+            String decoded = new String(Base64.getUrlDecoder().decode(encodedCursor), StandardCharsets.UTF_8);
+            String[] parts = decoded.split(DELIMITER);
+            if (parts.length != ARGUMENTS_COUNT) {
+                throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor);
+            }
+
+            long id = Long.parseLong(parts[ID_INDEX]);
+            LocalDateTime visitedAt = LocalDateTime.parse(parts[VISITED_AT_INDEX], DATETIME_FORMAT);
+            LocalDateTime createdAt = LocalDateTime.parse(parts[CREATED_AT_INDEX], DATETIME_FORMAT);
+
+            return new StaccatoCursor(id, visitedAt, createdAt);
+        } catch (Exception e) {
+            throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor, e);
+        }
+    }
+
+    public String encode() {
+        String cursor = String.format("%d|%s|%s",
+                id,
+                visitedAt.format(DATETIME_FORMAT),
+                createdAt.format(DATETIME_FORMAT));
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(cursor.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -35,7 +35,7 @@ public record StaccatoCursor(
             String decoded = new String(Base64.getUrlDecoder().decode(encodedCursor), StandardCharsets.UTF_8);
             String[] parts = decoded.split(DELIMITER);
             if (parts.length != ARGUMENTS_COUNT) {
-                throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor);
+                throw new StaccatoException("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: " + encodedCursor);
             }
 
             long id = Long.parseLong(parts[ID_INDEX]);
@@ -43,7 +43,7 @@ public record StaccatoCursor(
 
             return new StaccatoCursor(id, visitedAt);
         } catch (Exception e) {
-            throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor, e);
+            throw new StaccatoException("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: " + encodedCursor, e);
         }
     }
 

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -10,24 +10,21 @@ import com.staccato.staccato.domain.Staccato;
 
 public record StaccatoCursor(
         long id,
-        LocalDateTime visitedAt,
-        LocalDateTime createdAt
+        LocalDateTime visitedAt
 ) {
-    private static final StaccatoCursor EMPTY = new StaccatoCursor(-1L, null, null);
+    private static final StaccatoCursor EMPTY = new StaccatoCursor(-1L, null);
     private static final String DELIMITER = "\\|";
     private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSSSS");
-    private static final int ARGUMENTS_COUNT = 3;
+    private static final int ARGUMENTS_COUNT = 2;
     private static final int ID_INDEX = 0;
     private static final int VISITED_AT_INDEX = 1;
-    private static final int CREATED_AT_INDEX = 2;
 
     public StaccatoCursor {
         visitedAt = visitedAt == null ? null : LocalDateTime.parse(visitedAt.format(DATETIME_FORMAT), DATETIME_FORMAT);
-        createdAt = createdAt == null ? null : LocalDateTime.parse(createdAt.format(DATETIME_FORMAT), DATETIME_FORMAT);
     }
 
     public StaccatoCursor(Staccato staccato) {
-        this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
+        this(staccato.getId(), staccato.getVisitedAt());
     }
 
     public static StaccatoCursor fromEncoded(String encodedCursor) {
@@ -43,9 +40,8 @@ public record StaccatoCursor(
 
             long id = Long.parseLong(parts[ID_INDEX]);
             LocalDateTime visitedAt = LocalDateTime.parse(parts[VISITED_AT_INDEX], DATETIME_FORMAT);
-            LocalDateTime createdAt = LocalDateTime.parse(parts[CREATED_AT_INDEX], DATETIME_FORMAT);
 
-            return new StaccatoCursor(id, visitedAt, createdAt);
+            return new StaccatoCursor(id, visitedAt);
         } catch (Exception e) {
             throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor, e);
         }
@@ -63,10 +59,7 @@ public record StaccatoCursor(
         if (this.isEmpty()) {
             return null;
         }
-        String cursor = String.format("%d|%s|%s",
-                id,
-                visitedAt.format(DATETIME_FORMAT),
-                createdAt.format(DATETIME_FORMAT));
+        String cursor = String.format("%d|%s", id, visitedAt.format(DATETIME_FORMAT));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(cursor.getBytes(StandardCharsets.UTF_8));
     }
 

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
 import com.staccato.exception.StaccatoException;
+import com.staccato.staccato.domain.Staccato;
 
 public record StaccatoCursor(
         long id,
@@ -13,10 +14,10 @@ public record StaccatoCursor(
 ) {
     private static final String DELIMITER = "\\|";
     private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-    public static final int ARGUMENTS_COUNT = 3;
-    public static final int ID_INDEX = 0;
-    public static final int VISITED_AT_INDEX = 1;
-    public static final int CREATED_AT_INDEX = 2;
+    private static final int ARGUMENTS_COUNT = 3;
+    private static final int ID_INDEX = 0;
+    private static final int VISITED_AT_INDEX = 1;
+    private static final int CREATED_AT_INDEX = 2;
 
     public static StaccatoCursor fromEncoded(String encodedCursor) {
         try {
@@ -34,6 +35,10 @@ public record StaccatoCursor(
         } catch (Exception e) {
             throw new StaccatoException("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: " + encodedCursor, e);
         }
+    }
+
+    public StaccatoCursor(Staccato staccato) {
+        this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
     }
 
     public String encode() {

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -21,6 +21,11 @@ public record StaccatoCursor(
     private static final int VISITED_AT_INDEX = 1;
     private static final int CREATED_AT_INDEX = 2;
 
+    public StaccatoCursor {
+        visitedAt = visitedAt == null ? null : LocalDateTime.parse(visitedAt.format(DATETIME_FORMAT), DATETIME_FORMAT);
+        createdAt = createdAt == null ? null : LocalDateTime.parse(createdAt.format(DATETIME_FORMAT), DATETIME_FORMAT);
+    }
+
     public StaccatoCursor(Staccato staccato) {
         this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
     }
@@ -64,4 +69,21 @@ public record StaccatoCursor(
                 createdAt.format(DATETIME_FORMAT));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(cursor.getBytes(StandardCharsets.UTF_8));
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StaccatoCursor other)) {
+            return false;
+        }
+        return this.id == other.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Long.hashCode(id);
+    }
+
 }

--- a/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
+++ b/backend/src/main/java/com/staccato/category/service/StaccatoCursor.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.Objects;
 import com.staccato.exception.StaccatoException;
 import com.staccato.staccato.domain.Staccato;
 
@@ -12,6 +13,7 @@ public record StaccatoCursor(
         LocalDateTime visitedAt,
         LocalDateTime createdAt
 ) {
+    private static final StaccatoCursor EMPTY = new StaccatoCursor(-1L, null, null);
     private static final String DELIMITER = "\\|";
     private static final DateTimeFormatter DATETIME_FORMAT = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
     private static final int ARGUMENTS_COUNT = 3;
@@ -20,6 +22,9 @@ public record StaccatoCursor(
     private static final int CREATED_AT_INDEX = 2;
 
     public static StaccatoCursor fromEncoded(String encodedCursor) {
+        if (Objects.isNull(encodedCursor) || encodedCursor.isBlank()) {
+            return StaccatoCursor.empty();
+        }
         try {
             String decoded = new String(Base64.getUrlDecoder().decode(encodedCursor), StandardCharsets.UTF_8);
             String[] parts = decoded.split(DELIMITER);
@@ -37,11 +42,22 @@ public record StaccatoCursor(
         }
     }
 
+    public static StaccatoCursor empty() {
+        return EMPTY;
+    }
+
     public StaccatoCursor(Staccato staccato) {
         this(staccato.getId(), staccato.getVisitedAt(), staccato.getCreatedAt());
     }
 
+    public boolean isEmpty() {
+        return this.equals(EMPTY);
+    }
+
     public String encode() {
+        if (this.isEmpty()) {
+            return null;
+        }
         String cursor = String.format("%d|%s|%s",
                 id,
                 visitedAt.format(DATETIME_FORMAT),

--- a/backend/src/main/java/com/staccato/category/service/dto/request/CategoryStaccatoPaginationRequest.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/request/CategoryStaccatoPaginationRequest.java
@@ -1,0 +1,7 @@
+package com.staccato.category.service.dto.request;
+
+public record CategoryStaccatoPaginationRequest(
+        String cursor,
+        int limit
+) {
+}

--- a/backend/src/main/java/com/staccato/category/service/dto/request/CategoryStaccatoPaginationRequest.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/request/CategoryStaccatoPaginationRequest.java
@@ -1,7 +1,0 @@
-package com.staccato.category.service.dto.request;
-
-public record CategoryStaccatoPaginationRequest(
-        String cursor,
-        int limit
-) {
-}

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV4.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryDetailResponseV4.java
@@ -1,0 +1,76 @@
+package com.staccato.category.service.dto.response;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.staccato.category.domain.Category;
+import com.staccato.category.domain.CategoryMember;
+import com.staccato.config.swagger.SwaggerExamples;
+import com.staccato.member.domain.Member;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리(스타카토 목록 외)에 대한 응답 형식입니다.")
+public record CategoryDetailResponseV4(
+        @Schema(example = SwaggerExamples.CATEGORY_ID)
+        Long categoryId,
+        @Schema(example = SwaggerExamples.IMAGE_URL)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String categoryThumbnailUrl,
+        @Schema(example = SwaggerExamples.CATEGORY_TITLE)
+        String categoryTitle,
+        @Schema(example = SwaggerExamples.CATEGORY_DESCRIPTION)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String description,
+        @Schema(example = SwaggerExamples.CATEGORY_COLOR)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String categoryColor,
+        @Schema(example = SwaggerExamples.CATEGORY_START_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate startAt,
+        @Schema(example = SwaggerExamples.CATEGORY_END_AT)
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        LocalDate endAt,
+        @Schema(example = SwaggerExamples.CATEGORY_IS_SHARED)
+        boolean isShared,
+        @Schema(example = SwaggerExamples.CATEGORY_ROLE)
+        String myRole,
+        List<MemberDetailResponse> members
+) {
+    private static final int PRIORITY_HOST = 0;
+    private static final int PRIORITY_CURRENT_USER = 1;
+    private static final int PRIORITY_OTHERS = 2;
+
+    public CategoryDetailResponseV4(Category category, Member member) {
+        this(
+                category.getId(),
+                category.getThumbnailUrl(),
+                category.getTitle().getTitle(),
+                category.getDescription().getDescription(),
+                category.getColor().getName(),
+                category.getTerm().getStartAt(),
+                category.getTerm().getEndAt(),
+                category.getIsShared(),
+                category.getRoleOfMember(member).getRole(),
+                toMemberDetailResponses(category, member)
+        );
+    }
+
+    private static List<MemberDetailResponse> toMemberDetailResponses(Category category, Member currentMember) {
+        return category.getCategoryMembers().stream()
+                .sorted(byHostFirstThenCurrentUser(currentMember).thenComparing(CategoryMember::getCreatedAt))
+                .map(MemberDetailResponse::new)
+                .toList();
+    }
+
+    private static Comparator<CategoryMember> byHostFirstThenCurrentUser(Member currentMember) {
+        return Comparator.comparing((CategoryMember cm) -> {
+            if (cm.isHost())
+                return PRIORITY_HOST;
+            if (cm.isMember(currentMember))
+                return PRIORITY_CURRENT_USER;
+            return PRIORITY_OTHERS;
+        });
+    }
+}
+

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoLocationResponses.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoLocationResponses.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "카테고리에 속한 스타카토 목록에 해당하는 응답입니다.")
 public record CategoryStaccatoLocationResponses(
-        List<CategoryStaccatoLocationResponse> categoryStaccatoLocationResponses) {
+        List<CategoryStaccatoLocationResponse> staccatos) {
 
     public static CategoryStaccatoLocationResponses of(List<Staccato> staccatos) {
         List<CategoryStaccatoLocationResponse> categoryStaccatoLocationResponses = staccatos.stream()

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoResponses.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoResponses.java
@@ -1,0 +1,21 @@
+package com.staccato.category.service.dto.response;
+
+import java.util.List;
+import com.staccato.staccato.domain.Staccato;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "카테고리에 속한 스타카토 목록에 해당하는 응답입니다.")
+public record CategoryStaccatoResponses(
+        List<StaccatoResponse> staccatos,
+        String nextCursor
+        ) {
+
+    public static CategoryStaccatoResponses of(List<Staccato> staccatos, String nextCursor) {
+        List<StaccatoResponse> staccatoResponses = staccatos.stream().map(StaccatoResponse::new).toList();
+        return new CategoryStaccatoResponses(staccatoResponses, nextCursor);
+    }
+
+    private static List<StaccatoResponse> toStaccatoResponses(List<Staccato> staccatos) {
+        return staccatos.stream().map(StaccatoResponse::new).toList();
+    }
+}

--- a/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoResponses.java
+++ b/backend/src/main/java/com/staccato/category/service/dto/response/CategoryStaccatoResponses.java
@@ -1,6 +1,7 @@
 package com.staccato.category.service.dto.response;
 
 import java.util.List;
+import com.staccato.category.service.StaccatoCursor;
 import com.staccato.staccato.domain.Staccato;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,14 +9,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CategoryStaccatoResponses(
         List<StaccatoResponse> staccatos,
         String nextCursor
-        ) {
+) {
 
-    public static CategoryStaccatoResponses of(List<Staccato> staccatos, String nextCursor) {
+    public static CategoryStaccatoResponses of(List<Staccato> staccatos, StaccatoCursor nextCursor) {
         List<StaccatoResponse> staccatoResponses = staccatos.stream().map(StaccatoResponse::new).toList();
-        return new CategoryStaccatoResponses(staccatoResponses, nextCursor);
-    }
-
-    private static List<StaccatoResponse> toStaccatoResponses(List<Staccato> staccatos) {
-        return staccatos.stream().map(StaccatoResponse::new).toList();
+        return new CategoryStaccatoResponses(staccatoResponses, nextCursor.encode());
     }
 }

--- a/backend/src/main/java/com/staccato/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/staccato/config/OpenApiConfig.java
@@ -40,7 +40,7 @@ public class OpenApiConfig {
     public GroupedOpenApi v1Api() {
         return GroupedOpenApi.builder()
                 .group("V1 API")
-                .pathsToExclude("/v2/**", "/v3/**")
+                .pathsToExclude("/v2/**", "/v3/**", "/v4/**")
                 .build();
     }
 

--- a/backend/src/main/java/com/staccato/config/OpenApiConfig.java
+++ b/backend/src/main/java/com/staccato/config/OpenApiConfig.java
@@ -59,4 +59,12 @@ public class OpenApiConfig {
                 .pathsToMatch("/v3/**")
                 .build();
     }
+
+    @Bean
+    public GroupedOpenApi v4Api() {
+        return GroupedOpenApi.builder()
+                .group("V4 API")
+                .pathsToMatch("/v4/**")
+                .build();
+    }
 }

--- a/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
+++ b/backend/src/main/java/com/staccato/config/swagger/SwaggerExamples.java
@@ -38,4 +38,6 @@ public class SwaggerExamples {
     public static final String NOTIFICATION_TOKEN = "token";
     public static final String DEVICE_TYPE = "ANDROID";
     public static final String DEVICE_ID = "241Ae231es";
+    public static final String PAGINATION_CURSOR = "base64EncodedValue";
+    public static final String PAGINATION_LIMIT = "10";
 }

--- a/backend/src/main/java/com/staccato/staccato/controller/docs/StaccatoControllerV2Docs.java
+++ b/backend/src/main/java/com/staccato/staccato/controller/docs/StaccatoControllerV2Docs.java
@@ -17,7 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "Staccato V2", description = "Staccato API V2")
 public interface StaccatoControllerV2Docs {
-    @Operation(summary = "스타카토 목록 조회", description = "주어진 카테고리와 위경도 범위가 있다면, 그에 해당하는 모든 스타카토 목록을 조회하고, 조건이 없다면 모든 스타카토를 조회합니다.")
+    @Operation(summary = "스타카토 목록 조회", description = "주어진 위경도 범위가 있다면, 그에 해당하는 모든 스타카토 목록을 조회하고, 조건이 없다면 모든 스타카토를 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(description = "스타카토 목록 조회 성공", responseCode = "200"),
             @ApiResponse(description = """
@@ -25,7 +25,6 @@ public interface StaccatoControllerV2Docs {
                                 
                     (1) 쿼리 파라미터로 제공된 위도 또는 경도가 유효한 범위를 벗어난 경우
                     (2) 위도는 -90.0 이상 90.0 이하, 경도는 -180.0 이상 180.0 이하여야 함
-                    (3) 잘못된 카테고리 식별자가 주어지는 경우
                     """,
                     responseCode = "400")
     })

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -73,12 +73,12 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
                   AND (
                     s.visited_at < :visitedAt
                     OR (s.visited_at = :visitedAt AND s.created_at < :createdAt)
-                    OR (s.visited_at = :visitedAt AND s.created_at = :createdAt AND s.id <= :staccatoId)
+                    OR (s.visited_at = :visitedAt AND s.created_at = :createdAt AND s.id < :staccatoId)
                   )
                 ORDER BY s.visited_at DESC, s.created_at DESC
                 LIMIT :limit
             """, nativeQuery = true)
-    List<Staccato> findStaccatosByCategoryIdFromCursor(
+    List<Staccato> findStaccatosByCategoryIdAfterCursor(
             @Param("categoryId") long categoryId,
             @Param("staccatoId") long staccatoId,
             @Param("visitedAt") LocalDateTime visitedAt,

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -72,8 +72,7 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
                 WHERE s.category_id = :categoryId
                   AND (
                     s.visited_at < :visitedAt
-                    OR (s.visited_at = :visitedAt AND s.created_at < :createdAt)
-                    OR (s.visited_at = :visitedAt AND s.created_at = :createdAt AND s.id < :staccatoId)
+                    OR (s.visited_at = :visitedAt AND s.id < :staccatoId)
                   )
                 ORDER BY s.visited_at DESC, s.created_at DESC
                 LIMIT :limit
@@ -82,7 +81,6 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
             @Param("categoryId") long categoryId,
             @Param("staccatoId") long staccatoId,
             @Param("visitedAt") LocalDateTime visitedAt,
-            @Param("createdAt") LocalDateTime createdAt,
             @Param("limit") int limit
     );
 

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -59,7 +59,7 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
     @Query(value = """
                 SELECT * FROM staccato s
                 WHERE s.category_id = :categoryId
-                ORDER BY s.visited_at DESC, s.created_at DESC
+                ORDER BY s.visited_at DESC, s.id DESC
                 LIMIT :limit
             """, nativeQuery = true)
     List<Staccato> findFirstPageByCategoryId(
@@ -74,7 +74,7 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
                     s.visited_at < :visitedAt
                     OR (s.visited_at = :visitedAt AND s.id < :staccatoId)
                   )
-                ORDER BY s.visited_at DESC, s.created_at DESC
+                ORDER BY s.visited_at DESC, s.id DESC
                 LIMIT :limit
             """, nativeQuery = true)
     List<Staccato> findStaccatosByCategoryIdAfterCursor(

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -59,6 +59,17 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
     @Query(value = """
                 SELECT * FROM staccato s
                 WHERE s.category_id = :categoryId
+                ORDER BY s.visited_at DESC, s.created_at DESC
+                LIMIT :limit
+            """, nativeQuery = true)
+    List<Staccato> findFirstPageByCategoryId(
+            @Param("categoryId") long categoryId,
+            @Param("limit") int limit
+    );
+
+    @Query(value = """
+                SELECT * FROM staccato s
+                WHERE s.category_id = :categoryId
                   AND (
                     s.visited_at < :visitedAt
                     OR (s.visited_at = :visitedAt AND s.created_at < :createdAt)

--- a/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
+++ b/backend/src/main/java/com/staccato/staccato/repository/StaccatoRepository.java
@@ -1,6 +1,7 @@
 package com.staccato.staccato.repository;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -55,7 +56,24 @@ public interface StaccatoRepository extends JpaRepository<Staccato, Long> {
 
     List<Staccato> findAllByCategoryId(long categoryId);
 
-    List<Staccato> findAllByCategoryIdIn(List<Long> categoryIds);
+    @Query(value = """
+                SELECT * FROM staccato s
+                WHERE s.category_id = :categoryId
+                  AND (
+                    s.visited_at < :visitedAt
+                    OR (s.visited_at = :visitedAt AND s.created_at < :createdAt)
+                    OR (s.visited_at = :visitedAt AND s.created_at = :createdAt AND s.id <= :staccatoId)
+                  )
+                ORDER BY s.visited_at DESC, s.created_at DESC
+                LIMIT :limit
+            """, nativeQuery = true)
+    List<Staccato> findStaccatosByCategoryIdFromCursor(
+            @Param("categoryId") long categoryId,
+            @Param("staccatoId") long staccatoId,
+            @Param("visitedAt") LocalDateTime visitedAt,
+            @Param("createdAt") LocalDateTime createdAt,
+            @Param("limit") int limit
+    );
 
     @Modifying
     @Query("DELETE FROM Staccato s WHERE s.category.id = :categoryId")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -415,7 +415,7 @@ class CategoryControllerTest extends ControllerTest {
                 .andExpect(content().json(expectedResponse, true));
     }
 
-    @DisplayName("특정 카테고리에 속한 스타카토 목록 조회에 성공한다.")
+    @DisplayName("특정 카테고리에 속한 스타카토 위치 목록 조회에 성공한다.")
     @Test
     void readStaccatoLocationsByCategory() throws Exception {
         // given
@@ -433,10 +433,10 @@ class CategoryControllerTest extends ControllerTest {
         );
         CategoryStaccatoLocationResponses responses = new CategoryStaccatoLocationResponses(List.of(response1, response2));
 
-        when(categoryService.readAllLocationStaccatoByCategory(any(Member.class), anyLong(), any(CategoryStaccatoLocationRangeRequest.class))).thenReturn(responses);
+        when(categoryService.readStaccatoLocationsByCategory(any(Member.class), anyLong(), any(CategoryStaccatoLocationRangeRequest.class))).thenReturn(responses);
         String expectedResponse = """
                 {
-                    "categoryStaccatoLocationResponses": [
+                    "staccatos": [
                          {
                              "staccatoId": null,
                              "staccatoColor": "pink",
@@ -454,7 +454,7 @@ class CategoryControllerTest extends ControllerTest {
                 """;
 
         // when & then
-        mockMvc.perform(get("/categories/1/staccatos")
+        mockMvc.perform(get("/categories/1/staccatos/locations")
                         .param("neLat", "81")
                         .param("neLng", "124")
                         .param("swLat", "80")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -417,7 +417,7 @@ class CategoryControllerTest extends ControllerTest {
 
     @DisplayName("특정 카테고리에 속한 스타카토 목록 조회에 성공한다.")
     @Test
-    void readAllStaccatoLocationByCategory() throws Exception {
+    void readStaccatoLocationsByCategory() throws Exception {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -464,6 +464,41 @@ class CategoryControllerTest extends ControllerTest {
                 .andExpect(content().json(expectedResponse, true));
     }
 
+    @DisplayName("특정 카테고리에 속한 스타카토 목록 조회에 성공한다.")
+    @Test
+    void readStaccatosByCategory() throws Exception {
+        // given
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato()
+                .withCategory(category)
+                .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
+        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), "nextCursor");
+
+        when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), any(CategoryStaccatoPaginationRequest.class))).thenReturn(responses);
+        String expectedResponse = """
+                {
+                    "staccatos": [
+                            {
+                                "staccatoId": null,
+                                "staccatoTitle": "staccatoTitle",
+                                "staccatoImageUrl": "https://example.com/staccatoImage.jpg",
+                                "visitedAt": "2024-06-01T00:00:00"
+                            }
+                    ],
+                    "nextCursor": "nextCursor"
+                }
+                """;
+
+        // when & then
+        mockMvc.perform(get("/categories/1/staccatos")
+                        .param("cursor", "81")
+                        .param("limit", "1")
+                        .header(HttpHeaders.AUTHORIZATION, "token"))
+                .andExpect(status().isOk())
+                .andExpect(content().json(expectedResponse, true));
+    }
+
     @DisplayName("적합한 경로변수와 데이터를 통해 스타카토 수정에 성공한다.")
     @ParameterizedTest
     @MethodSource("categoryRequestProvider")

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -1,26 +1,9 @@
 package com.staccato.category.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,10 +14,10 @@ import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
 import com.staccato.ControllerTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.Color;
+import com.staccato.category.service.StaccatoCursor;
 import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
@@ -53,6 +36,22 @@ import com.staccato.fixture.member.MemberFixtures;
 import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
 import com.staccato.staccato.domain.Staccato;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class CategoryControllerTest extends ControllerTest {
 
@@ -553,7 +552,8 @@ class CategoryControllerTest extends ControllerTest {
                 anyString(),
                 limitCaptor.capture()
         );
-        assertThat(limitCaptor.getValue()).isEqualTo(10);    }
+        assertThat(limitCaptor.getValue()).isEqualTo(10);
+    }
 
     @DisplayName("적합한 경로변수와 데이터를 통해 스타카토 수정에 성공한다.")
     @ParameterizedTest

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -433,7 +433,7 @@ class CategoryControllerTest extends ControllerTest {
         );
         CategoryStaccatoLocationResponses responses = new CategoryStaccatoLocationResponses(List.of(response1, response2));
 
-        when(categoryService.readAllStaccatoByCategory(any(Member.class), anyLong(), any(CategoryStaccatoLocationRangeRequest.class))).thenReturn(responses);
+        when(categoryService.readAllLocationStaccatoByCategory(any(Member.class), anyLong(), any(CategoryStaccatoLocationRangeRequest.class))).thenReturn(responses);
         String expectedResponse = """
                 {
                     "categoryStaccatoLocationResponses": [

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -477,7 +477,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), "nextCursor");
+        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
         when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), anyString(), anyInt())).thenReturn(responses);
         String expectedResponse = """
@@ -490,7 +490,7 @@ class CategoryControllerTest extends ControllerTest {
                                 "visitedAt": "2024-06-01T00:00:00"
                             }
                     ],
-                    "nextCursor": "nextCursor"
+                    "nextCursor": null
                 }
                 """;
 
@@ -513,7 +513,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), "nextCursor");
+        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
         when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), anyString(), anyInt())).thenReturn(responses);
 
@@ -534,7 +534,7 @@ class CategoryControllerTest extends ControllerTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
-        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), "nextCursor");
+        CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
         when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), anyString(), anyInt())).thenReturn(responses);
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -512,7 +512,7 @@ class CategoryControllerTest extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
-                .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
+                .build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
         when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), anyString(), anyInt())).thenReturn(responses);

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -1,8 +1,11 @@
 package com.staccato.category.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -24,6 +27,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -41,6 +45,7 @@ import com.staccato.category.service.dto.response.CategoryResponseV3;
 import com.staccato.category.service.dto.response.CategoryResponsesV3;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponse;
 import com.staccato.category.service.dto.response.CategoryStaccatoLocationResponses;
+import com.staccato.category.service.dto.response.CategoryStaccatoResponses;
 import com.staccato.exception.ExceptionResponse;
 import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.category.CategoryRequestFixtures;
@@ -333,7 +338,7 @@ class CategoryControllerTest extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,
@@ -383,7 +388,7 @@ class CategoryControllerTest extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,
@@ -475,7 +480,7 @@ class CategoryControllerTest extends ControllerTest {
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), "nextCursor");
 
-        when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), any(CategoryStaccatoPaginationRequest.class))).thenReturn(responses);
+        when(categoryService.readStaccatosByCategory(any(Member.class), anyLong(), anyString(), anyInt())).thenReturn(responses);
         String expectedResponse = """
                 {
                     "staccatos": [
@@ -492,7 +497,7 @@ class CategoryControllerTest extends ControllerTest {
 
         // when & then
         mockMvc.perform(get("/categories/1/staccatos")
-                        .param("cursor", "81")
+                        .param("cursor", "cursor")
                         .param("limit", "1")
                         .header(HttpHeaders.AUTHORIZATION, "token"))
                 .andExpect(status().isOk())

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -417,7 +417,7 @@ class CategoryControllerTest extends ControllerTest {
 
     @DisplayName("특정 카테고리에 속한 스타카토 목록 조회에 성공한다.")
     @Test
-    void readAllStaccatoByCategory() throws Exception {
+    void readAllStaccatoLocationByCategory() throws Exception {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -239,7 +239,7 @@ class CategoryControllerV2Test extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,
@@ -290,7 +290,7 @@ class CategoryControllerV2Test extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -181,7 +181,7 @@ class CategoryControllerV3Test extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), host);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,
@@ -241,7 +241,7 @@ class CategoryControllerV3Test extends ControllerTest {
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
-        when(categoryService.readCategoryById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
+        when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
         String expectedResponse = """
                 {
                     "categoryId": null,

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -1,22 +1,17 @@
 package com.staccato.category.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-
 import com.staccato.ServiceSliceTest;
 import com.staccato.category.domain.Category;
 import com.staccato.category.domain.CategoryMember;
@@ -30,6 +25,7 @@ import com.staccato.category.service.dto.request.CategoryReadRequest;
 import com.staccato.category.service.dto.request.CategoryStaccatoLocationRangeRequest;
 import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 import com.staccato.category.service.dto.response.CategoryDetailResponseV3;
+import com.staccato.category.service.dto.response.CategoryDetailResponseV4;
 import com.staccato.category.service.dto.response.CategoryIdResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponse;
 import com.staccato.category.service.dto.response.CategoryNameResponses;
@@ -54,6 +50,11 @@ import com.staccato.member.repository.MemberRepository;
 import com.staccato.staccato.domain.Staccato;
 import com.staccato.staccato.repository.StaccatoRepository;
 import com.staccato.staccato.service.StaccatoService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class CategoryServiceTest extends ServiceSliceTest {
     @Autowired
@@ -176,133 +177,192 @@ class CategoryServiceTest extends ServiceSliceTest {
         );
     }
 
-    @DisplayName("HOST는 본인이 속한 특정 카테고리를 조회할 수 있다.")
-    @Test
-    void readCategoryWithStaccatosByIdByHost() {
-        // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+    @Nested
+    @DisplayName("특정 카테고리 조회 시")
+    class ReadCategoryTest {
+        Member host;
+        Member guest;
+        Member other;
+        Category category;
 
-        CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), host);
+        @BeforeEach
+        void setUp() {
+            host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
+            guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+            other = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);
 
-        // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), host);
+            category = CategoryFixtures.defaultCategory()
+                    .withTerm(LocalDate.of(2024, 1, 1),
+                            LocalDate.of(2024, 1, 4))
+                    .withHost(host)
+                    .withGuests(List.of(guest))
+                    .buildAndSave(categoryRepository);
+        }
 
-        // then
-        assertAll(
-                () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.members()).hasSize(1)
-        );
+        @Nested
+        @DisplayName("카테고리 조회(readCategoryById)일 경우")
+        class ReadCategory {
+            @DisplayName("HOST는 정상적으로 조회할 수 있다.")
+            @Test
+            void successForHost() {
+                // when
+                CategoryDetailResponseV4 response = categoryService.readCategoryById(category.getId(), host);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(category.getId()),
+                        () -> assertThat(response.members()).hasSize(2)
+                );
+            }
+
+            @DisplayName("GUEST도 정상적으로 조회할 수 있다.")
+            @Test
+            void successForGuest() {
+                CategoryDetailResponseV4 response = categoryService.readCategoryById(category.getId(), guest);
+                assertThat(response.categoryId()).isEqualTo(category.getId());
+                assertThat(response.members()).hasSize(2);
+            }
+
+            @DisplayName("기간이 없는 카테고리도 정상 조회된다.")
+            @Test
+            void successWhenTermIsNull() {
+                // given
+                category = CategoryFixtures.defaultCategory()
+                        .withHost(host)
+                        .withTerm(null, null)
+                        .buildAndSave(categoryRepository);
+
+                // when
+                CategoryDetailResponseV4 response = categoryService.readCategoryById(category.getId(), host);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(category.getId()),
+                        () -> assertThat(response.startAt()).isNull(),
+                        () -> assertThat(response.endAt()).isNull()
+                );
+            }
+
+            @DisplayName("카테고리에 속하지 않은 사용자는 조회할 수 없다.")
+            @Test
+            void failIfNotOwner() {
+                assertThatThrownBy(() -> categoryService.readCategoryById(category.getId(), other))
+                        .isInstanceOf(ForbiddenException.class)
+                        .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
+            }
+
+            @DisplayName("존재하지 않는 카테고리일 경우 예외가 발생한다.")
+            @Test
+            void failIfNotExist() {
+                assertThatThrownBy(() -> categoryService.readCategoryById(0L, host))
+                        .isInstanceOf(StaccatoException.class)
+                        .hasMessage("요청하신 카테고리를 찾을 수 없어요.");
+            }
+        }
+
+        @Nested
+        @DisplayName("스타카토를 포함한 카테고리 조회(readCategoryWithStaccatosById)일 경우")
+        class ReadCategoryWithStaccatos {
+            private Staccato staccato;
+            private Staccato staccato2;
+
+            @BeforeEach
+            void setUpStaccatos() {
+                staccato = StaccatoFixtures.defaultStaccato()
+                        .withVisitedAt(LocalDateTime.of(2024, 1, 3, 0, 0, 0))
+                        .withCategory(category)
+                        .build();
+                staccato2 = StaccatoFixtures.defaultStaccato()
+                        .withVisitedAt(LocalDateTime.of(2024, 1, 2, 0, 0, 0))
+                        .withCategory(category)
+                        .build();
+                staccatoRepository.saveAll(List.of(staccato, staccato2));
+            }
+
+            @DisplayName("HOST는 staccato 목록을 함께 조회한다.")
+            @Test
+            void successForHost() {
+                // when
+                CategoryDetailResponseV3 response = categoryService.readCategoryWithStaccatosById(category.getId(), host);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(category.getId()),
+                        () -> assertThat(response.staccatos()).hasSize(2)
+                );
+            }
+
+            @DisplayName("GUEST도 staccato 목록을 함께 조회한다.")
+            @Test
+            void successForGuest() {
+                // when
+                CategoryDetailResponseV3 response = categoryService.readCategoryWithStaccatosById(category.getId(), guest);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(category.getId()),
+                        () -> assertThat(response.staccatos()).hasSize(2)
+                );
+            }
+
+            @DisplayName("스타카토는 방문 날짜 기준 최신순으로 정렬된다.")
+            @Test
+            void successOrderByVisitedAtDesc() {
+                // when
+                CategoryDetailResponseV3 response = categoryService.readCategoryWithStaccatosById(category.getId(), host);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(response.categoryId()),
+                        () -> assertThat(response.staccatos()).hasSize(3),
+                        () -> assertThat(response.staccatos()).containsExactly(
+                                new StaccatoResponse(staccato),
+                                new StaccatoResponse(staccato2)
+                        )
+                );
+            }
+
+            @DisplayName("기간이 없는 카테고리도 정상 조회된다.")
+            @Test
+            void successWhenTermIsNull() {
+                // given
+                category = CategoryFixtures.defaultCategory()
+                        .withHost(host)
+                        .withTerm(null, null)
+                        .buildAndSave(categoryRepository);
+
+                // when
+                CategoryDetailResponseV3 response = categoryService.readCategoryWithStaccatosById(category.getId(), host);
+
+                // then
+                assertAll(
+                        () -> assertThat(response.categoryId()).isEqualTo(category.getId()),
+                        () -> assertThat(response.startAt()).isNull(),
+                        () -> assertThat(response.endAt()).isNull()
+                );
+            }
+
+            @DisplayName("카테고리에 속하지 않은 사용자는 조회할 수 없다.")
+            @Test
+            void failIfNotOwner() {
+                assertThatThrownBy(() -> categoryService.readCategoryById(category.getId(), other))
+                        .isInstanceOf(ForbiddenException.class)
+                        .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
+            }
+
+            @DisplayName("존재하지 않는 카테고리일 경우 예외가 발생한다.")
+            @Test
+            void failIfNotExist() {
+                assertThatThrownBy(() -> categoryService.readCategoryWithStaccatosById(999L, host))
+                        .isInstanceOf(StaccatoException.class)
+                        .hasMessage("요청하신 카테고리를 찾을 수 없어요.");
+            }
+        }
     }
 
-    @DisplayName("GUEST는 본인이 속한 특정 카테고리를 조회할 수 있다.")
+    @DisplayName("위경도 조건이 없으면 카테고리에 속한 모든 스타카토 위치 목록을 조회한다.")
     @Test
-    void readCategoryWithStaccatosByIdByGuest() {
-        // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-
-        CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), host);
-        Category category = categoryRepository.findById(categoryIdResponse.categoryId()).get();
-        categoryMemberRepository.save(CategoryMember.builder().category(category).member(guest).role(Role.GUEST)
-                .build());
-
-        // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), host);
-
-        // then
-        assertAll(
-                () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.members()).hasSize(2)
-        );
-    }
-
-    @DisplayName("기간이 없는 특정 카테고리를 조회한다.")
-    @Test
-    void readCategoryWithStaccatosByIdWithoutTerm() {
-        // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-
-        CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().withTerm(null, null).build(), member);
-
-        // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), member);
-
-        // then
-        assertAll(
-                () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.members()).hasSize(1),
-                () -> assertThat(categoryDetailResponse.startAt()).isNull(),
-                () -> assertThat(categoryDetailResponse.endAt()).isNull()
-        );
-    }
-
-    @DisplayName("본인 것이 아닌 특정 카테고리를 조회하려고 하면 예외가 발생한다.")
-    @Test
-    void cannotReadCategoryWithStaccatosByIdIfNotOwner() {
-        // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-
-        CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.readCategoryById(categoryIdResponse.categoryId(), otherMember))
-                .isInstanceOf(ForbiddenException.class)
-                .hasMessage("요청하신 작업을 처리할 권한이 없습니다.");
-    }
-
-    @DisplayName("특정 카테고리를 조회하면 스타카토는 최신순으로 반환한다.")
-    @Test
-    void readCategoryByIdOrderWithStaccatosByVisitedAt() {
-        // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-
-        CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
-        Category category = categoryRepository.findById(categoryIdResponse.categoryId()).get();
-        Staccato firstStaccato = StaccatoFixtures.defaultStaccato()
-                .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato secondStaccato = StaccatoFixtures.defaultStaccato()
-                .withVisitedAt(LocalDateTime.of(2024, 6, 2, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato thirdStaccato = StaccatoFixtures.defaultStaccato()
-                .withVisitedAt(LocalDateTime.of(2024, 6, 3, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-
-        // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), member);
-
-        // then
-        assertAll(
-                () -> assertThat(categoryDetailResponse.categoryId()).isEqualTo(categoryIdResponse.categoryId()),
-                () -> assertThat(categoryDetailResponse.staccatos()).hasSize(3),
-                () -> assertThat(categoryDetailResponse.staccatos().stream().map(StaccatoResponse::staccatoId).toList())
-                        .containsExactly(
-                                thirdStaccato.getId(), secondStaccato.getId(), firstStaccato.getId())
-        );
-    }
-
-    @DisplayName("존재하지 않는 카테고리를 조회하려고 할 경우 예외가 발생한다.")
-    @Test
-    void failReadCategory() {
-        // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        long unknownId = 1;
-
-        // when & then
-        assertThatThrownBy(() -> categoryService.readCategoryById(unknownId, member))
-                .isInstanceOf(StaccatoException.class)
-                .hasMessage("요청하신 카테고리를 찾을 수 없어요.");
-    }
-
-    @DisplayName("위경도 조건이 없으면 카테고리에 속한 모든 스타카토 목록을 조회한다.")
-    @Test
-    void readAllStaccato() {
+    void readAllStaccatoLocations() {
         // given
         Member member = MemberFixtures.defaultMember().withCode("me").buildAndSave(memberRepository);
         Member member2 = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -178,7 +178,7 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     @DisplayName("HOST는 본인이 속한 특정 카테고리를 조회할 수 있다.")
     @Test
-    void readCategoryByIdByHost() {
+    void readCategoryWithStaccatosByIdByHost() {
         // given
         Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
 
@@ -186,7 +186,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), host);
 
         // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), host);
 
         // then
         assertAll(
@@ -197,7 +197,7 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     @DisplayName("GUEST는 본인이 속한 특정 카테고리를 조회할 수 있다.")
     @Test
-    void readCategoryByIdByGuest() {
+    void readCategoryWithStaccatosByIdByGuest() {
         // given
         Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
         Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
@@ -209,7 +209,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .build());
 
         // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), host);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), host);
 
         // then
         assertAll(
@@ -220,7 +220,7 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     @DisplayName("기간이 없는 특정 카테고리를 조회한다.")
     @Test
-    void readCategoryByIdWithoutTerm() {
+    void readCategoryWithStaccatosByIdWithoutTerm() {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
 
@@ -228,7 +228,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest().withTerm(null, null).build(), member);
 
         // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(
@@ -241,7 +241,7 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     @DisplayName("본인 것이 아닌 특정 카테고리를 조회하려고 하면 예외가 발생한다.")
     @Test
-    void cannotReadCategoryByIdIfNotOwner() {
+    void cannotReadCategoryWithStaccatosByIdIfNotOwner() {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
@@ -257,7 +257,7 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     @DisplayName("특정 카테고리를 조회하면 스타카토는 최신순으로 반환한다.")
     @Test
-    void readCategoryByIdOrderByVisitedAt() {
+    void readCategoryByIdOrderWithStaccatosByVisitedAt() {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
 
@@ -275,7 +275,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withCategory(category).buildAndSave(staccatoRepository);
 
         // when
-        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryById(categoryIdResponse.categoryId(), member);
+        CategoryDetailResponseV3 categoryDetailResponse = categoryService.readCategoryWithStaccatosById(categoryIdResponse.categoryId(), member);
 
         // then
         assertAll(
@@ -323,13 +323,13 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withCategory(category).buildAndSave(staccatoRepository);
 
         // when
-        CategoryStaccatoLocationResponses responses = categoryService.readAllLocationStaccatoByCategory(
+        CategoryStaccatoLocationResponses responses = categoryService.readStaccatoLocationsByCategory(
                 member, category.getId(), new CategoryStaccatoLocationRangeRequest(null, null, null, null));
 
         // then
         assertAll(
-                () -> assertThat(responses.categoryStaccatoLocationResponses()).hasSize(2),
-                () -> assertThat(responses.categoryStaccatoLocationResponses())
+                () -> assertThat(responses.staccatos()).hasSize(2),
+                () -> assertThat(responses.staccatos())
                         .containsExactlyInAnyOrder(
                                 new CategoryStaccatoLocationResponse(staccato),
                                 new CategoryStaccatoLocationResponse(staccato2)

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -323,7 +323,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withCategory(category).buildAndSave(staccatoRepository);
 
         // when
-        CategoryStaccatoLocationResponses responses = categoryService.readAllStaccatoByCategory(
+        CategoryStaccatoLocationResponses responses = categoryService.readAllLocationStaccatoByCategory(
                 member, category.getId(), new CategoryStaccatoLocationRangeRequest(null, null, null, null));
 
         // then

--- a/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
+++ b/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
@@ -1,0 +1,104 @@
+package com.staccato.category.service;
+
+import java.time.LocalDateTime;
+import java.util.Base64;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import com.staccato.exception.StaccatoException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StaccatoCursorTest {
+    @Test
+    @DisplayName("정상적인 커서는 encode 후 decode 시 동일한 값으로 복원된다")
+    void encodeThenDecode() {
+        // given
+        StaccatoCursor original = new StaccatoCursor(
+                42L,
+                LocalDateTime.of(2025, 7, 12, 0, 0, 0),
+                LocalDateTime.of(2025, 7, 12, 0, 0, 0)
+        );
+
+        // when
+        String encoded = original.encode();
+        StaccatoCursor decoded = StaccatoCursor.fromEncoded(encoded);
+
+        // then
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("Base64 인코딩이 아닌 평문 커서는 decode 시 예외를 던진다")
+    void cannotDecodePlainText() {
+        // given
+        String plainText = "42|2025-07-12T23:45:00|2025-07-12T23:00:00";
+
+        // when & then
+        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(plainText))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining(plainText);
+    }
+
+    @Test
+    @DisplayName("필드 수가 3개가 아닌 경우 decode 시 예외를 던진다")
+    void cannotDecodeWrongFieldCount() {
+        // given
+        String encoded = encodeBase64("42|2025-07-12T23:45:00");
+
+        // when & then
+        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining(encoded);
+    }
+
+    @Test
+    @DisplayName("id 값이 숫자가 아닌 경우 decode 시 예외를 던진다")
+    void cannotDecodeInvalidId() {
+        // given
+        String raw = "abc|2025-07-12T23:45:00|2025-07-12T23:00:00";
+        String encoded = encodeBase64(raw);
+
+        // when & then
+        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining(encoded);
+    }
+
+    @Test
+    @DisplayName("visitedAt 필드의 날짜 형식이 잘못된 경우 decode 시 예외를 던진다")
+    void cannotDecodeInvalidVisitedAt() {
+        // given
+        String raw = "42|invalid-date|2025-07-12T23:00:00";
+        String encoded = encodeBase64(raw);
+
+        // when & then
+        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining(encoded);
+    }
+
+    @Test
+    @DisplayName("createdAt 필드의 날짜 형식이 잘못된 경우 decode 시 예외를 던진다")
+    void cannotDecodeInvalidCreatedAt() {
+        // given
+        String raw = "42|2025-07-12T23:45:00|invalid-created";
+        String encoded = encodeBase64(raw);
+
+        // when
+        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
+                .isInstanceOf(StaccatoException.class)
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining(encoded);
+    }
+
+    private String encodeBase64(String raw) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString(raw.getBytes());
+    }
+}

--- a/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
+++ b/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
@@ -20,7 +20,6 @@ class StaccatoCursorTest {
         // given
         StaccatoCursor original = new StaccatoCursor(
                 42L,
-                LocalDateTime.of(2025, 7, 12, 0, 0, 0),
                 LocalDateTime.of(2025, 7, 12, 0, 0, 0)
         );
 
@@ -129,7 +128,6 @@ class StaccatoCursorTest {
         // given
         StaccatoCursor cursor = new StaccatoCursor(
                 1L,
-                LocalDateTime.of(2025, 7, 15, 12, 0),
                 LocalDateTime.of(2025, 7, 15, 12, 0)
         );
 

--- a/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
+++ b/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
@@ -4,14 +4,18 @@ import java.time.LocalDateTime;
 import java.util.Base64;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EmptySource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import com.staccato.exception.StaccatoException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StaccatoCursorTest {
-    @Test
     @DisplayName("정상적인 커서는 encode 후 decode 시 동일한 값으로 복원된다")
+    @Test
     void encodeThenDecode() {
         // given
         StaccatoCursor original = new StaccatoCursor(
@@ -28,8 +32,8 @@ class StaccatoCursorTest {
         assertThat(decoded).isEqualTo(original);
     }
 
-    @Test
     @DisplayName("Base64 인코딩이 아닌 평문 커서는 decode 시 예외를 던진다")
+    @Test
     void cannotDecodePlainText() {
         // given
         String plainText = "42|2025-07-12T23:45:00|2025-07-12T23:00:00";
@@ -41,8 +45,8 @@ class StaccatoCursorTest {
                 .hasMessageContaining(plainText);
     }
 
-    @Test
     @DisplayName("필드 수가 3개가 아닌 경우 decode 시 예외를 던진다")
+    @Test
     void cannotDecodeWrongFieldCount() {
         // given
         String encoded = encodeBase64("42|2025-07-12T23:45:00");
@@ -54,8 +58,8 @@ class StaccatoCursorTest {
                 .hasMessageContaining(encoded);
     }
 
-    @Test
     @DisplayName("id 값이 숫자가 아닌 경우 decode 시 예외를 던진다")
+    @Test
     void cannotDecodeInvalidId() {
         // given
         String raw = "abc|2025-07-12T23:45:00|2025-07-12T23:00:00";
@@ -68,8 +72,8 @@ class StaccatoCursorTest {
                 .hasMessageContaining(encoded);
     }
 
-    @Test
     @DisplayName("visitedAt 필드의 날짜 형식이 잘못된 경우 decode 시 예외를 던진다")
+    @Test
     void cannotDecodeInvalidVisitedAt() {
         // given
         String raw = "42|invalid-date|2025-07-12T23:00:00";
@@ -82,8 +86,8 @@ class StaccatoCursorTest {
                 .hasMessageContaining(encoded);
     }
 
-    @Test
     @DisplayName("createdAt 필드의 날짜 형식이 잘못된 경우 decode 시 예외를 던진다")
+    @Test
     void cannotDecodeInvalidCreatedAt() {
         // given
         String raw = "42|2025-07-12T23:45:00|invalid-created";
@@ -94,6 +98,56 @@ class StaccatoCursorTest {
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
                 .hasMessageContaining(encoded);
+    }
+
+    @DisplayName("커서 값이 없거나 공백이면 empty()를 반환한다")
+    @ParameterizedTest
+    @NullSource
+    @EmptySource
+    @ValueSource(strings = {" "})
+    void nullOrBlankCursorReturnsEmpty(String cursor) {
+        // when
+        StaccatoCursor result = StaccatoCursor.fromEncoded(cursor);
+
+        // then
+        assertThat(result).isEqualTo(StaccatoCursor.empty());
+    }
+
+    @DisplayName("EMPTY 커서는 isEmpty()가 true를 반환한다")
+    @Test
+    void isEmptyTrueWhenEmptyCursor() {
+        // given
+        StaccatoCursor emptyCursor = StaccatoCursor.empty();
+
+        // when & then
+        assertThat(emptyCursor.isEmpty()).isTrue();
+    }
+
+    @DisplayName("일반 커서는 isEmpty()가 false를 반환한다")
+    @Test
+    void isEmptyFalseWhenNotEmpty() {
+        // given
+        StaccatoCursor cursor = new StaccatoCursor(
+                1L,
+                LocalDateTime.of(2025, 7, 15, 12, 0),
+                LocalDateTime.of(2025, 7, 15, 12, 0)
+        );
+
+        // when & then
+        assertThat(cursor.isEmpty()).isFalse();
+    }
+
+    @DisplayName("빈 커서는 encode() 시 null을 반환한다")
+    @Test
+    void encodeEmptyCursorReturnsNull() {
+        // given
+        StaccatoCursor cursor = StaccatoCursor.empty();
+
+        // when
+        String encoded = cursor.encode();
+
+        // then
+        assertThat(encoded).isNull();
     }
 
     private String encodeBase64(String raw) {

--- a/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
+++ b/backend/src/test/java/com/staccato/category/service/StaccatoCursorTest.java
@@ -35,25 +35,25 @@ class StaccatoCursorTest {
     @Test
     void cannotDecodePlainText() {
         // given
-        String plainText = "42|2025-07-12T23:45:00|2025-07-12T23:00:00";
+        String plainText = "42|2025-07-12T23:45:00";
 
         // when & then
         assertThatThrownBy(() -> StaccatoCursor.fromEncoded(plainText))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: ")
                 .hasMessageContaining(plainText);
     }
 
-    @DisplayName("필드 수가 3개가 아닌 경우 decode 시 예외를 던진다")
+    @DisplayName("필드 수가 2개가 아닌 경우 decode 시 예외를 던진다")
     @Test
     void cannotDecodeWrongFieldCount() {
         // given
-        String encoded = encodeBase64("42|2025-07-12T23:45:00");
+        String encoded = encodeBase64("42|2025-07-12T23:45:00|2025-07-12T23:45:00");
 
         // when & then
         assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: ")
                 .hasMessageContaining(encoded);
     }
 
@@ -61,13 +61,13 @@ class StaccatoCursorTest {
     @Test
     void cannotDecodeInvalidId() {
         // given
-        String raw = "abc|2025-07-12T23:45:00|2025-07-12T23:00:00";
+        String raw = "abc|2025-07-12T23:45:00";
         String encoded = encodeBase64(raw);
 
         // when & then
         assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: ")
                 .hasMessageContaining(encoded);
     }
 
@@ -75,27 +75,13 @@ class StaccatoCursorTest {
     @Test
     void cannotDecodeInvalidVisitedAt() {
         // given
-        String raw = "42|invalid-date|2025-07-12T23:00:00";
+        String raw = "42|invalid-date";
         String encoded = encodeBase64(raw);
 
         // when & then
         assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
                 .isInstanceOf(StaccatoException.class)
-                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
-                .hasMessageContaining(encoded);
-    }
-
-    @DisplayName("createdAt 필드의 날짜 형식이 잘못된 경우 decode 시 예외를 던진다")
-    @Test
-    void cannotDecodeInvalidCreatedAt() {
-        // given
-        String raw = "42|2025-07-12T23:45:00|invalid-created";
-        String encoded = encodeBase64(raw);
-
-        // when
-        assertThatThrownBy(() -> StaccatoCursor.fromEncoded(encoded))
-                .isInstanceOf(StaccatoException.class)
-                .hasMessageContaining("주어진 커서 포멧(id|visitedAt|createdAt)이 올바르지 않아요: ")
+                .hasMessageContaining("주어진 커서 포멧(id|visitedAt)이 올바르지 않아요: ")
                 .hasMessageContaining(encoded);
     }
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -332,7 +332,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
             Staccato firstStaccato = staccatos.get(0);
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
                     firstStaccato.getId(),
                     firstStaccato.getVisitedAt(),
@@ -349,80 +349,86 @@ class StaccatoRepositoryTest extends RepositoryTest {
         @Test
         void readStaccatosOrderByVisitedAtDesc() {
             // given
-            Staccato firstStaccato = staccatos.get(0);
+            Staccato cursorStaccato = staccatos.get(0);
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    firstStaccato.getId(),
-                    firstStaccato.getVisitedAt(),
-                    firstStaccato.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     4
             );
 
             // then
-            assertThat(result).hasSize(3)
-                    .containsExactly(staccatos.get(0), staccatos.get(1), staccatos.get(2));
+            assertThat(result).hasSize(2)
+                    .containsExactly(staccatos.get(1), staccatos.get(2));
         }
 
         @DisplayName("방문 날짜가 동일하면 생성 날짜 기준 최신순으로 정렬해서 조회한다.")
         @Test
         void readStaccatosOrderByCreatedAtDesc() {
             // given
-            Staccato first = StaccatoFixtures.defaultStaccato()
-                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                    .withCategory(category).buildAndSave(staccatoRepository);
-            Staccato second = StaccatoFixtures.defaultStaccato()
-                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                    .withCategory(category).buildAndSave(staccatoRepository);
+            Staccato cursorStaccato = staccatos.get(0);
+
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    second.getId(),
-                    second.getVisitedAt(),
-                    second.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     2
             );
 
             // then
-            assertThat(result).containsExactly(second, first);
+            assertThat(result).containsExactly(staccatos.get(1), staccatos.get(2));
         }
 
         @DisplayName("주어진 limit 개수 만큼을 조회한다.")
         @Test
         void readStaccatosAsMuchAsLimit() {
             // given
-            Staccato firstStaccato = staccatos.get(0);
+            Staccato cursorStaccato = staccatos.get(0);
             int limit = 2;
+            System.out.println("Cursor:");
+            System.out.println("ID: " + cursorStaccato.getId());
+            System.out.println("visitedAt: " + cursorStaccato.getVisitedAt());
+            System.out.println("createdAt: " + cursorStaccato.getCreatedAt());
+
+            System.out.println("---- All Staccatos ----");
+            staccatos.forEach(s -> System.out.println(
+                    "ID: " + s.getId() +
+                    " | visitedAt: " + s.getVisitedAt() +
+                    " | createdAt: " + s.getCreatedAt()));
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    firstStaccato.getId(),
-                    firstStaccato.getVisitedAt(),
-                    firstStaccato.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     limit
             );
 
             // then
             assertThat(result).hasSize(2)
-                    .containsExactly(staccatos.get(0), staccatos.get(1));
+                    .containsExactly(staccatos.get(1), staccatos.get(2));
         }
 
         @DisplayName("존재하는 데이터보다 많은 개수를 요구하면 존재하는 데이터 수만큼만 조회한다.")
         @Test
         void readStaccatosAsMuchAsExists() {
             // given
-            Staccato firstStaccato = staccatos.get(0);
+            Staccato cursorStaccato = staccatos.get(0);
             int limit = 100;
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    firstStaccato.getId(),
-                    firstStaccato.getVisitedAt(),
-                    firstStaccato.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     limit
             );
 
@@ -430,25 +436,25 @@ class StaccatoRepositoryTest extends RepositoryTest {
             assertThat(result).hasSize(2);
         }
 
-        @DisplayName("카테고리 내 스타카토 목록을 주어진 범위부터 조회한다.")
+        @DisplayName("카테고리 내 스타카토 목록을 주어진 커서 다음부터 조회한다.")
         @Test
         void readStaccatosFromCursor() {
             // given
-            Staccato secondStaccato = staccatos.get(1);
+            Staccato cursorStaccato = staccatos.get(1);
             int limit = 4;
 
             // when
-            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    secondStaccato.getId(),
-                    secondStaccato.getVisitedAt(),
-                    secondStaccato.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     limit
             );
 
             // then
-            assertThat(result).hasSize(2)
-                    .containsExactly(staccatos.get(1), staccatos.get(2));
+            assertThat(result).hasSize(1)
+                    .containsExactly(staccatos.get(2));
         }
     }
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -329,19 +329,19 @@ class StaccatoRepositoryTest extends RepositoryTest {
             Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
             Staccato otherStaccato = StaccatoFixtures.defaultStaccato().withCategory(otherCategory)
                     .buildAndSave(staccatoRepository);
-            Staccato firstStaccato = staccatos.get(0);
+            Staccato cursorStaccato = staccatos.get(0);
 
             // when
             List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
                     category.getId(),
-                    firstStaccato.getId(),
-                    firstStaccato.getVisitedAt(),
-                    firstStaccato.getCreatedAt(),
+                    cursorStaccato.getId(),
+                    cursorStaccato.getVisitedAt(),
+                    cursorStaccato.getCreatedAt(),
                     4
             );
 
             // then
-            assertThat(result).hasSize(3)
+            assertThat(result).hasSize(2)
                     .doesNotContain(otherStaccato);
         }
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -243,7 +243,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
         );
     }
 
-    @DisplayName("사용자의 스타카토 방문 날짜가 동일하다면, 생성날짜 기준 최신순으로 조회한다.")
+    @DisplayName("사용자의 스타카토 방문 날짜가 동일하다면, id 기준 내림차순으로 조회한다.")
     @Test
     void findAllByCategoryIdOrderByCreatedAt() {
         // given
@@ -318,7 +318,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
             }
             staccatos.sort(
                     Comparator.comparing(Staccato::getVisitedAt).reversed()
-                            .thenComparing(Comparator.comparing(Staccato::getCreatedAt).reversed())
+                            .thenComparing(Comparator.comparing(Staccato::getId).reversed())
             );
         }
 
@@ -368,7 +368,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
         void readStaccatosOrderByCreatedAtDesc() {
             // given
             Staccato cursorStaccato = staccatos.get(0);
-
 
             // when
             List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(
@@ -478,7 +477,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
             }
             staccatos.sort(
                     Comparator.comparing(Staccato::getVisitedAt).reversed()
-                            .thenComparing(Comparator.comparing(Staccato::getCreatedAt).reversed())
+                            .thenComparing(Comparator.comparing(Staccato::getId).reversed())
             );
         }
 
@@ -509,7 +508,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     .containsExactly(staccatos.get(0), staccatos.get(1), staccatos.get(2));
         }
 
-        @DisplayName("방문 날짜가 동일하면 생성 날짜 기준 최신순으로 정렬해서 조회한다.")
+        @DisplayName("방문 날짜가 동일하면 id 기준 내림차순으로 정렬해서 조회한다.")
         @Test
         void readStaccatosOrderByCreatedAtDesc() {
             // given

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -2,6 +2,8 @@ package com.staccato.staccato.repository;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -288,5 +290,142 @@ class StaccatoRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(result).isEqualTo(result);
+    }
+
+    @Nested
+    @DisplayName("카테고리 내 스타카토 목록을 일정 개수만큼 조회 시")
+    class readStaccatosInPage {
+        private Member member;
+        private Category category;
+        private List<Staccato> staccatos;
+
+        @BeforeEach
+        void setUp() {
+            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+            category = CategoryFixtures.defaultCategory()
+                    .withTerm(null, null)
+                    .withHost(member)
+                    .buildAndSave(categoryRepository);
+            staccatos = new ArrayList<>();
+            for (int count = 1; count <= 3; count++) {
+                staccatos.add(StaccatoFixtures.defaultStaccato()
+                        .withCategory(category)
+                        .withCreator(member)
+                        .withTitle("staccato " + count)
+                        .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
+                        .buildAndSave(staccatoRepository)
+                );
+            }
+            staccatos.sort(Comparator.comparing(Staccato::getVisitedAt).reversed());
+        }
+
+        @DisplayName("카테고리 내 스타카토만 조회된다.")
+        @Test
+        void readStaccatosByCategoryId() {
+            // given
+            Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
+            Staccato otherStaccato = StaccatoFixtures.defaultStaccato().withCategory(otherCategory)
+                    .buildAndSave(staccatoRepository);
+            Staccato firstStaccato = staccatos.get(0);
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    firstStaccato.getId(),
+                    firstStaccato.getVisitedAt(),
+                    firstStaccato.getCreatedAt(),
+                    4
+            );
+
+            // then
+            assertThat(result).hasSize(3)
+                    .doesNotContain(otherStaccato);
+        }
+
+        @DisplayName("방문 날짜 기준 최신순으로 정렬해서 조회한다.")
+        @Test
+        void readStaccatosOrderByVisitedAtDesc() {
+            // given
+            Staccato firstStaccato = staccatos.get(0);
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    firstStaccato.getId(),
+                    firstStaccato.getVisitedAt(),
+                    firstStaccato.getCreatedAt(),
+                    4
+            );
+
+            // then
+            assertThat(result).hasSize(3)
+                    .containsExactly(staccatos.get(0), staccatos.get(1), staccatos.get(2));
+        }
+
+        @DisplayName("방문 날짜가 동일하면 생성 날짜 기준 최신순으로 정렬해서 조회한다.")
+        @Test
+        void readStaccatosOrderByCreatedAtDesc() {
+            // given
+            Staccato first = StaccatoFixtures.defaultStaccato()
+                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
+                    .withCategory(category).buildAndSave(staccatoRepository);
+            Staccato second = StaccatoFixtures.defaultStaccato()
+                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
+                    .withCategory(category).buildAndSave(staccatoRepository);
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    second.getId(),
+                    second.getVisitedAt(),
+                    second.getCreatedAt(),
+                    2
+            );
+
+            // then
+            assertThat(result).containsExactly(second, first);
+        }
+
+        @DisplayName("주어진 limit 개수 만큼을 조회한다.")
+        @Test
+        void readStaccatosAsMuchAsLimit() {
+            // given
+            Staccato firstStaccato = staccatos.get(0);
+            int limit = 2;
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    firstStaccato.getId(),
+                    firstStaccato.getVisitedAt(),
+                    firstStaccato.getCreatedAt(),
+                    limit
+            );
+
+            // then
+            assertThat(result).hasSize(2)
+                    .containsExactly(staccatos.get(0), staccatos.get(1));
+        }
+
+        @DisplayName("카테고리 내 스타카토 목록을 주어진 범위부터 조회한다.")
+        @Test
+        void readStaccatosFromCursor() {
+            // given
+            Staccato secondStaccato = staccatos.get(1);
+            int limit = 4;
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    secondStaccato.getId(),
+                    secondStaccato.getVisitedAt(),
+                    secondStaccato.getCreatedAt(),
+                    limit
+            );
+
+            // then
+            assertThat(result).hasSize(2)
+                    .containsExactly(staccatos.get(1), staccatos.get(2));
+        }
     }
 }

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -387,16 +387,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
             // given
             Staccato cursorStaccato = staccatos.get(0);
             int limit = 2;
-            System.out.println("Cursor:");
-            System.out.println("ID: " + cursorStaccato.getId());
-            System.out.println("visitedAt: " + cursorStaccato.getVisitedAt());
-            System.out.println("createdAt: " + cursorStaccato.getCreatedAt());
-
-            System.out.println("---- All Staccatos ----");
-            staccatos.forEach(s -> System.out.println(
-                    "ID: " + s.getId() +
-                    " | visitedAt: " + s.getVisitedAt() +
-                    " | createdAt: " + s.getCreatedAt()));
 
             // when
             List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdAfterCursor(

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -336,7 +336,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     4
             );
 
@@ -356,7 +355,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     4
             );
 
@@ -377,7 +375,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     2
             );
 
@@ -407,7 +404,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     limit
             );
 
@@ -428,7 +424,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     limit
             );
 
@@ -448,7 +443,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     category.getId(),
                     cursorStaccato.getId(),
                     cursorStaccato.getVisitedAt(),
-                    cursorStaccato.getCreatedAt(),
                     limit
             );
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -316,7 +316,10 @@ class StaccatoRepositoryTest extends RepositoryTest {
                         .buildAndSave(staccatoRepository)
                 );
             }
-            staccatos.sort(Comparator.comparing(Staccato::getVisitedAt).reversed());
+            staccatos.sort(
+                    Comparator.comparing(Staccato::getVisitedAt).reversed()
+                            .thenComparing(Comparator.comparing(Staccato::getCreatedAt).reversed())
+            );
         }
 
         @DisplayName("카테고리 내 스타카토만 조회된다.")
@@ -407,6 +410,26 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     .containsExactly(staccatos.get(0), staccatos.get(1));
         }
 
+        @DisplayName("존재하는 데이터보다 많은 개수를 요구하면 존재하는 데이터 수만큼만 조회한다.")
+        @Test
+        void readStaccatosAsMuchAsExists() {
+            // given
+            Staccato firstStaccato = staccatos.get(0);
+            int limit = 100;
+
+            // when
+            List<Staccato> result = staccatoRepository.findStaccatosByCategoryIdFromCursor(
+                    category.getId(),
+                    firstStaccato.getId(),
+                    firstStaccato.getVisitedAt(),
+                    firstStaccato.getCreatedAt(),
+                    limit
+            );
+
+            // then
+            assertThat(result).hasSize(2);
+        }
+
         @DisplayName("카테고리 내 스타카토 목록을 주어진 범위부터 조회한다.")
         @Test
         void readStaccatosFromCursor() {
@@ -426,6 +449,109 @@ class StaccatoRepositoryTest extends RepositoryTest {
             // then
             assertThat(result).hasSize(2)
                     .containsExactly(staccatos.get(1), staccatos.get(2));
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 목록의 첫 페이지를 조회 시")
+    class readStaccatosInFirstPage {
+        private Member member;
+        private Category category;
+        private List<Staccato> staccatos;
+
+        @BeforeEach
+        void setUp() {
+            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+            category = CategoryFixtures.defaultCategory()
+                    .withTerm(null, null)
+                    .withHost(member)
+                    .buildAndSave(categoryRepository);
+            staccatos = new ArrayList<>();
+            for (int count = 1; count <= 3; count++) {
+                staccatos.add(StaccatoFixtures.defaultStaccato()
+                        .withCategory(category)
+                        .withCreator(member)
+                        .withTitle("staccato " + count)
+                        .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
+                        .buildAndSave(staccatoRepository)
+                );
+            }
+            staccatos.sort(
+                    Comparator.comparing(Staccato::getVisitedAt).reversed()
+                            .thenComparing(Comparator.comparing(Staccato::getCreatedAt).reversed())
+            );
+        }
+
+        @DisplayName("카테고리 내 스타카토만 조회된다.")
+        @Test
+        void readStaccatosByCategoryId() {
+            // given
+            Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
+            Staccato otherStaccato = StaccatoFixtures.defaultStaccato().withCategory(otherCategory)
+                    .buildAndSave(staccatoRepository);
+
+            // when
+            List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), 4);
+
+            // then
+            assertThat(result).hasSize(3)
+                    .doesNotContain(otherStaccato);
+        }
+
+        @DisplayName("방문 날짜 기준 최신순으로 정렬해서 조회한다.")
+        @Test
+        void readStaccatosOrderByVisitedAtDesc() {
+            // when
+            List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), 4);
+
+            // then
+            assertThat(result).hasSize(3)
+                    .containsExactly(staccatos.get(0), staccatos.get(1), staccatos.get(2));
+        }
+
+        @DisplayName("방문 날짜가 동일하면 생성 날짜 기준 최신순으로 정렬해서 조회한다.")
+        @Test
+        void readStaccatosOrderByCreatedAtDesc() {
+            // given
+            Staccato first = StaccatoFixtures.defaultStaccato()
+                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
+                    .withCategory(category).buildAndSave(staccatoRepository);
+            Staccato second = StaccatoFixtures.defaultStaccato()
+                    .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
+                    .withCategory(category).buildAndSave(staccatoRepository);
+
+            // when
+            List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), 2);
+
+            // then
+            assertThat(result).containsExactly(second, first);
+        }
+
+        @DisplayName("주어진 limit 개수 만큼을 조회한다.")
+        @Test
+        void readStaccatosAsMuchAsLimit() {
+            // given
+            int limit = 2;
+
+            // when
+            List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), limit);
+
+            // then
+            assertThat(result).hasSize(2)
+                    .containsExactly(staccatos.get(0), staccatos.get(1));
+        }
+
+        @DisplayName("존재하는 데이터보다 많은 개수를 요구하면 존재하는 데이터 수만큼만 조회한다.")
+        @Test
+        void readStaccatosAsMuchAsExists() {
+            // given
+            int limit = 100;
+
+            // when
+            List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), limit);
+
+            // then
+            assertThat(result).hasSize(3);
         }
     }
 }


### PR DESCRIPTION
## ⭐️ Issue Number
- #966 

## 🚩 Summary
- 카테고리 내 스타카토 목록 조회 시 커서 기반 페이지네이션을 합니다.
- 주어진 커서가 없다면 첫 페이지를 조회합니다.
- 응답으로 마지막 요소로 nextCursor를 제공합니다.
- 조회 시 주어진 Cursor 다음 값부터 조회합니다.
- 카테고리 내 스타카토 목록 조회가 `/categories` 내부에서 함께 이루어졌는데, 성능 개선 목적으로 API를 분리합니다. 자세한 내용은 이슈를 참고해주세요.

## 🛠️ Technical Concerns
- createdAt으로 인해 테스트 반복성이 보장되고 있지 않습니다...
- 슬랙으로 제안했던 아이디어를 적용해보며 createdAt에 의존한 테스트 신뢰도 개선이 필요할 듯 합니다.

<img width="953" height="370" alt="image" src="https://github.com/user-attachments/assets/57d6c2e4-9680-48c2-aef8-e973cf9c10be" />

- 커서 필드에서 **createdAt을 사용하지 않기로 결정했습니다**
  - `createdAt`과 id는 항상 동일한 생성 순서를 갖는 필드입니다.
  - `createdAt`은 데이터 생성 시점에 `LocalDateTime.now()`로 기록되며, id는 AUTO_INCREMENT로 할당되기 때문에, 두 값은 사실상 동일한 정렬 순서를 보장합니다.
  - 따라서 정렬 및 커서 기준으로 id 하나만으로 충분하다고 판단했습니다. 또한 id는 단조 증가하는 정수값이므로 커서로 사용하기에 더 간결하고 비교도 빠릅니다.
  - 즉, visitedAt DESC, id DESC로도 기존의 visitedAt DESC, createdAt DESC, id DESC와 동일한 정렬 순서를 재현할 수 있습니다.
- **물론, DB의 식별자 생성 전략에 의존적이라는 우려 사항도 있습니다.**
  - 하지만, DB 식별자 생성 전략이 변경될 가능성은 거의 없다고 생각하였고, 따라서 이 우려 사항보다는 createdAt과 동일한 정렬 효과를 id 만으로 낼 수 있다는 점이 더 매력적으로 다가왔습니다.


## 🙂 To Reviewer


## 📋 To Do
