### PR TITLE
refactor: textFixture 리팩토링 #984

### DIFF
--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerTest.java
@@ -27,7 +27,7 @@ class AuthControllerTest extends ControllerTest {
     @Test
     void login() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("staccato").build();
+        Member member = MemberFixtures.ofDefault().withNickname("staccato").build();
         String loginRequest = """
                 {
                     "nickname": "staccato"
@@ -55,7 +55,7 @@ class AuthControllerTest extends ControllerTest {
     @NullSource
     void cannotLoginIfNicknameTooShort(String nickname) throws Exception {
         // given
-        LoginRequest loginRequest = LoginRequestFixtures.defaultLoginRequest()
+        LoginRequest loginRequest = LoginRequestFixtures.ofDefault()
                 .withNickname(nickname).build();
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "닉네임을 입력해주세요.");
 
@@ -72,7 +72,7 @@ class AuthControllerTest extends ControllerTest {
     void findMemberByCodeAndCreateToken() throws Exception {
         // given
         String code = UUID.randomUUID().toString();
-        Member member = MemberFixtures.defaultMember().withCode(code).build();
+        Member member = MemberFixtures.ofDefault().withCode(code).build();
         LoginResponseV2 loginResponse = new LoginResponseV2(member, "token");
         when(authService.loginByCode(any(String.class))).thenReturn(loginResponse);
         String response = """

--- a/backend/src/test/java/com/staccato/auth/controller/AuthControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/auth/controller/AuthControllerV2Test.java
@@ -27,7 +27,7 @@ class AuthControllerV2Test extends ControllerTest {
     @Test
     void login() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("staccato").build();
+        Member member = MemberFixtures.ofDefault().withNickname("staccato").build();
         String loginRequest = """
                 {
                     "nickname": "staccato"
@@ -56,7 +56,7 @@ class AuthControllerV2Test extends ControllerTest {
     @NullSource
     void cannotLoginIfNicknameTooShort(String nickname) throws Exception {
         // given
-        LoginRequest loginRequest = LoginRequestFixtures.defaultLoginRequest()
+        LoginRequest loginRequest = LoginRequestFixtures.ofDefault()
                 .withNickname(nickname).build();
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "닉네임을 입력해주세요.");
 
@@ -73,7 +73,7 @@ class AuthControllerV2Test extends ControllerTest {
     void findMemberByCodeAndCreateToken() throws Exception {
         // given
         String code = UUID.randomUUID().toString();
-        Member member = MemberFixtures.defaultMember().withCode(code).build();
+        Member member = MemberFixtures.ofDefault().withCode(code).build();
         LoginResponseV2 loginResponse = new LoginResponseV2(member, "token");
         when(authService.loginByCode(any(String.class))).thenReturn(loginResponse);
         String response = """

--- a/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/staccato/auth/service/AuthServiceTest.java
@@ -35,7 +35,7 @@ class AuthServiceTest extends ServiceSliceTest {
     @Test
     void login() {
         // given
-        LoginRequest loginRequest = LoginRequestFixtures.defaultLoginRequest().build();
+        LoginRequest loginRequest = LoginRequestFixtures.ofDefault().build();
 
         // when
         LoginResponseV2 loginResponse = authService.login(loginRequest);
@@ -51,7 +51,7 @@ class AuthServiceTest extends ServiceSliceTest {
     @Test
     void loginThenCreateBasicCategory() {
         // given
-        LoginRequest loginRequest = LoginRequestFixtures.defaultLoginRequest().build();
+        LoginRequest loginRequest = LoginRequestFixtures.ofDefault().build();
 
         // when
         LoginResponseV2 loginResponse = authService.login(loginRequest);
@@ -68,9 +68,9 @@ class AuthServiceTest extends ServiceSliceTest {
     @Test
     void cannotLoginByDuplicated() {
         // given
-        MemberFixtures.defaultMember()
+        MemberFixtures.ofDefault()
                 .withNickname("nickname").buildAndSave(memberRepository);
-        LoginRequest loginRequest = LoginRequestFixtures.defaultLoginRequest()
+        LoginRequest loginRequest = LoginRequestFixtures.ofDefault()
                 .withNickname("nickname").build();
 
         // when & then
@@ -83,7 +83,7 @@ class AuthServiceTest extends ServiceSliceTest {
     @Test
     void cannotExtractMemberByUnknown() {
         // given
-        MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
         // when & then
         assertThatThrownBy(() -> authService.extractFromToken(null))
@@ -96,7 +96,7 @@ class AuthServiceTest extends ServiceSliceTest {
     void createTokenByCode() {
         // given
         String code = UUID.randomUUID().toString();
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withCode(code).buildAndSave(memberRepository);
 
         // when

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -60,8 +60,7 @@ class CategoryControllerTest extends ControllerTest {
                 CategoryRequestFixtures.defaultCategoryRequest()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryRequestFixtures.defaultCategoryRequest()
-                        .withTerm(null, null).build()
+                CategoryRequestFixtures.defaultCategoryRequest().build()
         );
     }
 
@@ -182,7 +181,7 @@ class CategoryControllerTest extends ControllerTest {
                         LocalDate.of(2024, 12, 31)).build();
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
-                .withTerm(null, null).build();
+                .build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
                 new CategoryResponseV3(categoryWithoutTerm, 0))
@@ -343,8 +342,6 @@ class CategoryControllerTest extends ControllerTest {
                     "categoryId": null,
                     "categoryThumbnailUrl": "https://example.com/categoryThumbnail.jpg",
                     "categoryTitle": "categoryTitle",
-                    "startAt": "2024-01-01",
-                    "endAt": "2024-12-31",
                     "description": "categoryDescription",
                     "mates": [
                         {
@@ -380,7 +377,6 @@ class CategoryControllerTest extends ControllerTest {
         Member member = MemberFixtures.defaultMember().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .withHost(member)
                 .build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -332,8 +332,7 @@ class CategoryControllerTest extends ControllerTest {
         Member member = MemberFixtures.defaultMember().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category = CategoryFixtures.defaultCategory().withHost(member).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -379,8 +378,7 @@ class CategoryControllerTest extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -422,13 +420,11 @@ class CategoryControllerTest extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
         CategoryStaccatoLocationResponse response1 = new CategoryStaccatoLocationResponse(
-                StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                StaccatoFixtures.defaultStaccato(category)
                         .withSpot(BigDecimal.ZERO, BigDecimal.ZERO).build()
         );
         CategoryStaccatoLocationResponse response2 = new CategoryStaccatoLocationResponse(
-                StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                StaccatoFixtures.defaultStaccato(category)
                         .withSpot(new BigDecimal("80.456789"), new BigDecimal("123.456789")).build()
         );
         CategoryStaccatoLocationResponses responses = new CategoryStaccatoLocationResponses(List.of(response1, response2));
@@ -470,8 +466,7 @@ class CategoryControllerTest extends ControllerTest {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
@@ -506,8 +501,7 @@ class CategoryControllerTest extends ControllerTest {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
@@ -527,8 +521,7 @@ class CategoryControllerTest extends ControllerTest {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerTest.java
@@ -57,19 +57,19 @@ class CategoryControllerTest extends ControllerTest {
 
     static Stream<CategoryRequest> categoryRequestProvider() {
         return Stream.of(
-                CategoryRequestFixtures.defaultCategoryRequest()
+                CategoryRequestFixtures.ofDefault()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryRequestFixtures.defaultCategoryRequest().build()
+                CategoryRequestFixtures.ofDefault().build()
         );
     }
 
     static Stream<Arguments> invalidCategoryRequestProvider() {
         return Stream.of(
-                Arguments.of(CategoryRequestFixtures.defaultCategoryRequest()
+                Arguments.of(CategoryRequestFixtures.ofDefault()
                                 .withCategoryTitle(null).build(),
                         "카테고리 제목을 입력해주세요."),
-                Arguments.of(CategoryRequestFixtures.defaultCategoryRequest()
+                Arguments.of(CategoryRequestFixtures.ofDefault()
                                 .withCategoryTitle("  ").build(),
                         "카테고리 제목을 입력해주세요.")
         );
@@ -79,7 +79,7 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void createCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -110,7 +110,7 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void createCategoryWithoutTerm() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -140,7 +140,7 @@ class CategoryControllerTest extends ControllerTest {
     @MethodSource("categoryRequestProvider")
     void createCategoryWithoutOption(CategoryRequest categoryRequest) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(categoryService.createCategory(any(), any())).thenReturn(new CategoryIdResponse(1));
 
         // when & then
@@ -158,7 +158,7 @@ class CategoryControllerTest extends ControllerTest {
     @MethodSource("invalidCategoryRequestProvider")
     void failCreateCategory(CategoryRequest categoryRequest, String expectedMessage) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
         // when & then
@@ -174,12 +174,12 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void readAllCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category categoryWithTerm = CategoryFixtures.defaultCategory()
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category categoryWithTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.PINK)
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
+        Category categoryWithoutTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.BLUE)
                 .build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
@@ -217,10 +217,10 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void readAllCategoryIgnoringInvalidFilter() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category1 = CategoryFixtures.defaultCategory().build();
-        Category category2 = CategoryFixtures.defaultCategory().build();
+        Category category1 = CategoryFixtures.ofDefault().build();
+        Category category2 = CategoryFixtures.ofDefault().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
                 new CategoryResponseV3(category2, 0))
@@ -239,8 +239,8 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void readAllCandidateCategoriesIncludingDate() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().build();
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().build();
         CategoryNameResponses categoryNameResponses = CategoryNameResponses.from(List.of(category));
         when(categoryService.readAllCategoriesByMemberAndDateAndPrivateFlag(any(Member.class), any(), any(Boolean.class))).thenReturn(categoryNameResponses);
         String expectedResponse = """
@@ -267,7 +267,7 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void cannotReadAllCandidateCategoriesWithoutSpecificDate() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "필수 요청 파라미터가 누락되었습니다. 필요한 파라미터를 제공해주세요.");
 
         // when & then
@@ -282,7 +282,7 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void canReadAllCandidateCategoriesWithoutIsPrivate() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(get("/categories/candidates")
@@ -296,7 +296,7 @@ class CategoryControllerTest extends ControllerTest {
     @ValueSource(strings = {"2024.07.01", "2024-07", "2024", "a"})
     void cannotReadAllCandidateCategoriesByInvalidDateFormat(String currentDate) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "올바르지 않은 쿼리 스트링 형식입니다.");
 
         // when & then
@@ -312,7 +312,7 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void cannotReadAllCandidateCategoriesByInvalidBooleanFormat() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "올바르지 않은 쿼리 스트링 형식입니다.");
 
         // when & then
@@ -329,10 +329,10 @@ class CategoryControllerTest extends ControllerTest {
     void readCategory() throws Exception {
         // given
         long categoryId = 1;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category = CategoryFixtures.defaultCategory().withHost(member).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().withHost(member).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -373,12 +373,12 @@ class CategoryControllerTest extends ControllerTest {
     void readCategoryWithoutTerm() throws Exception {
         // given
         long categoryId = 1;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -417,14 +417,14 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void readStaccatoLocationsByCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
         CategoryStaccatoLocationResponse response1 = new CategoryStaccatoLocationResponse(
-                StaccatoFixtures.defaultStaccato(category)
+                StaccatoFixtures.ofDefault(category)
                         .withSpot(BigDecimal.ZERO, BigDecimal.ZERO).build()
         );
         CategoryStaccatoLocationResponse response2 = new CategoryStaccatoLocationResponse(
-                StaccatoFixtures.defaultStaccato(category)
+                StaccatoFixtures.ofDefault(category)
                         .withSpot(new BigDecimal("80.456789"), new BigDecimal("123.456789")).build()
         );
         CategoryStaccatoLocationResponses responses = new CategoryStaccatoLocationResponses(List.of(response1, response2));
@@ -464,9 +464,9 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void readStaccatosByCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
@@ -499,9 +499,9 @@ class CategoryControllerTest extends ControllerTest {
     @ValueSource(ints = {0, 101})
     void cannotReadStaccatosByCategoryIfLimitOutOfBounds(int limit) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
@@ -519,9 +519,9 @@ class CategoryControllerTest extends ControllerTest {
     @Test
     void defaultLimitIsApplied() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryStaccatoResponses responses = CategoryStaccatoResponses.of(List.of(staccato), StaccatoCursor.empty());
 
@@ -550,7 +550,7 @@ class CategoryControllerTest extends ControllerTest {
     void updateCategory(CategoryRequest categoryRequest) throws Exception {
         // given
         long categoryId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(put("/categories/{categoryId}", categoryId)
@@ -566,7 +566,7 @@ class CategoryControllerTest extends ControllerTest {
     void failUpdateCategory(CategoryRequest categoryRequest, String expectedMessage) throws Exception {
         // given
         long categoryId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
         // when & then
@@ -584,7 +584,7 @@ class CategoryControllerTest extends ControllerTest {
     void failUpdateCategoryByInvalidPath(CategoryRequest categoryRequest) throws Exception {
         // given
         long categoryId = 0L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "카테고리 식별자는 양수로 이루어져야 합니다.");
 
         // when & then
@@ -601,7 +601,7 @@ class CategoryControllerTest extends ControllerTest {
     void deleteCategory() throws Exception {
         // given
         long categoryId = 1;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(delete("/categories/{categoryId}", categoryId)
@@ -628,7 +628,7 @@ class CategoryControllerTest extends ControllerTest {
     void deleteSelfFromCategory() throws Exception {
         // given
         long categoryId = 1;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(delete("/categories/{categoryId}/members/me", categoryId)

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -44,19 +44,19 @@ class CategoryControllerV2Test extends ControllerTest {
 
     static Stream<CategoryRequestV2> categoryRequestProvider() {
         return Stream.of(
-                CategoryRequestV2Fixtures.defaultCategoryRequestV2()
+                CategoryRequestV2Fixtures.ofDefault()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryRequestV2Fixtures.defaultCategoryRequestV2().build()
+                CategoryRequestV2Fixtures.ofDefault().build()
         );
     }
 
     static Stream<Arguments> invalidCategoryRequestProvider() {
         return Stream.of(
-                Arguments.of(CategoryRequestV2Fixtures.defaultCategoryRequestV2()
+                Arguments.of(CategoryRequestV2Fixtures.ofDefault()
                                 .withCategoryTitle(null).build(),
                         "카테고리 제목을 입력해주세요."),
-                Arguments.of(CategoryRequestV2Fixtures.defaultCategoryRequestV2()
+                Arguments.of(CategoryRequestV2Fixtures.ofDefault()
                                 .withCategoryTitle("  ").build(),
                         "카테고리 제목을 입력해주세요.")
         );
@@ -66,7 +66,7 @@ class CategoryControllerV2Test extends ControllerTest {
     @Test
     void createCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -98,7 +98,7 @@ class CategoryControllerV2Test extends ControllerTest {
     @Test
     void createCategoryWithoutTerm() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -129,7 +129,7 @@ class CategoryControllerV2Test extends ControllerTest {
     @MethodSource("categoryRequestProvider")
     void createCategoryWithoutOption(CategoryRequestV2 categoryRequest) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(categoryService.createCategory(any(), any())).thenReturn(new CategoryIdResponse(1));
 
         // when & then
@@ -147,7 +147,7 @@ class CategoryControllerV2Test extends ControllerTest {
     @MethodSource("invalidCategoryRequestProvider")
     void failCreateCategory(CategoryRequestV2 categoryRequest, String expectedMessage) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
         // when & then
@@ -163,12 +163,12 @@ class CategoryControllerV2Test extends ControllerTest {
     @Test
     void readAllCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category categoryWithTerm = CategoryFixtures.defaultCategory()
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category categoryWithTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.PINK)
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
+        Category categoryWithoutTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.BLUE)
                 .build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
@@ -208,10 +208,10 @@ class CategoryControllerV2Test extends ControllerTest {
     @Test
     void readAllCategoryIgnoringInvalidFilter() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category1 = CategoryFixtures.defaultCategory().build();
-        Category category2 = CategoryFixtures.defaultCategory().build();
+        Category category1 = CategoryFixtures.ofDefault().build();
+        Category category2 = CategoryFixtures.ofDefault().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
                 new CategoryResponseV3(category2, 0))
@@ -231,10 +231,10 @@ class CategoryControllerV2Test extends ControllerTest {
     void readCategory() throws Exception {
         // given
         long categoryId = 1;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category = CategoryFixtures.defaultCategory().withHost(member).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().withHost(member).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -276,12 +276,12 @@ class CategoryControllerV2Test extends ControllerTest {
     void readCategoryWithoutTerm() throws Exception {
         // given
         long categoryId = 1;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -323,7 +323,7 @@ class CategoryControllerV2Test extends ControllerTest {
     void updateCategory(CategoryRequestV2 categoryRequest) throws Exception {
         // given
         long categoryId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(put("/v2/categories/{categoryId}", categoryId)
@@ -339,7 +339,7 @@ class CategoryControllerV2Test extends ControllerTest {
     void failUpdateCategory(CategoryRequestV2 categoryRequest, String expectedMessage) throws Exception {
         // given
         long categoryId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
         // when & then
@@ -357,7 +357,7 @@ class CategoryControllerV2Test extends ControllerTest {
     void failUpdateCategoryByInvalidPath(CategoryRequestV2 categoryRequest) throws Exception {
         // given
         long categoryId = 0L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "카테고리 식별자는 양수로 이루어져야 합니다.");
 
         // when & then

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -234,8 +234,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Member member = MemberFixtures.defaultMember().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category = CategoryFixtures.defaultCategory().withHost(member).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -282,8 +281,7 @@ class CategoryControllerV2Test extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV2Test.java
@@ -47,8 +47,7 @@ class CategoryControllerV2Test extends ControllerTest {
                 CategoryRequestV2Fixtures.defaultCategoryRequestV2()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryRequestV2Fixtures.defaultCategoryRequestV2()
-                        .withTerm(null, null).build()
+                CategoryRequestV2Fixtures.defaultCategoryRequestV2().build()
         );
     }
 
@@ -171,7 +170,7 @@ class CategoryControllerV2Test extends ControllerTest {
                         LocalDate.of(2024, 12, 31)).build();
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
-                .withTerm(null, null).build();
+                .build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
                 new CategoryResponseV3(categoryWithoutTerm, 0))
@@ -247,8 +246,6 @@ class CategoryControllerV2Test extends ControllerTest {
                     "categoryTitle": "categoryTitle",
                     "description": "categoryDescription",
                     "categoryColor": "pink",
-                    "startAt": "2024-01-01",
-                    "endAt": "2024-12-31",
                     "mates": [
                         {
                             "memberId": null,
@@ -283,7 +280,6 @@ class CategoryControllerV2Test extends ControllerTest {
         Member member = MemberFixtures.defaultMember().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .withHost(member)
                 .build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -181,8 +181,7 @@ class CategoryControllerV3Test extends ControllerTest {
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), host);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -240,8 +239,7 @@ class CategoryControllerV3Test extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -43,26 +43,26 @@ class CategoryControllerV3Test extends ControllerTest {
 
     static Stream<CategoryCreateRequest> categoryRequestProvider() {
         return Stream.of(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(),
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault().build(),
+                CategoryCreateRequestFixtures.ofDefault()
                         .withIsShared(false).build(),
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault()
                         .withIsShared(true).build()
         );
     }
 
     static Stream<Arguments> invalidCategoryRequestProvider() {
         return Stream.of(
-                Arguments.of(CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                Arguments.of(CategoryCreateRequestFixtures.ofDefault()
                                 .withCategoryTitle(null).build(),
                         "카테고리 제목을 입력해주세요."),
-                Arguments.of(CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                Arguments.of(CategoryCreateRequestFixtures.ofDefault()
                                 .withCategoryTitle("  ").build(),
                         "카테고리 제목을 입력해주세요."),
-                Arguments.of(CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                Arguments.of(CategoryCreateRequestFixtures.ofDefault()
                                 .withIsShared(null).build(),
                         "카테고리 공개 여부를 입력해주세요.")
         );
@@ -72,7 +72,7 @@ class CategoryControllerV3Test extends ControllerTest {
     @Test
     void createCategory() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -105,7 +105,7 @@ class CategoryControllerV3Test extends ControllerTest {
     @Test
     void createCategoryWithoutTerm() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String categoryRequest = """
                 {
                     "categoryThumbnailUrl": "https://example.com/categories/geumohrm.jpg",
@@ -137,7 +137,7 @@ class CategoryControllerV3Test extends ControllerTest {
     @MethodSource("categoryRequestProvider")
     void createCategoryWithoutOption(CategoryCreateRequest categoryCreateRequest) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(categoryService.createCategory(any(), any())).thenReturn(new CategoryIdResponse(1));
 
         // when & then
@@ -155,7 +155,7 @@ class CategoryControllerV3Test extends ControllerTest {
     @MethodSource("invalidCategoryRequestProvider")
     void failCreateCategory(CategoryCreateRequest categoryCreateRequest, String expectedMessage) throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
         // when & then
@@ -172,16 +172,16 @@ class CategoryControllerV3Test extends ControllerTest {
     void readCategory() throws Exception {
         // given
         long categoryId = 1;
-        Member host = MemberFixtures.defaultMember().withNickname("host").build();
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
+        Member host = MemberFixtures.ofDefault().withNickname("host").build();
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").build();
         when(authService.extractFromToken(anyString())).thenReturn(host);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                     LocalDate.of(2024, 12, 31))
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), host);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -234,12 +234,12 @@ class CategoryControllerV3Test extends ControllerTest {
     void readCategoryWithoutTerm() throws Exception {
         // given
         long categoryId = 1;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         CategoryDetailResponseV3 categoryDetailResponse = new CategoryDetailResponseV3(category, List.of(staccato), member);
         when(categoryService.readCategoryWithStaccatosById(anyLong(), any(Member.class))).thenReturn(categoryDetailResponse);
@@ -282,18 +282,18 @@ class CategoryControllerV3Test extends ControllerTest {
     @Test
     void readAllCategory() throws Exception {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").build();
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").build();
-        Member guest3 = MemberFixtures.defaultMember().withNickname("guest3").build();
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category categoryWithTerm = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").build();
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").build();
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").build();
+        Member guest3 = MemberFixtures.ofDefault().withNickname("guest3").build();
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category categoryWithTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.PINK)
                 .withHost(host)
                 .withGuests(List.of(guest, guest2, guest3))
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
+        Category categoryWithoutTerm = CategoryFixtures.ofDefault()
                 .withColor(Color.BLUE)
                 .withHost(host)
                 .build();
@@ -364,10 +364,10 @@ class CategoryControllerV3Test extends ControllerTest {
     @Test
     void readAllCategoryIgnoringInvalidFilter() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
-        Category category1 = CategoryFixtures.defaultCategory().build();
-        Category category2 = CategoryFixtures.defaultCategory().build();
+        Category category1 = CategoryFixtures.ofDefault().build();
+        Category category2 = CategoryFixtures.ofDefault().build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(category1, 0),
                 new CategoryResponseV3(category2, 0))

--- a/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
+++ b/backend/src/test/java/com/staccato/category/controller/CategoryControllerV3Test.java
@@ -46,8 +46,7 @@ class CategoryControllerV3Test extends ControllerTest {
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(),
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
-                        .withTerm(null, null).build(),
+                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(),
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
                         .withIsShared(false).build(),
                 CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
@@ -176,7 +175,12 @@ class CategoryControllerV3Test extends ControllerTest {
         Member host = MemberFixtures.defaultMember().withNickname("host").build();
         Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
         when(authService.extractFromToken(anyString())).thenReturn(host);
-        Category category = CategoryFixtures.defaultCategory().withHost(host).withGuests(List.of(guest)).build();
+        Category category = CategoryFixtures.defaultCategory()
+                .withTerm(LocalDate.of(2024, 1, 1),
+                    LocalDate.of(2024, 12, 31))
+                .withHost(host)
+                .withGuests(List.of(guest))
+                .build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
                 .withCategory(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
@@ -234,7 +238,6 @@ class CategoryControllerV3Test extends ControllerTest {
         Member member = MemberFixtures.defaultMember().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .withHost(member)
                 .build();
         Staccato staccato = StaccatoFixtures.defaultStaccato()
@@ -295,7 +298,7 @@ class CategoryControllerV3Test extends ControllerTest {
         Category categoryWithoutTerm = CategoryFixtures.defaultCategory()
                 .withColor(Color.BLUE)
                 .withHost(host)
-                .withTerm(null, null).build();
+                .build();
         CategoryResponsesV3 categoryResponses = new CategoryResponsesV3(List.of(
                 new CategoryResponseV3(categoryWithTerm, 0),
                 new CategoryResponseV3(categoryWithoutTerm, 0))

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -48,9 +48,9 @@ class CategoryTest {
         Category updatedCategory = CategoryFixtures.defaultCategory()
                 .withTerm(LocalDate.of(2023, 1, 1),
                         LocalDate.of(2023, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                .withCategory(category).build();
+                .build();
 
         // when & then
         assertThatThrownBy(() -> category.update(updatedCategory, List.of(staccato)))

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -27,7 +27,7 @@ class CategoryTest {
     void createBasicCategoryWithMemberNickname() {
         // given
         String nickname = "staccato";
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withNickname(nickname)
                 .build();
 
@@ -42,13 +42,13 @@ class CategoryTest {
     @Test
     void validateDuration() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Category updatedCategory = CategoryFixtures.defaultCategory()
+        Category updatedCategory = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2023, 1, 1),
                         LocalDate.of(2023, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .build();
 
@@ -63,7 +63,7 @@ class CategoryTest {
     void isNotSameTitle() {
         // given
         String title = "title";
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTitle(title).build();
 
         // when
@@ -77,7 +77,7 @@ class CategoryTest {
     @Test
     void hasTerm() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
 
@@ -92,7 +92,7 @@ class CategoryTest {
     @Test
     void doesNotHaveTerm() {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
+        Category category = CategoryFixtures.ofDefault().build();
 
         // when
         boolean result = category.hasTerm();
@@ -128,9 +128,9 @@ class CategoryTest {
 
         @BeforeEach
         void setUp() {
-            host = MemberFixtures.defaultMember().withNickname("host").build();
-            guest = MemberFixtures.defaultMember().withNickname("guest").build();
-            category = CategoryFixtures.defaultCategory()
+            host = MemberFixtures.ofDefault().withNickname("host").build();
+            guest = MemberFixtures.ofDefault().withNickname("guest").build();
+            category = CategoryFixtures.ofDefault()
                     .withHost(host)
                     .withGuests(List.of(guest))
                     .build();
@@ -151,7 +151,7 @@ class CategoryTest {
         @DisplayName("카테고리의 함께하는 사람이 아니면 카테고리 안에 있는 스타카토의 소유자가 아니다.")
         @Test
         void failValidateOwnerIfMemberNotInCategory() {
-            Member other = MemberFixtures.defaultMember().withNickname("other").build();
+            Member other = MemberFixtures.ofDefault().withNickname("other").build();
             assertThatThrownBy(() -> category.validateOwner(other))
                     .isInstanceOf(ForbiddenException.class);
         }
@@ -167,9 +167,9 @@ class CategoryTest {
 
         @BeforeEach
         void setUp() {
-            host = MemberFixtures.defaultMember().withNickname("host").build();
-            guest = MemberFixtures.defaultMember().withNickname("guest").build();
-            category = CategoryFixtures.defaultCategory()
+            host = MemberFixtures.ofDefault().withNickname("host").build();
+            guest = MemberFixtures.ofDefault().withNickname("guest").build();
+            category = CategoryFixtures.ofDefault()
                     .withHost(host)
                     .withGuests(List.of(guest))
                     .build();
@@ -191,7 +191,7 @@ class CategoryTest {
         @DisplayName("validateHost는 멤버가 카테고리에 소속되어 있지 않으면 예외를 발생시킨다.")
         @Test
         void failValidateHostIfMemberNotInCategory() {
-            Member other = MemberFixtures.defaultMember().withNickname("other").build();
+            Member other = MemberFixtures.ofDefault().withNickname("other").build();
             assertThatThrownBy(() -> category.validateHost(other))
                     .isInstanceOf(ForbiddenException.class);
         }
@@ -212,7 +212,7 @@ class CategoryTest {
         @DisplayName("validateGuest는 멤버가 카테고리에 소속되어 있지 않으면 예외를 발생시킨다.")
         @Test
         void failValidateGuestIfMemberNotInCategory() {
-            Member other = MemberFixtures.defaultMember().withNickname("other").build();
+            Member other = MemberFixtures.ofDefault().withNickname("other").build();
             assertThatThrownBy(() -> category.validateMemberCanLeave(other))
                     .isInstanceOf(ForbiddenException.class);
         }
@@ -222,9 +222,9 @@ class CategoryTest {
     @Test
     void changeUpdatedAtWhenAddGuest() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").build();
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").build();
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").build();
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .build();
 

--- a/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
+++ b/backend/src/test/java/com/staccato/category/domain/CategoryTest.java
@@ -92,8 +92,7 @@ class CategoryTest {
     @Test
     void doesNotHaveTerm() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null).build();
+        Category category = CategoryFixtures.defaultCategory().build();
 
         // when
         boolean result = category.hasTerm();

--- a/backend/src/test/java/com/staccato/category/repository/CategoryMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/category/repository/CategoryMemberRepositoryTest.java
@@ -58,7 +58,6 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .withTitle("no-term")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
@@ -139,7 +138,6 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository);
         Category category2 = CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository);
         CategoryMemberFixtures.defaultCategoryMember()
                 .withMember(member)

--- a/backend/src/test/java/com/staccato/category/repository/CategoryMemberRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/category/repository/CategoryMemberRepositoryTest.java
@@ -35,13 +35,13 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberId() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category1 = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category1 = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        Category category2 = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category1).buildAndSave(categoryMemberRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category2).buildAndSave(categoryMemberRepository);
 
@@ -56,12 +56,12 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberIdAndDate() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CategoryFixtures.ofDefault()
                 .withTitle("no-term")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        CategoryFixtures.defaultCategory()
+        CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .withTitle("term")
@@ -93,16 +93,16 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberIdAndFlag() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .withTitle("shared")
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
-        CategoryFixtures.defaultCategory()
+        CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .withTitle("nonShared")
@@ -132,17 +132,17 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberIdAndDateWhenNull() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category1 = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category1 = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .buildAndSave(categoryRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category1).buildAndSave(categoryMemberRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category2).buildAndSave(categoryMemberRepository);
 
@@ -157,13 +157,13 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByCategoryIdInBulk() {
         // given
-        Member member1 = MemberFixtures.defaultMember().withNickname("member1").buildAndSave(memberRepository);
-        Member member2 = MemberFixtures.defaultMember().withNickname("member2").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        CategoryMember categoryMember1 = CategoryMemberFixtures.defaultCategoryMember()
+        Member member1 = MemberFixtures.ofDefault().withNickname("member1").buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.ofDefault().withNickname("member2").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        CategoryMember categoryMember1 = CategoryMemberFixtures.ofDefault()
                 .withMember(member1)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
-        CategoryMember categoryMember2 = CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMember categoryMember2 = CategoryMemberFixtures.ofDefault()
                 .withMember(member2)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
@@ -182,13 +182,13 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @DisplayName("카테고리 멤버는 (카테고리, 멤버) 쌍으로 유일해야 한다.")
     @Test
     void categoryMemberShouldBeUniqueByCategoryAndMember() {
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CategoryMember categoryMember1 = CategoryMemberFixtures.defaultCategoryMember()
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CategoryMember categoryMember1 = CategoryMemberFixtures.ofDefault()
                 .withCategory(category)
                 .withMember(member)
                 .build();
-        CategoryMember categoryMember2 = CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMember categoryMember2 = CategoryMemberFixtures.ofDefault()
                 .withCategory(category)
                 .withMember(member)
                 .build();
@@ -206,16 +206,16 @@ class CategoryMemberRepositoryTest extends RepositoryTest {
     @Test
     void findAllMembersByCategoryId() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
 
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTitle("category")
                 .withHost(host)
                 .withGuests(List.of(guest, guest2))
                 .buildAndSave(categoryRepository);
-        CategoryFixtures.defaultCategory()
+        CategoryFixtures.ofDefault()
                 .withTitle("anotherCategory")
                 .withHost(host)
                 .withGuests(List.of(guest))

--- a/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
@@ -102,12 +102,10 @@ class CategoryRepositoryTest extends RepositoryTest {
         // given
         Category privateCategory = CategoryFixtures.defaultCategory()
                 .withHost(host)
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository);
         Category publicCategory = CategoryFixtures.defaultCategory()
                 .withHost(host)
                 .withGuests(List.of(guest))
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository);
 
         // when
@@ -124,12 +122,10 @@ class CategoryRepositoryTest extends RepositoryTest {
         // given
         Category privateCategory = CategoryFixtures.defaultCategory()
                 .withHost(host)
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository);
         Category publicCategory = CategoryFixtures.defaultCategory()
                 .withHost(host)
                 .withGuests(List.of(guest))
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository);
 
         // when

--- a/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/category/repository/CategoryRepositoryTest.java
@@ -30,15 +30,15 @@ class CategoryRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     void setUp() {
-        host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
+        host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
     }
 
     @DisplayName("카테고리 id로 조회 시, categoryMembers와 member까지 함께 조회된다")
     @Test
     void findWithCategoryMembersByIdWithCategoryMembersAndMembers() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -62,23 +62,23 @@ class CategoryRepositoryTest extends RepositoryTest {
     @Test
     void findByMemberIdAndDateWithPrivateFlagWhenSpecificDateIsGiven() {
         // given
-        Category privateCategoryIn2024 = CategoryFixtures.defaultCategory()
+        Category privateCategoryIn2024 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository);
-        Category publicCategoryIn2024 = CategoryFixtures.defaultCategory()
+        Category publicCategoryIn2024 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository);
-        Category privateCategoryIn2025 = CategoryFixtures.defaultCategory()
+        Category privateCategoryIn2025 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withTerm(LocalDate.of(2025, 1, 1),
                         LocalDate.of(2025, 12, 31))
                 .buildAndSave(categoryRepository);
-        Category publicCategoryIn2025 = CategoryFixtures.defaultCategory()
+        Category publicCategoryIn2025 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .withTerm(LocalDate.of(2025, 1, 1),
@@ -100,10 +100,10 @@ class CategoryRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberIdAndDateAndSharingFilterIsNull() {
         // given
-        Category privateCategory = CategoryFixtures.defaultCategory()
+        Category privateCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category publicCategory = CategoryFixtures.defaultCategory()
+        Category publicCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -120,10 +120,10 @@ class CategoryRepositoryTest extends RepositoryTest {
     @Test
     void findAllByMemberIdAndDateAndSharingFilterIsFalse() {
         // given
-        Category privateCategory = CategoryFixtures.defaultCategory()
+        Category privateCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category publicCategory = CategoryFixtures.defaultCategory()
+        Category publicCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);

--- a/backend/src/test/java/com/staccato/category/service/CategoryFilterTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryFilterTest.java
@@ -79,7 +79,6 @@ class CategoryFilterTest extends ServiceSliceTest {
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         Category category1 = CategoryFixtures.defaultCategory()
                 .withTitle("first")
-                .withTerm(null, null)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         Category category2 = CategoryFixtures.defaultCategory()
@@ -109,7 +108,6 @@ class CategoryFilterTest extends ServiceSliceTest {
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         Category category1 = CategoryFixtures.defaultCategory()
                 .withTitle("first")
-                .withTerm(null, null)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         Category category2 = CategoryFixtures.defaultCategory()

--- a/backend/src/test/java/com/staccato/category/service/CategoryFilterTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryFilterTest.java
@@ -76,12 +76,12 @@ class CategoryFilterTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesWithTerm() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category1 = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category1 = CategoryFixtures.ofDefault()
                 .withTitle("first")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withTitle("second")
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
@@ -105,12 +105,12 @@ class CategoryFilterTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesWithoutTerm() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category1 = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category1 = CategoryFixtures.ofDefault()
                 .withTitle("first")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withTitle("second")
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -79,9 +79,9 @@ class CategoryServiceTest extends ServiceSliceTest {
 
     static Stream<Arguments> updateCategoryProvider() {
         return Stream.of(
-                Arguments.of(CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+                Arguments.of(CategoryUpdateRequestFixtures.ofDefault()
                         .withCategoryThumbnailUrl(null).build(), null),
-                Arguments.of(CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+                Arguments.of(CategoryUpdateRequestFixtures.ofDefault()
                         .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                         .build(), "https://example.com/categoryThumbnailUrl.jpg"));
     }
@@ -90,8 +90,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void createCategory() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build();
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault().build();
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
         // when
         categoryService.createCategory(categoryCreateRequest, member);
@@ -109,8 +109,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void createCategoryWithoutTerm() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build();
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault().build();
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
         // when
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(categoryCreateRequest, member);
@@ -128,9 +128,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void cannotCreateCategoryByDuplicatedTitle() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault()
                 .build();
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         categoryService.createCategory(categoryCreateRequest, member);
 
         // when & then
@@ -143,10 +143,10 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void canCreateCategoryByDuplicatedTitleOfOther() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault()
                 .build();
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
         categoryService.createCategory(categoryCreateRequest, otherMember);
 
         // when & then
@@ -157,14 +157,14 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesOrderByUpdatedAtDesc() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault()
                         .withCategoryTitle("first").build(), member);
         categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault()
                         .withCategoryTitle("second").build(), member);
-        staccatoService.createStaccato(StaccatoRequestFixtures.defaultStaccatoRequest()
+        staccatoService.createStaccato(StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(categoryIdResponse.categoryId()).build(), member);
         CategoryReadRequest categoryReadRequest = new CategoryReadRequest("false", null);
 
@@ -188,11 +188,11 @@ class CategoryServiceTest extends ServiceSliceTest {
 
         @BeforeEach
         void setUp() {
-            host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-            guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-            other = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);
+            host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+            guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+            other = MemberFixtures.ofDefault().withNickname("other").buildAndSave(memberRepository);
 
-            category = CategoryFixtures.defaultCategory()
+            category = CategoryFixtures.ofDefault()
                     .withTerm(LocalDate.of(2024, 1, 1),
                             LocalDate.of(2024, 1, 4))
                     .withHost(host)
@@ -228,7 +228,7 @@ class CategoryServiceTest extends ServiceSliceTest {
             @Test
             void successWhenTermIsNull() {
                 // given
-                category = CategoryFixtures.defaultCategory()
+                category = CategoryFixtures.ofDefault()
                         .withHost(host)
                         .buildAndSave(categoryRepository);
 
@@ -268,10 +268,10 @@ class CategoryServiceTest extends ServiceSliceTest {
 
             @BeforeEach
             void setUpStaccatos() {
-                staccato = StaccatoFixtures.defaultStaccato(category)
+                staccato = StaccatoFixtures.ofDefault(category)
                         .withVisitedAt(LocalDateTime.of(2024, 1, 3, 0, 0, 0))
                         .build();
-                staccato2 = StaccatoFixtures.defaultStaccato(category)
+                staccato2 = StaccatoFixtures.ofDefault(category)
                         .withVisitedAt(LocalDateTime.of(2024, 1, 2, 0, 0, 0))
                         .build();
                 staccatoRepository.saveAll(List.of(staccato, staccato2));
@@ -324,7 +324,7 @@ class CategoryServiceTest extends ServiceSliceTest {
             @Test
             void successWhenTermIsNull() {
                 // given
-                category = CategoryFixtures.defaultCategory()
+                category = CategoryFixtures.ofDefault()
                         .withHost(host)
                         .buildAndSave(categoryRepository);
 
@@ -361,20 +361,20 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void readAllStaccatoLocations() {
         // given
-        Member member = MemberFixtures.defaultMember().withCode("me").buildAndSave(memberRepository);
-        Member member2 = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().withCode("me").buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.ofDefault().withNickname("other").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withColor(Color.BLUE)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withTitle("title2")
                 .withColor(Color.PINK)
                 .withHost(member2)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato otherStaccato = StaccatoFixtures.defaultStaccato(category2).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato otherStaccato = StaccatoFixtures.ofDefault(category2).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         CategoryStaccatoLocationResponses responses = categoryService.readStaccatoLocationsByCategory(
@@ -396,13 +396,13 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesContainsStaccatoCount() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
 
-        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         CategoryReadRequest request = new CategoryReadRequest(null, null);
 
@@ -420,12 +420,12 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesByMemberAndDateAndPrivateFlagWhenPrivateFlagIsFalse() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category privateCategory = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category privateCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category publicCategory = CategoryFixtures.defaultCategory()
+        Category publicCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -447,12 +447,12 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesByMemberAndDateAndPrivateFlagWhenPrivateFlagIsTrue() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category privateCategory = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category privateCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category publicCategory = CategoryFixtures.defaultCategory()
+        Category publicCategory = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -480,13 +480,13 @@ class CategoryServiceTest extends ServiceSliceTest {
 
         @BeforeEach
         void setup() {
-            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            category = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 10; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato(category)
+                staccatos.add(StaccatoFixtures.ofDefault(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -592,9 +592,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @ParameterizedTest
     void updateCategory(CategoryUpdateRequest categoryUpdateRequest, String expected) {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
+                CategoryCreateRequestFixtures.ofDefault().build(), member);
 
         // when
         categoryService.updateCategory(categoryUpdateRequest, categoryIdResponse.categoryId(), member);
@@ -617,14 +617,14 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void updateCategoryWithNullableTerm() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                CategoryCreateRequestFixtures.ofDefault()
                         .withTerm(LocalDate.of(2024, 1, 1),
                                 LocalDate.of(2024, 12, 31)).build(), member);
 
         // when
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest().build();
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault().build();
         categoryService.updateCategory(categoryUpdateRequest, categoryIdResponse.categoryId(), member);
         Category foundedCategory = categoryRepository.findById(categoryIdResponse.categoryId()).get();
 
@@ -639,8 +639,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failUpdateCategory() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault()
                 .build();
 
         // when & then
@@ -653,12 +653,12 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void cannotUpdateCategoryIfNotOwner() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault()
                 .build();
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
+                CategoryCreateRequestFixtures.ofDefault().build(), member);
 
         // when & then
         assertThatThrownBy(() -> categoryService.updateCategory(categoryUpdateRequest, categoryIdResponse.categoryId(), otherMember))
@@ -671,8 +671,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     void updateCategoryColor() {
         // given
         CategoryColorRequest categoryColorRequest = new CategoryColorRequest(Color.PINK.getName());
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault()
                 .build();
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(categoryCreateRequest, member);
 
@@ -687,11 +687,11 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void updateCategoryByOriginTitle() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault()
                 .withCategoryTitle("title").build();
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault()
                 .withCategoryTitle("title").build();
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(categoryCreateRequest, member);
 
         // when & then
@@ -702,18 +702,18 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void cannotUpdateCategoryByDuplicatedTitle() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
-        CategoryCreateRequest existingTitleRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        CategoryCreateRequest existingTitleRequest = CategoryCreateRequestFixtures.ofDefault()
                 .withCategoryTitle("existingTitle").build();
         categoryService.createCategory(existingTitleRequest, member);
 
-        CategoryCreateRequest editableCategoryRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        CategoryCreateRequest editableCategoryRequest = CategoryCreateRequestFixtures.ofDefault()
                 .withCategoryTitle("otherTitle").build();
         CategoryIdResponse editableCategoryId = categoryService.createCategory(editableCategoryRequest, member);
 
         // when & then
-        CategoryUpdateRequest updateToDuplicateTitleRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+        CategoryUpdateRequest updateToDuplicateTitleRequest = CategoryUpdateRequestFixtures.ofDefault()
                 .withCategoryTitle(existingTitleRequest.categoryTitle()).build();
 
         assertThatThrownBy(() -> categoryService.updateCategory(updateToDuplicateTitleRequest, editableCategoryId.categoryId(), member))
@@ -725,9 +725,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void deleteCategory() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
+                CategoryCreateRequestFixtures.ofDefault().build(), member);
 
         // when
         categoryService.deleteCategory(categoryIdResponse.categoryId(), member);
@@ -743,15 +743,15 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void deleteCategoryWithStaccato() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment(staccato, host).buildAndSave(commentRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentFixtures.ofDefault(staccato, host).buildAndSave(commentRepository);
         categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest2));
 
         // when
@@ -771,10 +771,10 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void cannotDeleteCategoryIfNotOwner() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
+                CategoryCreateRequestFixtures.ofDefault().build(), member);
 
         // when & then
         assertThatThrownBy(() -> categoryService.deleteCategory(categoryIdResponse.categoryId(), otherMember))
@@ -786,8 +786,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void createCategorySetsMemberRoleAsHost() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.ofDefault()
                 .build();
 
         // when
@@ -803,11 +803,11 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failUpdateCategoryIfGuestMemberTried() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withGuests(List.of(member))
                 .buildAndSave(categoryRepository);
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault()
                 .build();
 
         // when & then
@@ -820,8 +820,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failDeleteCategoryIfGuestMemberTried() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withGuests(List.of(member))
                 .buildAndSave(categoryRepository);
 
@@ -835,8 +835,8 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failUpdateCategoryColorIfGuestMemberTried() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withGuests(List.of(member))
                 .buildAndSave(categoryRepository);
         CategoryColorRequest categoryColorRequest = new CategoryColorRequest(Color.BLUE.getName());
@@ -851,9 +851,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void getRoleOfMemberReturnsRole() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -873,9 +873,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void deleteSelfFromCategory() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -893,9 +893,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failDeleteSelfFromCategoryIfCategoryNotExist() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -910,10 +910,10 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failDeleteSelfFromCategoryIfMemberNotInCategory() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Member other = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Member other = MemberFixtures.ofDefault().withNickname("other").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -927,9 +927,9 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void failDeleteSelfFromCategoryIfMemberHost() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -268,13 +268,11 @@ class CategoryServiceTest extends ServiceSliceTest {
 
             @BeforeEach
             void setUpStaccatos() {
-                staccato = StaccatoFixtures.defaultStaccato()
+                staccato = StaccatoFixtures.defaultStaccato(category)
                         .withVisitedAt(LocalDateTime.of(2024, 1, 3, 0, 0, 0))
-                        .withCategory(category)
                         .build();
-                staccato2 = StaccatoFixtures.defaultStaccato()
+                staccato2 = StaccatoFixtures.defaultStaccato(category)
                         .withVisitedAt(LocalDateTime.of(2024, 1, 2, 0, 0, 0))
-                        .withCategory(category)
                         .build();
                 staccatoRepository.saveAll(List.of(staccato, staccato2));
             }
@@ -374,12 +372,9 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withColor(Color.PINK)
                 .withHost(member2)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato otherStaccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category2).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato otherStaccato = StaccatoFixtures.defaultStaccato(category2).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         CategoryStaccatoLocationResponses responses = categoryService.readStaccatoLocationsByCategory(
@@ -406,8 +401,8 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withHost(member)
                 .buildAndSave(categoryRepository);
 
-        StaccatoFixtures.defaultStaccato().withCategory(category).buildAndSave(staccatoRepository);
-        StaccatoFixtures.defaultStaccato().withCategory(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         CategoryReadRequest request = new CategoryReadRequest(null, null);
 
@@ -491,8 +486,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 10; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                staccatos.add(StaccatoFixtures.defaultStaccato(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -756,8 +750,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(host).buildAndSave(commentRepository);

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -624,7 +624,8 @@ class CategoryServiceTest extends ServiceSliceTest {
                                 LocalDate.of(2024, 12, 31)).build(), member);
 
         // when
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault().build();
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.ofDefault()
+                .withTerm(null, null).build();
         categoryService.updateCategory(categoryUpdateRequest, categoryIdResponse.categoryId(), member);
         Category foundedCategory = categoryRepository.findById(categoryIdResponse.categoryId()).get();
 

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -751,9 +751,7 @@ class CategoryServiceTest extends ServiceSliceTest {
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(host).buildAndSave(commentRepository);
+        CommentFixtures.defaultComment(staccato, host).buildAndSave(commentRepository);
         categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest2));
 
         // when

--- a/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategoryServiceTest.java
@@ -90,8 +90,7 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void createCategory() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
-                .build();
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build();
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
 
         // when
@@ -110,8 +109,7 @@ class CategoryServiceTest extends ServiceSliceTest {
     @Test
     void createCategoryWithoutTerm() {
         // given
-        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
-                .withTerm(null, null).build();
+        CategoryCreateRequest categoryCreateRequest = CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build();
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
 
         // when
@@ -232,7 +230,6 @@ class CategoryServiceTest extends ServiceSliceTest {
                 // given
                 category = CategoryFixtures.defaultCategory()
                         .withHost(host)
-                        .withTerm(null, null)
                         .buildAndSave(categoryRepository);
 
                 // when
@@ -331,7 +328,6 @@ class CategoryServiceTest extends ServiceSliceTest {
                 // given
                 category = CategoryFixtures.defaultCategory()
                         .withHost(host)
-                        .withTerm(null, null)
                         .buildAndSave(categoryRepository);
 
                 // when
@@ -491,7 +487,6 @@ class CategoryServiceTest extends ServiceSliceTest {
         void setup() {
             member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
             category = CategoryFixtures.defaultCategory()
-                    .withTerm(null, null)
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
@@ -630,11 +625,12 @@ class CategoryServiceTest extends ServiceSliceTest {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         CategoryIdResponse categoryIdResponse = categoryService.createCategory(
-                CategoryCreateRequestFixtures.defaultCategoryCreateRequest().build(), member);
+                CategoryCreateRequestFixtures.defaultCategoryCreateRequest()
+                        .withTerm(LocalDate.of(2024, 1, 1),
+                                LocalDate.of(2024, 12, 31)).build(), member);
 
         // when
-        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest()
-                .withTerm(null, null).build();
+        CategoryUpdateRequest categoryUpdateRequest = CategoryUpdateRequestFixtures.defaultCategoryUpdateRequest().build();
         categoryService.updateCategory(categoryUpdateRequest, categoryIdResponse.categoryId(), member);
         Category foundedCategory = categoryRepository.findById(categoryIdResponse.categoryId()).get();
 

--- a/backend/src/test/java/com/staccato/category/service/CategorySortTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategorySortTest.java
@@ -99,11 +99,9 @@ public class CategorySortTest extends ServiceSliceTest {
                 .buildAndSave(categoryRepository));
         categories.add(CategoryFixtures.defaultCategory()
                 .withTitle("third")
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository));
         categories.add(CategoryFixtures.defaultCategory()
                 .withTitle("fourth")
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository));
 
         // when
@@ -135,11 +133,9 @@ public class CategorySortTest extends ServiceSliceTest {
                 .buildAndSave(categoryRepository));
         categories.add(CategoryFixtures.defaultCategory()
                 .withTitle("third")
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository));
         categories.add(CategoryFixtures.defaultCategory()
                 .withTitle("fourth")
-                .withTerm(null, null)
                 .buildAndSave(categoryRepository));
 
         // when

--- a/backend/src/test/java/com/staccato/category/service/CategorySortTest.java
+++ b/backend/src/test/java/com/staccato/category/service/CategorySortTest.java
@@ -61,13 +61,13 @@ public class CategorySortTest extends ServiceSliceTest {
     @Test
     void readAllCategoriesByUpdatedAtDesc() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         List<Category> categories = new ArrayList<>();
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("first")
                 .withHost(member)
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("second")
                 .withHost(member)
                 .buildAndSave(categoryRepository));
@@ -87,20 +87,20 @@ public class CategorySortTest extends ServiceSliceTest {
     void readAllCategoriesByNewest() {
         // given
         List<Category> categories = new ArrayList<>();
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("first")
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("second")
                 .withTerm(LocalDate.of(2024, 6, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("third")
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("fourth")
                 .buildAndSave(categoryRepository));
 
@@ -121,20 +121,20 @@ public class CategorySortTest extends ServiceSliceTest {
     void readAllCategoriesByOldest() {
         // given
         List<Category> categories = new ArrayList<>();
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("first")
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("second")
                 .withTerm(LocalDate.of(2024, 6, 1),
                         LocalDate.of(2024, 12, 31))
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("third")
                 .buildAndSave(categoryRepository));
-        categories.add(CategoryFixtures.defaultCategory()
+        categories.add(CategoryFixtures.ofDefault()
                 .withTitle("fourth")
                 .buildAndSave(categoryRepository));
 

--- a/backend/src/test/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3Test.java
+++ b/backend/src/test/java/com/staccato/category/service/dto/response/CategoryDetailResponseV3Test.java
@@ -22,11 +22,11 @@ public class CategoryDetailResponseV3Test {
     @Test
     void sortMembersByHostThenSelfThenCreatedAt() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").build();
-        Member guestSelf = MemberFixtures.defaultMember().withNickname("guestSelf").build();
-        Member guestOld = MemberFixtures.defaultMember().withNickname("guestOld").build();
-        Member guestNew = MemberFixtures.defaultMember().withNickname("guestNew").build();
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").build();
+        Member guestSelf = MemberFixtures.ofDefault().withNickname("guestSelf").build();
+        Member guestOld = MemberFixtures.ofDefault().withNickname("guestOld").build();
+        Member guestNew = MemberFixtures.ofDefault().withNickname("guestNew").build();
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guestOld, guestSelf, guestNew))
                 .build();

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.staccato.ControllerTest;
+import com.staccato.category.domain.Category;
 import com.staccato.comment.domain.Comment;
 import com.staccato.comment.service.dto.request.CommentRequest;
 import com.staccato.comment.service.dto.request.CommentUpdateRequest;
@@ -18,11 +19,14 @@ import com.staccato.comment.service.dto.response.CommentResponseV2;
 import com.staccato.comment.service.dto.response.CommentResponsesV2;
 import com.staccato.exception.ExceptionResponse;
 
+import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.comment.CommentFixtures;
 import com.staccato.fixture.comment.CommentRequestFixtures;
 import com.staccato.fixture.comment.CommentUpdateRequestFixtures;
 import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
+import com.staccato.staccato.domain.Staccato;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -107,12 +111,13 @@ public class CommentControllerTest extends ControllerTest {
     void readCommentsByStaccatoId() throws Exception {
         // given
         when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        Category category = CategoryFixtures.defaultCategory().build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
         Member member = MemberFixtures.defaultMember()
                 .withNickname("member")
                 .withImageUrl("image.jpg")
                 .build();
-        Comment comment = CommentFixtures.defaultComment()
-                .withMember(member)
+        Comment comment = CommentFixtures.defaultComment(staccato, member)
                 .withContent("내용")
                 .build();
         CommentResponseV2 commentResponseV2 = new CommentResponseV2(comment);

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerTest.java
@@ -47,19 +47,19 @@ public class CommentControllerTest extends ControllerTest {
 
     static Stream<Arguments> invalidCommentRequestProvider() {
         return Stream.of(
-            Arguments.of(CommentRequestFixtures.defaultCommentRequest()
+            Arguments.of(CommentRequestFixtures.ofDefault()
                             .withStaccatoId(null).build(),
                     "스타카토를 선택해주세요."),
-            Arguments.of(CommentRequestFixtures.defaultCommentRequest()
+            Arguments.of(CommentRequestFixtures.ofDefault()
                             .withStaccatoId(MIN_STACCATO_ID - 1).build(),
                     "스타카토 식별자는 양수로 이루어져야 합니다."),
-            Arguments.of(CommentRequestFixtures.defaultCommentRequest()
+            Arguments.of(CommentRequestFixtures.ofDefault()
                             .withContent(null).build(),
                     "댓글 내용을 입력해주세요."),
-            Arguments.of(CommentRequestFixtures.defaultCommentRequest()
+            Arguments.of(CommentRequestFixtures.ofDefault()
                             .withContent("").build(),
                     "댓글 내용을 입력해주세요."),
-            Arguments.of(CommentRequestFixtures.defaultCommentRequest()
+            Arguments.of(CommentRequestFixtures.ofDefault()
                             .withContent("  ").build(),
                     "댓글 내용을 입력해주세요.")
         );
@@ -69,7 +69,7 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void createComment() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         String commentRequest = """
             {
                 "staccatoId": 1,
@@ -93,7 +93,7 @@ public class CommentControllerTest extends ControllerTest {
     void createCommentFail(CommentRequest commentRequest, String expectedMessage)
         throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(
             HttpStatus.BAD_REQUEST.toString(), expectedMessage);
 
@@ -110,14 +110,14 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void readCommentsByStaccatoId() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
-        Member member = MemberFixtures.defaultMember()
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).build();
+        Member member = MemberFixtures.ofDefault()
                 .withNickname("member")
                 .withImageUrl("image.jpg")
                 .build();
-        Comment comment = CommentFixtures.defaultComment(staccato, member)
+        Comment comment = CommentFixtures.ofDefault(staccato, member)
                 .withContent("내용")
                 .build();
         CommentResponseV2 commentResponseV2 = new CommentResponseV2(comment);
@@ -150,7 +150,7 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void readCommentsByStaccatoIdFail() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(
             HttpStatus.BAD_REQUEST.toString(), "스타카토 식별자는 양수로 이루어져야 합니다.");
 
@@ -167,7 +167,7 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void updateComment() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         String commentUpdateRequest = """
             {
                 "content": "content"
@@ -186,8 +186,8 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void updateCommentFail() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
-        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
+        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.ofDefault().build();
         ExceptionResponse exceptionResponse = new ExceptionResponse(
             HttpStatus.BAD_REQUEST.toString(), "댓글 식별자는 양수로 이루어져야 합니다.");
 
@@ -206,8 +206,8 @@ public class CommentControllerTest extends ControllerTest {
     @ValueSource(strings = {"", " "})
     void updateCommentFailByBlank(String updatedContent) throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
-        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest()
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
+        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.ofDefault()
                 .withContent(updatedContent).build();
         ExceptionResponse exceptionResponse = new ExceptionResponse(
             HttpStatus.BAD_REQUEST.toString(), "댓글 내용을 입력해주세요.");
@@ -225,7 +225,7 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void deleteComment() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(delete("/comments/{commentId}", 1)
@@ -238,7 +238,7 @@ public class CommentControllerTest extends ControllerTest {
     @Test
     void deleteCommentFail() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(
             HttpStatus.BAD_REQUEST.toString(), "댓글 식별자는 양수로 이루어져야 합니다.");
 

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
@@ -33,14 +33,14 @@ public class CommentControllerV2Test extends ControllerTest {
     @Test
     void readCommentsByStaccatoId() throws Exception {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
-        Member member = MemberFixtures.defaultMember()
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).build();
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
+        Member member = MemberFixtures.ofDefault()
                 .withNickname("member")
                 .withImageUrl("image.jpg")
                 .build();
-        Comment comment = CommentFixtures.defaultComment(staccato, member)
+        Comment comment = CommentFixtures.ofDefault(staccato, member)
                 .withContent("내용")
                 .build();
         CommentResponseV2 commentResponse = new CommentResponseV2(comment);
@@ -75,7 +75,7 @@ public class CommentControllerV2Test extends ControllerTest {
     @Test
     void readCommentsByStaccatoIdFail() throws Exception {
         // given
-        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(any())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(
                 HttpStatus.BAD_REQUEST.toString(), "스타카토 식별자는 양수로 이루어져야 합니다.");
 

--- a/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/comment/controller/CommentControllerV2Test.java
@@ -15,13 +15,17 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import com.staccato.ControllerTest;
+import com.staccato.category.domain.Category;
 import com.staccato.comment.domain.Comment;
 import com.staccato.comment.service.dto.response.CommentResponseV2;
 import com.staccato.comment.service.dto.response.CommentResponsesV2;
 import com.staccato.exception.ExceptionResponse;
+import com.staccato.fixture.category.CategoryFixtures;
 import com.staccato.fixture.comment.CommentFixtures;
 import com.staccato.fixture.member.MemberFixtures;
+import com.staccato.fixture.staccato.StaccatoFixtures;
 import com.staccato.member.domain.Member;
+import com.staccato.staccato.domain.Staccato;
 
 public class CommentControllerV2Test extends ControllerTest {
 
@@ -29,13 +33,14 @@ public class CommentControllerV2Test extends ControllerTest {
     @Test
     void readCommentsByStaccatoId() throws Exception {
         // given
+        Category category = CategoryFixtures.defaultCategory().build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
         when(authService.extractFromToken(any())).thenReturn(MemberFixtures.defaultMember().build());
         Member member = MemberFixtures.defaultMember()
                 .withNickname("member")
                 .withImageUrl("image.jpg")
                 .build();
-        Comment comment = CommentFixtures.defaultComment()
-                .withMember(member)
+        Comment comment = CommentFixtures.defaultComment(staccato, member)
                 .withContent("내용")
                 .build();
         CommentResponseV2 commentResponse = new CommentResponseV2(comment);

--- a/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
+++ b/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
@@ -23,14 +23,14 @@ import com.staccato.staccato.domain.Staccato;
 
 class CommentTest {
     private Member member;
+    private Category category;
     private Staccato staccato;
 
     @BeforeEach
     void init() {
         member = MemberFixtures.defaultMember().build();
-        staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(CategoryFixtures.defaultCategory().build())
-                .build();
+        category = CategoryFixtures.defaultCategory().build();
+        staccato = StaccatoFixtures.defaultStaccato(category).build();
     }
 
     @DisplayName("정상적인 댓글은 생성에 성공한다.")
@@ -83,9 +83,7 @@ class CommentTest {
             category = CategoryFixtures.defaultCategory()
                     .withHost(member)
                     .build();
-            staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category)
-                    .build();
+            staccato = StaccatoFixtures.defaultStaccato(category).build();
         }
 
         @DisplayName("댓글 작성자 본인만 댓글을 수정할 수 있다.")

--- a/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
+++ b/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
@@ -28,9 +28,9 @@ class CommentTest {
 
     @BeforeEach
     void init() {
-        member = MemberFixtures.defaultMember().build();
-        category = CategoryFixtures.defaultCategory().build();
-        staccato = StaccatoFixtures.defaultStaccato(category).build();
+        member = MemberFixtures.ofDefault().build();
+        category = CategoryFixtures.ofDefault().build();
+        staccato = StaccatoFixtures.ofDefault(category).build();
     }
 
     @DisplayName("정상적인 댓글은 생성에 성공한다.")
@@ -79,18 +79,18 @@ class CommentTest {
 
         @BeforeEach
         void setUp() {
-            member = MemberFixtures.defaultMember().withNickname("member").build();
-            category = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().withNickname("member").build();
+            category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .build();
-            staccato = StaccatoFixtures.defaultStaccato(category).build();
+            staccato = StaccatoFixtures.ofDefault(category).build();
         }
 
         @DisplayName("댓글 작성자 본인만 댓글을 수정할 수 있다.")
         @Test
         void validateCommentOwnerSuccess() {
             // given
-            Comment comment = CommentFixtures.defaultComment(staccato, member).build();
+            Comment comment = CommentFixtures.ofDefault(staccato, member).build();
 
             // when & then
             assertDoesNotThrow(() -> comment.validateOwner(member));
@@ -100,8 +100,8 @@ class CommentTest {
         @Test
         void validateCommentOwnerFail() {
             // given
-            Comment comment = CommentFixtures.defaultComment(staccato, member).build();
-            Member other = MemberFixtures.defaultMember().withNickname("other").build();
+            Comment comment = CommentFixtures.ofDefault(staccato, member).build();
+            Member other = MemberFixtures.ofDefault().withNickname("other").build();
 
             // when & then
             assertThatThrownBy(() -> comment.validateOwner(other))

--- a/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
+++ b/backend/src/test/java/com/staccato/comment/domain/CommentTest.java
@@ -90,10 +90,7 @@ class CommentTest {
         @Test
         void validateCommentOwnerSuccess() {
             // given
-            Comment comment = CommentFixtures.defaultComment()
-                    .withStaccato(staccato)
-                    .withMember(member)
-                    .build();
+            Comment comment = CommentFixtures.defaultComment(staccato, member).build();
 
             // when & then
             assertDoesNotThrow(() -> comment.validateOwner(member));
@@ -103,10 +100,7 @@ class CommentTest {
         @Test
         void validateCommentOwnerFail() {
             // given
-            Comment comment = CommentFixtures.defaultComment()
-                    .withStaccato(staccato)
-                    .withMember(member)
-                    .build();
+            Comment comment = CommentFixtures.defaultComment(staccato, member).build();
             Member other = MemberFixtures.defaultMember().withNickname("other").build();
 
             // when & then

--- a/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
@@ -40,8 +40,8 @@ class CommentRepositoryTest extends RepositoryTest {
         Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
         Staccato staccato1 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
         Staccato staccato2 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
-        CommentFixtures.ofDefault(staccato1, member).build();
-        CommentFixtures.ofDefault(staccato2, member).build();
+        CommentFixtures.ofDefault(staccato1, member).buildAndSave(commentRepository);
+        CommentFixtures.ofDefault(staccato2, member).buildAndSave(commentRepository);
 
         // when
         commentRepository.deleteAllByStaccatoIdInBulk(List.of(staccato1.getId(), staccato2.getId()));

--- a/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
@@ -36,12 +36,12 @@ class CommentRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByStaccatoIdInBulk() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment(staccato1, member).build();
-        CommentFixtures.defaultComment(staccato2, member).build();
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        Staccato staccato1 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentFixtures.ofDefault(staccato1, member).build();
+        CommentFixtures.ofDefault(staccato2, member).build();
 
         // when
         commentRepository.deleteAllByStaccatoIdInBulk(List.of(staccato1.getId(), staccato2.getId()));

--- a/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
@@ -40,12 +40,8 @@ class CommentRepositoryTest extends RepositoryTest {
         Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
         Staccato staccato1 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment()
-                .withStaccato(staccato1)
-                .withMember(member).build();
-        CommentFixtures.defaultComment()
-                .withStaccato(staccato2)
-                .withMember(member).build();
+        CommentFixtures.defaultComment(staccato1, member).build();
+        CommentFixtures.defaultComment(staccato2, member).build();
 
         // when
         commentRepository.deleteAllByStaccatoIdInBulk(List.of(staccato1.getId(), staccato2.getId()));

--- a/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/comment/repository/CommentRepositoryTest.java
@@ -38,10 +38,8 @@ class CommentRepositoryTest extends RepositoryTest {
         // given
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentFixtures.defaultComment()
                 .withStaccato(staccato1)
                 .withMember(member).build();

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -46,12 +46,12 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void createComment() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest().build();
+        StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentRequest commentRequest = CommentRequestFixtures.ofDefault().build();
 
         // when
         long commentId = commentService.createComment(commentRequest, member);
@@ -64,8 +64,8 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void createCommentFailByNotExistStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest().build();
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        CommentRequest commentRequest = CommentRequestFixtures.ofDefault().build();
 
         // when & then
         assertThatThrownBy(() -> commentService.createComment(commentRequest, member))
@@ -77,13 +77,13 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void createCommentFailByForbidden() {
         // given
-        Member staccatoOwner = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member unexpectedMember = MemberFixtures.defaultMember().withNickname("otherMem")
+        Member staccatoOwner = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member unexpectedMember = MemberFixtures.ofDefault().withNickname("otherMem")
                 .buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest().build();
+        StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentRequest commentRequest = CommentRequestFixtures.ofDefault().build();
 
         // when & then
         assertThatThrownBy(() -> commentService.createComment(commentRequest, unexpectedMember))
@@ -95,17 +95,17 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void readAllByStaccatoId() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato anotherStaccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentRequest commentRequest1 = CommentRequestFixtures.defaultCommentRequest()
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato anotherStaccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentRequest commentRequest1 = CommentRequestFixtures.ofDefault()
                 .withStaccatoId(staccato.getId()).build();
-        CommentRequest commentRequest2 = CommentRequestFixtures.defaultCommentRequest()
+        CommentRequest commentRequest2 = CommentRequestFixtures.ofDefault()
                 .withStaccatoId(staccato.getId()).build();
-        CommentRequest commentRequestOfAnotherStaccato = CommentRequestFixtures.defaultCommentRequest()
+        CommentRequest commentRequestOfAnotherStaccato = CommentRequestFixtures.ofDefault()
                 .withStaccatoId(anotherStaccato.getId()).build();
         long commentId1 = commentService.createComment(commentRequest1, member);
         long commentId2 = commentService.createComment(commentRequest2, member);
@@ -123,13 +123,13 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void readAllByStaccatoIdFailByForbidden() {
         // given
-        Member staccatoOwner = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member unexpectedMember = MemberFixtures.defaultMember().withNickname("otherMem")
+        Member staccatoOwner = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member unexpectedMember = MemberFixtures.ofDefault().withNickname("otherMem")
                 .buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment(staccato, staccatoOwner).buildAndSave(commentRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        CommentFixtures.ofDefault(staccato, staccatoOwner).buildAndSave(commentRepository);
 
         // when & then
         assertThatThrownBy(
@@ -142,13 +142,13 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void updateComment() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
-        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Comment comment = CommentFixtures.ofDefault(staccato, member).buildAndSave(commentRepository);
+        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.ofDefault().build();
 
         // when
         commentService.updateComment(member, comment.getId(), commentUpdateRequest);
@@ -163,11 +163,11 @@ class CommentServiceTest extends ServiceSliceTest {
     void updateCommentFailByNotExist() {
         // given
         long notExistCommentId = 1;
-        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
+        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.ofDefault().build();
 
         // when & then
         assertThatThrownBy(
-                () -> commentService.updateComment(MemberFixtures.defaultMember().build(), notExistCommentId,
+                () -> commentService.updateComment(MemberFixtures.ofDefault().build(), notExistCommentId,
                         commentUpdateRequest))
                 .isInstanceOf(StaccatoException.class)
                 .hasMessageContaining("요청하신 댓글을 찾을 수 없어요.");
@@ -177,15 +177,15 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void updateCommentFailByForbidden() {
         // given
-        Member staccatoOwner = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member unexpectedMember = MemberFixtures.defaultMember().withNickname("otherMem")
+        Member staccatoOwner = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member unexpectedMember = MemberFixtures.ofDefault().withNickname("otherMem")
                 .buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment(staccato, staccatoOwner)
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Comment comment = CommentFixtures.ofDefault(staccato, staccatoOwner)
                 .buildAndSave(commentRepository);
-        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
+        CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.ofDefault().build();
 
         // when & then
         assertThatThrownBy(() -> commentService.updateComment(unexpectedMember, comment.getId(),
@@ -198,12 +198,12 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void deleteComment() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Comment comment = CommentFixtures.ofDefault(staccato, member).buildAndSave(commentRepository);
 
         // when
         commentService.deleteComment(comment.getId(), member);
@@ -216,13 +216,13 @@ class CommentServiceTest extends ServiceSliceTest {
     @Test
     void deleteCommentFail() {
         // given
-        Member commentOwner = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member unexpectedMember = MemberFixtures.defaultMember().withNickname("otherMem")
+        Member commentOwner = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member unexpectedMember = MemberFixtures.ofDefault().withNickname("otherMem")
                 .buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(commentOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment(staccato, commentOwner).buildAndSave(commentRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Comment comment = CommentFixtures.ofDefault(staccato, commentOwner).buildAndSave(commentRepository);
 
         // when & then
         assertThatThrownBy(() -> commentService.deleteComment(comment.getId(), unexpectedMember))

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -129,9 +129,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(staccatoOwner).buildAndSave(commentRepository);
+        CommentFixtures.defaultComment(staccato, staccatoOwner).buildAndSave(commentRepository);
 
         // when & then
         assertThatThrownBy(
@@ -149,9 +147,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member).buildAndSave(commentRepository);
+        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
         CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
 
         // when
@@ -187,9 +183,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(staccatoOwner)
+        Comment comment = CommentFixtures.defaultComment(staccato, staccatoOwner)
                 .buildAndSave(commentRepository);
         CommentUpdateRequest commentUpdateRequest = CommentUpdateRequestFixtures.defaultCommentUpdateRequest().build();
 
@@ -209,9 +203,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member).buildAndSave(commentRepository);
+        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
 
         // when
         commentService.deleteComment(comment.getId(), member);
@@ -230,9 +222,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(commentOwner).buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(commentOwner).buildAndSave(commentRepository);
+        Comment comment = CommentFixtures.defaultComment(staccato, commentOwner).buildAndSave(commentRepository);
 
         // when & then
         assertThatThrownBy(() -> commentService.deleteComment(comment.getId(), unexpectedMember))

--- a/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
+++ b/backend/src/test/java/com/staccato/comment/service/CommentServiceTest.java
@@ -50,8 +50,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest().build();
 
         // when
@@ -83,8 +82,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest().build();
 
         // when & then
@@ -101,10 +99,8 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato anotherStaccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato anotherStaccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentRequest commentRequest1 = CommentRequestFixtures.defaultCommentRequest()
                 .withStaccatoId(staccato.getId()).build();
         CommentRequest commentRequest2 = CommentRequestFixtures.defaultCommentRequest()
@@ -132,8 +128,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(staccatoOwner).buildAndSave(commentRepository);
@@ -153,8 +148,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Comment comment = CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(member).buildAndSave(commentRepository);
@@ -192,8 +186,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(staccatoOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Comment comment = CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(staccatoOwner)
@@ -215,8 +208,7 @@ class CommentServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Comment comment = CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(member).buildAndSave(commentRepository);
@@ -237,8 +229,7 @@ class CommentServiceTest extends ServiceSliceTest {
                 .buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(commentOwner).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Comment comment = CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(commentOwner).buildAndSave(commentRepository);

--- a/backend/src/test/java/com/staccato/config/jwt/MemberTokenProviderTest.java
+++ b/backend/src/test/java/com/staccato/config/jwt/MemberTokenProviderTest.java
@@ -23,7 +23,7 @@ public class MemberTokenProviderTest extends ServiceSliceTest {
     public void setUp() {
         TokenProperties tokenProperties = new TokenProperties("test-secret-key");
         tokenProvider = new MemberTokenProvider(tokenProperties);
-        member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
     }
 
     @DisplayName("멤버 토큰은 멤버 아이디를 갖고 있다.")

--- a/backend/src/test/java/com/staccato/config/log/CreateStaccatoMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/CreateStaccatoMetricsAspectTest.java
@@ -46,7 +46,6 @@ class CreateStaccatoMetricsAspectTest extends ServiceSliceTest {
     List<DynamicTest> createStaccatoMetricsAspect() {
         Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         LocalDateTime now = LocalDateTime.now();

--- a/backend/src/test/java/com/staccato/config/log/CreateStaccatoMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/CreateStaccatoMetricsAspectTest.java
@@ -44,8 +44,8 @@ class CreateStaccatoMetricsAspectTest extends ServiceSliceTest {
     @DisplayName("기록 상의 날짜를 현재를 기준으로 과거 혹은 미래 인지 매트릭을 통해 표현 할 수 있습니다.")
     @TestFactory
     List<DynamicTest> createStaccatoMetricsAspect() {
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
         LocalDateTime now = LocalDateTime.now();
@@ -53,11 +53,11 @@ class CreateStaccatoMetricsAspectTest extends ServiceSliceTest {
         return List.of(
                 dynamicTest("기록 상의 날짜가 과거인 기록과 미래인 기록을 매트릭에 등록합니다.", () -> {
                     // given
-                    StaccatoRequest pastRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+                    StaccatoRequest pastRequest = StaccatoRequestFixtures.ofDefault()
                             .withVisitedAt(now.minusDays(2))
                             .withCategoryId(category.getId())
                             .build();
-                    StaccatoRequest futureRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+                    StaccatoRequest futureRequest = StaccatoRequestFixtures.ofDefault()
                             .withVisitedAt(now.plusDays(2))
                             .withCategoryId(category.getId())
                             .build();
@@ -74,7 +74,7 @@ class CreateStaccatoMetricsAspectTest extends ServiceSliceTest {
                 }),
                 dynamicTest("기록 상의 날짜가 과거인 기록 작성 요청 → 누적: past:2.0, future:1.0", () -> {
                     // given
-                    StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+                    StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                             .withVisitedAt(now.minusDays(3))
                             .withCategoryId(category.getId())
                             .build();

--- a/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
+++ b/backend/src/test/java/com/staccato/config/log/ReadAllCategoryMetricsAspectTest.java
@@ -27,7 +27,7 @@ public class ReadAllCategoryMetricsAspectTest extends ServiceSliceTest {
     @Test
     void testMetricsAfterServiceExecution() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         CategoryReadRequest categoryReadRequest = new CategoryReadRequest("with_term", "oldest");
 
         // when

--- a/backend/src/test/java/com/staccato/fixture/auth/LoginRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/auth/LoginRequestFixtures.java
@@ -4,7 +4,7 @@ import com.staccato.auth.service.dto.request.LoginRequest;
 
 public class LoginRequestFixtures {
 
-    public static LoginRequestBuilder defaultLoginRequest() {
+    public static LoginRequestBuilder ofDefault() {
         return new LoginRequestBuilder()
                 .withNickname("nickname");
     }

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryCreateRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryCreateRequestFixtures.java
@@ -7,7 +7,7 @@ import com.staccato.category.service.dto.request.CategoryCreateRequest;
 
 public class CategoryCreateRequestFixtures {
 
-    public static CategoryCreateRequestBuilder defaultCategoryCreateRequest() {
+    public static CategoryCreateRequestBuilder ofDefault() {
         return new CategoryCreateRequestBuilder()
                 .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                 .withCategoryTitle("categoryTitle")

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryCreateRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryCreateRequestFixtures.java
@@ -13,8 +13,7 @@ public class CategoryCreateRequestFixtures {
                 .withCategoryTitle("categoryTitle")
                 .withDescription("categoryDescription")
                 .withColor(Color.PINK.getName())
-                .withTerm(LocalDate.of(2024, 1, 1),
-                        LocalDate.of(2024, 12, 31))
+                .withTerm(null, null)
                 .withIsShared(false);
     }
 

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
@@ -13,7 +13,7 @@ import com.staccato.member.domain.Member;
 
 public class CategoryFixtures {
 
-    public static CategoryBuilder defaultCategory() {
+    public static CategoryBuilder ofDefault() {
         return new CategoryBuilder()
                 .withThumbnailUrl("https://example.com/categoryThumbnail.jpg")
                 .withTitle("categoryTitle")

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryFixtures.java
@@ -19,8 +19,7 @@ public class CategoryFixtures {
                 .withTitle("categoryTitle")
                 .withDescription("categoryDescription")
                 .withColor(Color.PINK)
-                .withTerm(LocalDate.of(2024, 1, 1),
-                        LocalDate.of(2024, 12, 31))
+                .withTerm(null, null)
                 .withIsShared(false);
     }
 

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryMemberFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryMemberFixtures.java
@@ -8,7 +8,7 @@ import com.staccato.member.domain.Member;
 
 public class CategoryMemberFixtures {
 
-    public static CategoryMemberBuilder defaultCategoryMember() {
+    public static CategoryMemberBuilder ofDefault() {
         return new CategoryMemberBuilder()
                 .withRole(Role.HOST);
     }

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryRequestFixtures.java
@@ -7,7 +7,7 @@ import com.staccato.category.service.dto.request.CategoryRequest;
 
 public class CategoryRequestFixtures {
 
-    public static CategoryRequestBuilder defaultCategoryRequest() {
+    public static CategoryRequestBuilder ofDefault() {
         return new CategoryRequestBuilder()
                 .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                 .withCategoryTitle("categoryTitle")

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryRequestFixtures.java
@@ -12,8 +12,7 @@ public class CategoryRequestFixtures {
                 .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                 .withCategoryTitle("categoryTitle")
                 .withDescription("categoryDescription")
-                .withTerm(LocalDate.of(2024, 1, 1),
-                        LocalDate.of(2024, 12, 31));
+                .withTerm(null, null);
     }
 
     public static class CategoryRequestBuilder {

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryRequestV2Fixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryRequestV2Fixtures.java
@@ -7,7 +7,7 @@ import com.staccato.category.service.dto.request.CategoryRequestV2;
 
 public class CategoryRequestV2Fixtures {
 
-    public static CategoryRequestV2Builder defaultCategoryRequestV2() {
+    public static CategoryRequestV2Builder ofDefault() {
         return new CategoryRequestV2Builder()
                 .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                 .withCategoryTitle("categoryTitle")

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryRequestV2Fixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryRequestV2Fixtures.java
@@ -13,8 +13,7 @@ public class CategoryRequestV2Fixtures {
                 .withCategoryTitle("categoryTitle")
                 .withDescription("categoryDescription")
                 .withColor(Color.PINK.getName())
-                .withTerm(LocalDate.of(2024, 1, 1),
-                        LocalDate.of(2024, 12, 31));
+                .withTerm(null, null);
     }
 
     public static class CategoryRequestV2Builder {

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryUpdateRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryUpdateRequestFixtures.java
@@ -13,8 +13,7 @@ public class CategoryUpdateRequestFixtures {
                 .withCategoryTitle("categoryTitle")
                 .withDescription("categoryDescription")
                 .withColor(Color.PINK.getName())
-                .withTerm(LocalDate.of(2024, 1, 1),
-                        LocalDate.of(2024, 12, 31));
+                .withTerm(null, null);
     }
 
     public static class CategoryUpdateRequestBuilder {

--- a/backend/src/test/java/com/staccato/fixture/category/CategoryUpdateRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/category/CategoryUpdateRequestFixtures.java
@@ -7,7 +7,7 @@ import com.staccato.category.service.dto.request.CategoryUpdateRequest;
 
 public class CategoryUpdateRequestFixtures {
 
-    public static CategoryUpdateRequestBuilder defaultCategoryUpdateRequest() {
+    public static CategoryUpdateRequestBuilder ofDefault() {
         return new CategoryUpdateRequestBuilder()
                 .withCategoryThumbnailUrl("https://example.com/categoryThumbnailUrl.jpg")
                 .withCategoryTitle("categoryTitle")

--- a/backend/src/test/java/com/staccato/fixture/comment/CommentFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/comment/CommentFixtures.java
@@ -7,8 +7,10 @@ import com.staccato.staccato.domain.Staccato;
 
 public class CommentFixtures {
 
-    public static CommentBuilder defaultComment() {
+    public static CommentBuilder defaultComment(Staccato staccato, Member member) {
         return new CommentBuilder()
+                .withStaccato(staccato)
+                .withMember(member)
                 .withContent("commentContent");
     }
 

--- a/backend/src/test/java/com/staccato/fixture/comment/CommentFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/comment/CommentFixtures.java
@@ -7,7 +7,7 @@ import com.staccato.staccato.domain.Staccato;
 
 public class CommentFixtures {
 
-    public static CommentBuilder defaultComment(Staccato staccato, Member member) {
+    public static CommentBuilder ofDefault(Staccato staccato, Member member) {
         return new CommentBuilder()
                 .withStaccato(staccato)
                 .withMember(member)

--- a/backend/src/test/java/com/staccato/fixture/comment/CommentRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/comment/CommentRequestFixtures.java
@@ -4,7 +4,7 @@ import com.staccato.comment.service.dto.request.CommentRequest;
 
 public class CommentRequestFixtures {
 
-    public static CommentRequestBuilder defaultCommentRequest() {
+    public static CommentRequestBuilder ofDefault() {
         return new CommentRequestBuilder()
                 .withStaccatoId(1L)
                 .withContent("commentContent");

--- a/backend/src/test/java/com/staccato/fixture/comment/CommentUpdateRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/comment/CommentUpdateRequestFixtures.java
@@ -4,7 +4,7 @@ import com.staccato.comment.service.dto.request.CommentUpdateRequest;
 
 public class CommentUpdateRequestFixtures {
 
-    public static CommentUpdateRequestBuilder defaultCommentUpdateRequest() {
+    public static CommentUpdateRequestBuilder ofDefault() {
         return new CommentUpdateRequestBuilder()
                 .withContent("commentUpdateContent");
     }

--- a/backend/src/test/java/com/staccato/fixture/member/MemberFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/member/MemberFixtures.java
@@ -8,7 +8,7 @@ import com.staccato.member.repository.MemberRepository;
 
 public class MemberFixtures {
 
-    public static MemberBuilder defaultMember() {
+    public static MemberBuilder ofDefault() {
         return new MemberBuilder()
                 .withNickname("nickname")
                 .withImageUrl("https://example.com/memberImage.png")

--- a/backend/src/test/java/com/staccato/fixture/member/MemberReadRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/member/MemberReadRequestFixtures.java
@@ -3,7 +3,8 @@ package com.staccato.fixture.member;
 import com.staccato.member.service.dto.request.MemberReadRequest;
 
 public class MemberReadRequestFixtures {
-    public static MemberReadRequestBuilder defaultMemberReadRequest() {
+
+    public static MemberReadRequestBuilder ofDefault() {
         return new MemberReadRequestBuilder()
                 .withNickname("member");
     }

--- a/backend/src/test/java/com/staccato/fixture/notification/NotificationTokenFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/notification/NotificationTokenFixtures.java
@@ -7,7 +7,7 @@ import com.staccato.notification.repository.NotificationTokenRepository;
 
 public class NotificationTokenFixtures {
 
-    public static NotificationTokenBuilder defaultNotificationToken(Member member) {
+    public static NotificationTokenBuilder ofDefault(Member member) {
         return new NotificationTokenBuilder()
                 .withToken("default-token")
                 .withMember(member)

--- a/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
@@ -15,7 +15,7 @@ import com.staccato.staccato.repository.StaccatoRepository;
 
 public class StaccatoFixtures {
 
-    public static StaccatoBuilder defaultStaccato(Category category) {
+    public static StaccatoBuilder ofDefault(Category category) {
         return new StaccatoBuilder()
                 .withCategory(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))

--- a/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/staccato/StaccatoFixtures.java
@@ -15,8 +15,9 @@ import com.staccato.staccato.repository.StaccatoRepository;
 
 public class StaccatoFixtures {
 
-    public static StaccatoBuilder defaultStaccato() {
+    public static StaccatoBuilder defaultStaccato(Category category) {
         return new StaccatoBuilder()
+                .withCategory(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .withTitle("staccatoTitle")
                 .withFeeling(Feeling.NOTHING)

--- a/backend/src/test/java/com/staccato/fixture/staccato/StaccatoRequestFixtures.java
+++ b/backend/src/test/java/com/staccato/fixture/staccato/StaccatoRequestFixtures.java
@@ -8,7 +8,7 @@ import com.staccato.staccato.service.dto.request.StaccatoRequest;
 
 public class StaccatoRequestFixtures {
 
-    public static StaccatoBuilder defaultStaccatoRequest() {
+    public static StaccatoBuilder ofDefault() {
         return new StaccatoBuilder()
                 .withStaccatoTitle("staccatoTitle")
                 .withPlaceName("placeName")

--- a/backend/src/test/java/com/staccato/image/service/ImageServiceTest.java
+++ b/backend/src/test/java/com/staccato/image/service/ImageServiceTest.java
@@ -46,8 +46,7 @@ class ImageServiceTest extends ServiceSliceTest {
                 .withThumbnailUrl(FAKE_CLOUD_FRONT_END_POINT + "/" + "images/category.jpg")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato()
-                .withCategory(category).withStaccatoImages(
+        StaccatoFixtures.defaultStaccato(category).withStaccatoImages(
                         List.of(FAKE_CLOUD_FRONT_END_POINT + "/" + "images/staccato1-1.jpg",
                                 FAKE_CLOUD_FRONT_END_POINT + "/" + "images/staccato1-2.jpg"))
                 .buildAndSave(staccatoRepository);

--- a/backend/src/test/java/com/staccato/image/service/ImageServiceTest.java
+++ b/backend/src/test/java/com/staccato/image/service/ImageServiceTest.java
@@ -41,12 +41,12 @@ class ImageServiceTest extends ServiceSliceTest {
     @Test
     void deleteUnusedImages() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withThumbnailUrl(FAKE_CLOUD_FRONT_END_POINT + "/" + "images/category.jpg")
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoFixtures.defaultStaccato(category).withStaccatoImages(
+        StaccatoFixtures.ofDefault(category).withStaccatoImages(
                         List.of(FAKE_CLOUD_FRONT_END_POINT + "/" + "images/staccato1-1.jpg",
                                 FAKE_CLOUD_FRONT_END_POINT + "/" + "images/staccato1-2.jpg"))
                 .buildAndSave(staccatoRepository);

--- a/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
+++ b/backend/src/test/java/com/staccato/invitation/controller/InvitationControllerTest.java
@@ -35,7 +35,7 @@ class InvitationControllerTest extends ControllerTest {
     void inviteMembers() throws Exception {
         // given
         long categoryId = 1L;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         String invitationRequest = """
                 {
@@ -83,7 +83,7 @@ class InvitationControllerTest extends ControllerTest {
     void cancel() throws Exception {
         // given
         long invitationId = 1L;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
 
         // when & then
@@ -110,7 +110,7 @@ class InvitationControllerTest extends ControllerTest {
     @Test
     void readSentInvitations() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
 
         when(invitationService.readSentInvitations(any(Member.class)))
@@ -154,7 +154,7 @@ class InvitationControllerTest extends ControllerTest {
     void accept() throws Exception {
         // given
         long invitationId = 1L;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
 
         // when & then
@@ -182,7 +182,7 @@ class InvitationControllerTest extends ControllerTest {
     void reject() throws Exception {
         // given
         long invitationId = 1L;
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
 
         // when & then
@@ -209,7 +209,7 @@ class InvitationControllerTest extends ControllerTest {
     @Test
     void readReceivedInvitations() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
 
         when(invitationService.readReceivedInvitations(any(Member.class)))

--- a/backend/src/test/java/com/staccato/invitation/domain/CategoryInvitationTest.java
+++ b/backend/src/test/java/com/staccato/invitation/domain/CategoryInvitationTest.java
@@ -23,9 +23,9 @@ class CategoryInvitationTest {
 
     @BeforeEach
     void init() {
-        host = MemberFixtures.defaultMember().withNickname("host").build();
-        guest = MemberFixtures.defaultMember().withNickname("guest").build();
-        category = CategoryFixtures.defaultCategory().withHost(host).build();
+        host = MemberFixtures.ofDefault().withNickname("host").build();
+        guest = MemberFixtures.ofDefault().withNickname("guest").build();
+        category = CategoryFixtures.ofDefault().withHost(host).build();
     }
 
     @DisplayName("주어진 카테고리, 초대자, 초대 대상에 대한 초대 내역(REQUESTED)를 생성한다.")

--- a/backend/src/test/java/com/staccato/invitation/repository/CategoryInvitationRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/invitation/repository/CategoryInvitationRepositoryTest.java
@@ -36,13 +36,13 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     void init() {
-        host = MemberFixtures.defaultMember()
+        host = MemberFixtures.ofDefault()
                 .withNickname("host")
                 .buildAndSave(memberRepository);
-        guest = MemberFixtures.defaultMember()
+        guest = MemberFixtures.ofDefault()
                 .withNickname("guest")
                 .buildAndSave(memberRepository);
-        category = CategoryFixtures.defaultCategory()
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
     }
@@ -51,10 +51,10 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
     @Test
     void readAllByInviter() {
         // given
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category otherCategory = CategoryFixtures.defaultCategory()
+        Category otherCategory = CategoryFixtures.ofDefault()
                 .withHost(guest)
                 .buildAndSave(categoryRepository);
         CategoryInvitation invitation = CategoryInvitation.invite(category, host, guest);
@@ -75,9 +75,9 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
     @Test
     void readAllByInviterOnlyReturnsRequestedStatus() {
         // given
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
-        Member guest3 = MemberFixtures.defaultMember().withNickname("guest3").buildAndSave(memberRepository);
-        Member guest4 = MemberFixtures.defaultMember().withNickname("guest4").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
+        Member guest3 = MemberFixtures.ofDefault().withNickname("guest3").buildAndSave(memberRepository);
+        Member guest4 = MemberFixtures.ofDefault().withNickname("guest4").buildAndSave(memberRepository);
         CategoryInvitation invitationRequested = CategoryInvitation.invite(category, host, guest);
         CategoryInvitation invitationCanceled = CategoryInvitation.invite(category, host, guest2);
         CategoryInvitation invitationAccepted = CategoryInvitation.invite(category, host, guest3);
@@ -106,10 +106,10 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
     @Test
     void readAllByInvitee() {
         // given
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
-        Category otherCategory = CategoryFixtures.defaultCategory()
+        Category otherCategory = CategoryFixtures.ofDefault()
                 .withHost(guest)
                 .buildAndSave(categoryRepository);
         CategoryInvitation invitation = CategoryInvitation.invite(category, host, guest);
@@ -130,9 +130,9 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
     @Test
     void readAllByInviteeOnlyReturnsRequestedStatus() {
         // given
-        Category category2 = CategoryFixtures.defaultCategory().withTitle("category2").withHost(host).buildAndSave(categoryRepository);
-        Category category3 = CategoryFixtures.defaultCategory().withTitle("category3").withHost(host).buildAndSave(categoryRepository);
-        Category category4 = CategoryFixtures.defaultCategory().withTitle("category4").withHost(host).buildAndSave(categoryRepository);
+        Category category2 = CategoryFixtures.ofDefault().withTitle("category2").withHost(host).buildAndSave(categoryRepository);
+        Category category3 = CategoryFixtures.ofDefault().withTitle("category3").withHost(host).buildAndSave(categoryRepository);
+        Category category4 = CategoryFixtures.ofDefault().withTitle("category4").withHost(host).buildAndSave(categoryRepository);
         CategoryInvitation invitationRequested = CategoryInvitation.invite(category, host, guest);
         CategoryInvitation invitationCanceled = CategoryInvitation.invite(category2, host, guest);
         CategoryInvitation invitationAccepted = CategoryInvitation.invite(category3, host, guest);
@@ -161,8 +161,8 @@ class CategoryInvitationRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByCategoryIdInBulk() {
         // given
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
-        category = CategoryFixtures.defaultCategory()
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest, guest2))
                 .buildAndSave(categoryRepository);

--- a/backend/src/test/java/com/staccato/invitation/service/InvitationServiceTest.java
+++ b/backend/src/test/java/com/staccato/invitation/service/InvitationServiceTest.java
@@ -60,9 +60,9 @@ class InvitationServiceTest extends ServiceSliceTest {
 
     @BeforeEach
     void init() {
-        host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        category = CategoryFixtures.defaultCategory()
+        host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
     }
@@ -71,7 +71,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void invite() {
         // given
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
         CategoryInvitationRequest invitationRequest = new CategoryInvitationRequest(category.getId(), Set.of(guest.getId(), guest2.getId()));
 
         // when
@@ -100,7 +100,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void failToInviteIfNotHost() {
         // given
-        Member anotherUser = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
+        Member anotherUser = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
         CategoryInvitationRequest invitationRequest = new CategoryInvitationRequest(category.getId(), Set.of(guest.getId()));
 
         // when & then
@@ -132,7 +132,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void failIfAlreadyCategoryMember() {
         // given
-        category = CategoryFixtures.defaultCategory()
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -167,10 +167,10 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void inviteMixedSuccessAndFailure() {
         // given
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
-        Member guest3 = MemberFixtures.defaultMember().withNickname("guest3").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
+        Member guest3 = MemberFixtures.ofDefault().withNickname("guest3").buildAndSave(memberRepository);
 
-        category = CategoryFixtures.defaultCategory()
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -192,7 +192,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void readAllSentInvitations() {
         // given
-        Member guest2 = MemberFixtures.defaultMember().withNickname("guest2").buildAndSave(memberRepository);
+        Member guest2 = MemberFixtures.ofDefault().withNickname("guest2").buildAndSave(memberRepository);
         CategoryInvitation invitation = categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
         CategoryInvitation invitation2 = categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest2));
 
@@ -305,7 +305,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     void acceptDoesNotThrowWhenMemberAlreadyInCategory() {
         // given
         CategoryInvitation invitation = categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
-        CategoryMemberFixtures.defaultCategoryMember()
+        CategoryMemberFixtures.ofDefault()
                 .withCategory(category)
                 .withMember(guest)
                 .buildAndSave(categoryMemberRepository);
@@ -368,7 +368,7 @@ class InvitationServiceTest extends ServiceSliceTest {
     @Test
     void readAllReceivedInvitations() {
         // given
-        Member host2 = MemberFixtures.defaultMember().withNickname("host2").buildAndSave(memberRepository);
+        Member host2 = MemberFixtures.ofDefault().withNickname("host2").buildAndSave(memberRepository);
         CategoryInvitation invitation = categoryInvitationRepository.save(CategoryInvitation.invite(category, host, guest));
         CategoryInvitation invitation2 = categoryInvitationRepository.save(CategoryInvitation.invite(category, host2, guest));
 

--- a/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MemberControllerTest.java
@@ -23,8 +23,8 @@ class MemberControllerTest extends ControllerTest {
     @Test
     void readMembersByNickname() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("스타카토").build();
-        Member member2 = MemberFixtures.defaultMember().withNickname("스타").build();
+        Member member = MemberFixtures.ofDefault().withNickname("스타카토").build();
+        Member member2 = MemberFixtures.ofDefault().withNickname("스타").build();
         MemberSearchResponses memberSearchResponses = MemberSearchResponses.none(List.of(member2));
         when(authService.extractFromToken(anyString())).thenReturn(member);
         when(memberService.readMembersByNickname(any(Member.class), any(MemberReadRequest.class))).thenReturn(memberSearchResponses);
@@ -55,7 +55,7 @@ class MemberControllerTest extends ControllerTest {
     @Test
     void readMemberWithoutNickname() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("스타카토").build();
+        Member member = MemberFixtures.ofDefault().withNickname("스타카토").build();
         MemberSearchResponses response = MemberSearchResponses.empty();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         when(memberService.readMembersByNickname(any(Member.class), any(MemberReadRequest.class))).thenReturn(response);
@@ -78,8 +78,8 @@ class MemberControllerTest extends ControllerTest {
     @Test
     void readMemberWithoutCategoryId() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("스타카토").build();
-        Member member2 = MemberFixtures.defaultMember().withNickname("스타").build();
+        Member member = MemberFixtures.ofDefault().withNickname("스타카토").build();
+        Member member2 = MemberFixtures.ofDefault().withNickname("스타").build();
         MemberSearchResponses response = MemberSearchResponses.none(List.of(member2));
         when(authService.extractFromToken(anyString())).thenReturn(member);
         when(memberService.readMembersByNickname(any(Member.class), any(MemberReadRequest.class))).thenReturn(response);

--- a/backend/src/test/java/com/staccato/member/controller/MyPageControllerTest.java
+++ b/backend/src/test/java/com/staccato/member/controller/MyPageControllerTest.java
@@ -50,7 +50,7 @@ class MyPageControllerTest extends ControllerTest {
     @Test
     void readMyPage() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withCode("550e8400-e29b-41d4-a716-446655440000").build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         String expectedResponse = """

--- a/backend/src/test/java/com/staccato/member/controller/MyPageControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/member/controller/MyPageControllerV2Test.java
@@ -18,7 +18,7 @@ class MyPageControllerV2Test extends ControllerTest {
     @Test
     void readMyPage() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withNickname("nickname")
                 .withCode("550e8400-e29b-41d4-a716-446655440000").build();
         when(authService.extractFromToken(anyString())).thenReturn(member);

--- a/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/staccato/member/service/MemberServiceTest.java
@@ -43,7 +43,7 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void changeProfileImage() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         String imageUrl = "image.jpg";
 
         // when
@@ -61,7 +61,7 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void cannotChangeUnknownProfileImage() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
         memberRepository.delete(member);
         String imageUrl = "image.jpg";
 
@@ -75,20 +75,20 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersByNickname() {
         // given
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withNickname("사용자")
                 .buildAndSave(memberRepository);
-        Member member1 = MemberFixtures.defaultMember()
+        Member member1 = MemberFixtures.ofDefault()
                 .withNickname("스타카토")
                 .buildAndSave(memberRepository);
-        Member member2 = MemberFixtures.defaultMember()
+        Member member2 = MemberFixtures.ofDefault()
                 .withNickname("스타")
                 .buildAndSave(memberRepository);
-        Member member3 = MemberFixtures.defaultMember()
+        Member member3 = MemberFixtures.ofDefault()
                 .withNickname("타스")
                 .buildAndSave(memberRepository);
         String keyword = "스타";
-        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.ofDefault()
                 .withNickname(keyword)
                 .withExcludeCategoryId(0L)
                 .build();
@@ -115,7 +115,7 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMemberWithoutOneself() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("me").buildAndSave(memberRepository);
+        Member me = MemberFixtures.ofDefault().withNickname("me").buildAndSave(memberRepository);
         MemberReadRequest memberReadRequest = new MemberReadRequest("me", null);
 
         // when
@@ -131,13 +131,13 @@ class MemberServiceTest extends ServiceSliceTest {
     @ValueSource(strings = {" "})
     void readMembersByBlankNickname(String keyword) {
         // given
-        Member member = MemberFixtures.defaultMember()
+        Member member = MemberFixtures.ofDefault()
                 .withNickname("스타")
                 .buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest memberReadRequest = MemberReadRequestFixtures.ofDefault()
                 .withNickname(keyword)
                 .withExcludeCategoryId(category.getId())
                 .build();
@@ -153,13 +153,13 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersWithRequestedStatus() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("나").buildAndSave(memberRepository);
-        Member invited = MemberFixtures.defaultMember().withNickname("스타").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().withHost(me).buildAndSave(categoryRepository);
+        Member me = MemberFixtures.ofDefault().withNickname("나").buildAndSave(memberRepository);
+        Member invited = MemberFixtures.ofDefault().withNickname("스타").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().withHost(me).buildAndSave(categoryRepository);
 
         categoryInvitationRepository.save(CategoryInvitation.invite(category, me, invited));
 
-        MemberReadRequest request = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest request = MemberReadRequestFixtures.ofDefault()
                 .withNickname("스타")
                 .withExcludeCategoryId(category.getId())
                 .build();
@@ -179,14 +179,14 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersWithCategoryIdAndRequestedStatus() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("나").buildAndSave(memberRepository);
-        Member invited = MemberFixtures.defaultMember().withNickname("스타").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().withHost(me).buildAndSave(categoryRepository);
+        Member me = MemberFixtures.ofDefault().withNickname("나").buildAndSave(memberRepository);
+        Member invited = MemberFixtures.ofDefault().withNickname("스타").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().withHost(me).buildAndSave(categoryRepository);
 
         categoryInvitationRepository.save(CategoryInvitation.invite(category, me, invited));
 
         long excludeCategoryId = category.getId() + 1;
-        MemberReadRequest request = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest request = MemberReadRequestFixtures.ofDefault()
                 .withNickname("스타")
                 .withExcludeCategoryId(excludeCategoryId)
                 .build();
@@ -206,12 +206,12 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersWithJoinedStatus() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("나").buildAndSave(memberRepository);
-        Member joined = MemberFixtures.defaultMember().withNickname("스타카토").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().withHost(me).withGuests(List.of(joined))
+        Member me = MemberFixtures.ofDefault().withNickname("나").buildAndSave(memberRepository);
+        Member joined = MemberFixtures.ofDefault().withNickname("스타카토").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().withHost(me).withGuests(List.of(joined))
                 .buildAndSave(categoryRepository);
 
-        MemberReadRequest request = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest request = MemberReadRequestFixtures.ofDefault()
                 .withNickname("스타")
                 .withExcludeCategoryId(category.getId())
                 .build();
@@ -231,13 +231,13 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersWithCategoryIdAndNoneStatus() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("나").buildAndSave(memberRepository);
-        Member joined = MemberFixtures.defaultMember().withNickname("스타카토").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().withHost(me).withGuests(List.of(joined))
+        Member me = MemberFixtures.ofDefault().withNickname("나").buildAndSave(memberRepository);
+        Member joined = MemberFixtures.ofDefault().withNickname("스타카토").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().withHost(me).withGuests(List.of(joined))
                 .buildAndSave(categoryRepository);
 
         long excludeCategoryId = category.getId() + 1;
-        MemberReadRequest request = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest request = MemberReadRequestFixtures.ofDefault()
                 .withNickname("스타")
                 .withExcludeCategoryId(excludeCategoryId)
                 .build();
@@ -257,10 +257,10 @@ class MemberServiceTest extends ServiceSliceTest {
     @Test
     void readMembersWithoutExcludeCategoryId() {
         // given
-        Member me = MemberFixtures.defaultMember().withNickname("나").buildAndSave(memberRepository);
-        Member none = MemberFixtures.defaultMember().withNickname("스타").buildAndSave(memberRepository);
+        Member me = MemberFixtures.ofDefault().withNickname("나").buildAndSave(memberRepository);
+        Member none = MemberFixtures.ofDefault().withNickname("스타").buildAndSave(memberRepository);
 
-        MemberReadRequest request = MemberReadRequestFixtures.defaultMemberReadRequest()
+        MemberReadRequest request = MemberReadRequestFixtures.ofDefault()
                 .withNickname("스타")
                 .withExcludeCategoryId(0L)
                 .build();

--- a/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
+++ b/backend/src/test/java/com/staccato/notification/controller/NotificationControllerTest.java
@@ -24,7 +24,7 @@ class NotificationControllerTest extends ControllerTest {
     @Test
     void readMyPage() throws Exception {
         // given
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         when(authService.extractFromToken(anyString())).thenReturn(member);
         when(notificationService.isExistNotifications(any(Member.class))).thenReturn(new NotificationExistResponse(true));
         String expectedResponse = """
@@ -44,7 +44,7 @@ class NotificationControllerTest extends ControllerTest {
     @Test
     void register() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         String notificationTokenRequest = """
                 {
                   "token": "example-fcm-token",
@@ -63,7 +63,7 @@ class NotificationControllerTest extends ControllerTest {
     @Test
     void failRegister() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         ExceptionResponse exceptionResponse = new ExceptionResponse(
                 HttpStatus.BAD_REQUEST.toString(), "토큰 값을 입력해주세요.");
         String notificationTokenRequest = """

--- a/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
@@ -115,8 +115,7 @@ class NotificationEventListenerTest extends ServiceSliceTest {
                 .withHost(host)
                 .withGuests(List.of(guest, commentCreator))
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .buildAndSave(staccatoRepository);
 
         CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest()

--- a/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
+++ b/backend/src/test/java/com/staccato/notification/listener/NotificationEventListenerTest.java
@@ -64,19 +64,19 @@ class NotificationEventListenerTest extends ServiceSliceTest {
     @Test
     void handleNewStaccato() {
         // given
-        Member host = MemberFixtures.defaultMember()
+        Member host = MemberFixtures.ofDefault()
                 .withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember()
+        Member guest = MemberFixtures.ofDefault()
                 .withNickname("guest").buildAndSave(memberRepository);
-        Member staccatoCreator = MemberFixtures.defaultMember()
+        Member staccatoCreator = MemberFixtures.ofDefault()
                 .withNickname("creator").buildAndSave(memberRepository);
 
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest, staccatoCreator))
                 .buildAndSave(categoryRepository);
 
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId()).build();
 
         // when
@@ -104,21 +104,21 @@ class NotificationEventListenerTest extends ServiceSliceTest {
     @Test
     void handleNewComment() {
         // given
-        Member host = MemberFixtures.defaultMember()
+        Member host = MemberFixtures.ofDefault()
                 .withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember()
+        Member guest = MemberFixtures.ofDefault()
                 .withNickname("guest").buildAndSave(memberRepository);
-        Member commentCreator = MemberFixtures.defaultMember()
+        Member commentCreator = MemberFixtures.ofDefault()
                 .withNickname("creator").buildAndSave(memberRepository);
 
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest, commentCreator))
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .buildAndSave(staccatoRepository);
 
-        CommentRequest commentRequest = CommentRequestFixtures.defaultCommentRequest()
+        CommentRequest commentRequest = CommentRequestFixtures.ofDefault()
                 .withStaccatoId(staccato.getId()).build();
 
         // when
@@ -146,16 +146,16 @@ class NotificationEventListenerTest extends ServiceSliceTest {
     @Test
     void handleInvitation() {
         // given
-        Member host = MemberFixtures.defaultMember()
+        Member host = MemberFixtures.ofDefault()
                 .withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember()
+        Member guest = MemberFixtures.ofDefault()
                 .withNickname("guest").buildAndSave(memberRepository);
-        Member invitee1 = MemberFixtures.defaultMember()
+        Member invitee1 = MemberFixtures.ofDefault()
                 .withNickname("invitee1").buildAndSave(memberRepository);
-        Member invitee2 = MemberFixtures.defaultMember()
+        Member invitee2 = MemberFixtures.ofDefault()
                 .withNickname("invitee2").buildAndSave(memberRepository);
 
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
@@ -182,14 +182,14 @@ class NotificationEventListenerTest extends ServiceSliceTest {
     @Test
     void handleInvitationAccepted() {
         // given
-        Member host = MemberFixtures.defaultMember()
+        Member host = MemberFixtures.ofDefault()
                 .withNickname("host").buildAndSave(memberRepository);
-        Member guest = MemberFixtures.defaultMember()
+        Member guest = MemberFixtures.ofDefault()
                 .withNickname("guest").buildAndSave(memberRepository);
-        Member invitee = MemberFixtures.defaultMember()
+        Member invitee = MemberFixtures.ofDefault()
                 .withNickname("invitee").buildAndSave(memberRepository);
 
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);

--- a/backend/src/test/java/com/staccato/notification/repository/NotificationTokenRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/notification/repository/NotificationTokenRepositoryTest.java
@@ -26,14 +26,14 @@ class NotificationTokenRepositoryTest extends RepositoryTest {
 
     @BeforeEach
     void setUp() {
-        member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
     }
 
     @DisplayName("사용자의 토큰을 조회할 수 있다.")
     @Test
     void findByMember() {
         // given
-        NotificationToken token = NotificationTokenFixtures.defaultNotificationToken(member)
+        NotificationToken token = NotificationTokenFixtures.ofDefault(member)
                 .buildAndSave(notificationTokenRepository);
 
         // when
@@ -51,7 +51,7 @@ class NotificationTokenRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByToken() {
         // given
-        NotificationToken token = NotificationTokenFixtures.defaultNotificationToken(member)
+        NotificationToken token = NotificationTokenFixtures.ofDefault(member)
                 .withToken("token-to-delete")
                 .buildAndSave(notificationTokenRepository);
 
@@ -67,14 +67,14 @@ class NotificationTokenRepositoryTest extends RepositoryTest {
     @Test
     void findByMemberIn() {
         // given
-        Member member1 = MemberFixtures.defaultMember().withNickname("user1").buildAndSave(memberRepository);
-        Member member2 = MemberFixtures.defaultMember().withNickname("user2").buildAndSave(memberRepository);
+        Member member1 = MemberFixtures.ofDefault().withNickname("user1").buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.ofDefault().withNickname("user2").buildAndSave(memberRepository);
 
-        NotificationToken token1 = NotificationTokenFixtures.defaultNotificationToken(member1)
+        NotificationToken token1 = NotificationTokenFixtures.ofDefault(member1)
                 .withToken("token-1")
                 .buildAndSave(notificationTokenRepository);
 
-        NotificationToken token2 = NotificationTokenFixtures.defaultNotificationToken(member2)
+        NotificationToken token2 = NotificationTokenFixtures.ofDefault(member2)
                 .withToken("token-2")
                 .buildAndSave(notificationTokenRepository);
 

--- a/backend/src/test/java/com/staccato/notification/service/FcmServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/FcmServiceTest.java
@@ -58,8 +58,8 @@ class FcmServiceTest {
     }
 
     private PushMessage dummyPushMessage() {
-        Member inviter = MemberFixtures.defaultMember().build();
-        Category category = CategoryFixtures.defaultCategory().build();
+        Member inviter = MemberFixtures.ofDefault().build();
+        Category category = CategoryFixtures.ofDefault().build();
 
         return new ReceiveInvitationMessage(inviter, category);
     }

--- a/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
@@ -67,25 +67,25 @@ class NotificationServiceTest extends ServiceSliceTest {
 
     @BeforeEach
     void setUp() {
-        host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        guest = MemberFixtures.defaultMember().withNickname("guest").buildAndSave(memberRepository);
-        other = MemberFixtures.defaultMember().withNickname("other").buildAndSave(memberRepository);
-        category = CategoryFixtures.defaultCategory()
+        host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        guest = MemberFixtures.ofDefault().withNickname("guest").buildAndSave(memberRepository);
+        other = MemberFixtures.ofDefault().withNickname("other").buildAndSave(memberRepository);
+        category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
-        staccato = StaccatoFixtures.defaultStaccato(category)
+        staccato = StaccatoFixtures.ofDefault(category)
                 .buildAndSave(staccatoRepository);
-        comment = CommentFixtures.defaultComment(staccato, host)
+        comment = CommentFixtures.ofDefault(staccato, host)
                 .buildAndSave(commentRepository);
 
-        NotificationTokenFixtures.defaultNotificationToken(host)
+        NotificationTokenFixtures.ofDefault(host)
                 .withToken("hostToken")
                 .buildAndSave(notificationTokenRepository);
-        NotificationTokenFixtures.defaultNotificationToken(guest)
+        NotificationTokenFixtures.ofDefault(guest)
                 .withToken("guestToken")
                 .buildAndSave(notificationTokenRepository);
-        NotificationTokenFixtures.defaultNotificationToken(other)
+        NotificationTokenFixtures.ofDefault(other)
                 .withToken("otherToken")
                 .buildAndSave(notificationTokenRepository);
     }
@@ -169,8 +169,8 @@ class NotificationServiceTest extends ServiceSliceTest {
     @Test
     void registerNewToken() {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("newbie").buildAndSave(memberRepository);
-        NotificationToken notificationToken = NotificationTokenFixtures.defaultNotificationToken(member).build();
+        Member member = MemberFixtures.ofDefault().withNickname("newbie").buildAndSave(memberRepository);
+        NotificationToken notificationToken = NotificationTokenFixtures.ofDefault(member).build();
         NotificationTokenRequest notificationTokenRequest = new NotificationTokenRequest(
                 notificationToken.getToken(),
                 notificationToken.getDeviceType().getName(),
@@ -195,8 +195,8 @@ class NotificationServiceTest extends ServiceSliceTest {
     @Test
     void updateTokenValueWhenSameTokenExists() {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("member").buildAndSave(memberRepository);
-        NotificationToken oldToken = NotificationTokenFixtures.defaultNotificationToken(member)
+        Member member = MemberFixtures.ofDefault().withNickname("member").buildAndSave(memberRepository);
+        NotificationToken oldToken = NotificationTokenFixtures.ofDefault(member)
                 .withToken("old-token").buildAndSave(notificationTokenRepository);
         NotificationTokenRequest notificationTokenRequest = new NotificationTokenRequest("updated-token", oldToken.getDeviceType()
                 .getName(), oldToken.getDeviceId());
@@ -219,9 +219,9 @@ class NotificationServiceTest extends ServiceSliceTest {
     @Test
     void updateDeviceIdWhenSameTokenValueExistsOnce() {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("member").buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().withNickname("member").buildAndSave(memberRepository);
         String tokenValue = "token-value";
-        NotificationTokenFixtures.defaultNotificationToken(member)
+        NotificationTokenFixtures.ofDefault(member)
                 .withToken(tokenValue)
                 .withDeviceId("old-device-id")
                 .buildAndSave(notificationTokenRepository);
@@ -245,13 +245,13 @@ class NotificationServiceTest extends ServiceSliceTest {
     @Test
     void deleteAllAndSaveOneWhenSameTokenValueExistsMoreThanTwice() {
         // given
-        Member member = MemberFixtures.defaultMember().withNickname("member").buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().withNickname("member").buildAndSave(memberRepository);
         String tokenValue = "token-value";
-        NotificationTokenFixtures.defaultNotificationToken(member)
+        NotificationTokenFixtures.ofDefault(member)
                 .withToken(tokenValue)
                 .withDeviceId("old-device-id1")
                 .buildAndSave(notificationTokenRepository);
-        NotificationTokenFixtures.defaultNotificationToken(member)
+        NotificationTokenFixtures.ofDefault(member)
                 .withToken(tokenValue)
                 .withDeviceId("old-device-id2")
                 .buildAndSave(notificationTokenRepository);

--- a/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
@@ -74,8 +74,7 @@ class NotificationServiceTest extends ServiceSliceTest {
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .buildAndSave(categoryRepository);
-        staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        staccato = StaccatoFixtures.defaultStaccato(category)
                 .buildAndSave(staccatoRepository);
         comment = CommentFixtures.defaultComment()
                 .withStaccato(staccato)

--- a/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
+++ b/backend/src/test/java/com/staccato/notification/service/NotificationServiceTest.java
@@ -76,9 +76,7 @@ class NotificationServiceTest extends ServiceSliceTest {
                 .buildAndSave(categoryRepository);
         staccato = StaccatoFixtures.defaultStaccato(category)
                 .buildAndSave(staccatoRepository);
-        comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(host)
+        comment = CommentFixtures.defaultComment(staccato, host)
                 .buildAndSave(commentRepository);
 
         NotificationTokenFixtures.defaultNotificationToken(host)

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
@@ -52,28 +52,28 @@ class StaccatoControllerTest extends ControllerTest {
 
     static Stream<Arguments> invalidStaccatoRequestProvider() {
         return Stream.of(
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withCategoryId(0L).build(),
                         "카테고리 식별자는 양수로 이루어져야 합니다."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withStaccatoTitle(null).build(),
                         "스타카토 제목을 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withStaccatoTitle("").build(),
                         "스타카토 제목을 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withPlaceName(null).build(),
                         "장소 이름을 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withLatitude(null).build(),
                         "스타카토의 위도를 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withLongitude(null).build(),
                         "스타카토의 경도를 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withAddress(null).build(),
                         "스타카토의 주소를 입력해주세요."),
-                Arguments.of(StaccatoRequestFixtures.defaultStaccatoRequest()
+                Arguments.of(StaccatoRequestFixtures.ofDefault()
                                 .withVisitedAt(null).build(),
                         "스타카토 날짜를 입력해주세요.")
         );
@@ -100,7 +100,7 @@ class StaccatoControllerTest extends ControllerTest {
                     "staccatoId": 1
                 }
                 """;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(staccatoService.createStaccato(any(StaccatoRequest.class),
                 any(Member.class))).thenReturn(new StaccatoIdResponse(1L));
 
@@ -129,7 +129,7 @@ class StaccatoControllerTest extends ControllerTest {
                         "categoryId": 1
                     }
                 """;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(staccatoService.createStaccato(any(StaccatoRequest.class),
                 any(Member.class))).thenReturn(new StaccatoIdResponse(1L));
 
@@ -149,7 +149,7 @@ class StaccatoControllerTest extends ControllerTest {
         // given
         ExceptionResponse exceptionResponse = new ExceptionResponse(
                 HttpStatus.BAD_REQUEST.toString(), expectedMessage);
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
         when(staccatoService.createStaccato(any(StaccatoRequest.class),
                 any(Member.class))).thenReturn(new StaccatoIdResponse(1L));
 
@@ -166,14 +166,14 @@ class StaccatoControllerTest extends ControllerTest {
     @Test
     void readAllStaccato() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
         StaccatoLocationResponseV2 response1 = new StaccatoLocationResponseV2(
-                StaccatoFixtures.defaultStaccato(category)
+                StaccatoFixtures.ofDefault(category)
                         .withSpot(BigDecimal.ZERO, BigDecimal.ZERO).build()
         );
         StaccatoLocationResponseV2 response2 = new StaccatoLocationResponseV2(
-                StaccatoFixtures.defaultStaccato(category)
+                StaccatoFixtures.ofDefault(category)
                         .withSpot(new BigDecimal("123.456789"), new BigDecimal("123.456789")).build()
         );
         StaccatoLocationResponsesV2 responses = new StaccatoLocationResponsesV2(List.of(response1, response2));
@@ -208,11 +208,11 @@ class StaccatoControllerTest extends ControllerTest {
     void readStaccatoById() throws Exception {
         // given
         long staccatoId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory()
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         StaccatoDetailResponseV2 response = new StaccatoDetailResponseV2(staccato);
         when(staccatoService.readStaccatoById(anyLong(), any(Member.class))).thenReturn(response);
@@ -273,7 +273,7 @@ class StaccatoControllerTest extends ControllerTest {
                     ]
                 }
                 """;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(put("/staccatos/{staccatoId}", staccatoId)
@@ -288,10 +288,10 @@ class StaccatoControllerTest extends ControllerTest {
     void failUpdateStaccatoById() throws Exception {
         // given
         long staccatoId = 0L;
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest().build();
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault().build();
         ExceptionResponse exceptionResponse = new ExceptionResponse(
                 HttpStatus.BAD_REQUEST.toString(), "스타카토 식별자는 양수로 이루어져야 합니다.");
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(put("/staccatos/{staccatoId}", staccatoId)
@@ -307,7 +307,7 @@ class StaccatoControllerTest extends ControllerTest {
     void deleteStaccatoById() throws Exception {
         // given
         long staccatoId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
 
         // when & then
         mockMvc.perform(delete("/staccatos/{staccatoId}", staccatoId)
@@ -375,18 +375,18 @@ class StaccatoControllerTest extends ControllerTest {
         // given
         String token = "sample-token";
         LocalDateTime expiredAt = LocalDateTime.of(2024, 6, 1, 0, 0, 0);
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/stacccatoImage1.jpg",
                         "https://example.com/stacccatoImage2.jpg")).build();
-        Member member1 = MemberFixtures.defaultMember()
+        Member member1 = MemberFixtures.ofDefault()
                 .withNickname("nickname1")
                 .withImageUrl("memberImageUrl1.jpg").build();
-        Member member2 = MemberFixtures.defaultMember()
+        Member member2 = MemberFixtures.ofDefault()
                 .withNickname("nickname2")
                 .withImageUrl("memberImageUrl2.jpg").build();
-        Comment comment1 = CommentFixtures.defaultComment(staccato, member1).build();
-        Comment comment2 = CommentFixtures.defaultComment(staccato, member2).build();
+        Comment comment1 = CommentFixtures.ofDefault(staccato, member1).build();
+        Comment comment2 = CommentFixtures.ofDefault(staccato, member2).build();
         StaccatoSharedResponse staccatoSharedResponse = new StaccatoSharedResponse(expiredAt, staccato, member1, List.of(comment1, comment2));
         when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(staccatoSharedResponse);
         String expectedResponse = """

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
@@ -169,13 +169,11 @@ class StaccatoControllerTest extends ControllerTest {
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
         StaccatoLocationResponseV2 response1 = new StaccatoLocationResponseV2(
-                StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                StaccatoFixtures.defaultStaccato(category)
                         .withSpot(BigDecimal.ZERO, BigDecimal.ZERO).build()
         );
         StaccatoLocationResponseV2 response2 = new StaccatoLocationResponseV2(
-                StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                StaccatoFixtures.defaultStaccato(category)
                         .withSpot(new BigDecimal("123.456789"), new BigDecimal("123.456789")).build()
         );
         StaccatoLocationResponsesV2 responses = new StaccatoLocationResponsesV2(List.of(response1, response2));
@@ -214,8 +212,7 @@ class StaccatoControllerTest extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         StaccatoDetailResponseV2 response = new StaccatoDetailResponseV2(staccato);
         when(staccatoService.readStaccatoById(anyLong(), any(Member.class))).thenReturn(response);
@@ -379,8 +376,7 @@ class StaccatoControllerTest extends ControllerTest {
         String token = "sample-token";
         LocalDateTime expiredAt = LocalDateTime.of(2024, 6, 1, 0, 0, 0);
         Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/stacccatoImage1.jpg",
                         "https://example.com/stacccatoImage2.jpg")).build();
         Member member1 = MemberFixtures.defaultMember()

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerTest.java
@@ -385,12 +385,8 @@ class StaccatoControllerTest extends ControllerTest {
         Member member2 = MemberFixtures.defaultMember()
                 .withNickname("nickname2")
                 .withImageUrl("memberImageUrl2.jpg").build();
-        Comment comment1 = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member1).build();
-        Comment comment2 = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member2).build();
+        Comment comment1 = CommentFixtures.defaultComment(staccato, member1).build();
+        Comment comment2 = CommentFixtures.defaultComment(staccato, member2).build();
         StaccatoSharedResponse staccatoSharedResponse = new StaccatoSharedResponse(expiredAt, staccato, member1, List.of(comment1, comment2));
         when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(staccatoSharedResponse);
         String expectedResponse = """

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerV2Test.java
@@ -49,14 +49,14 @@ class StaccatoControllerV2Test extends ControllerTest {
     @Test
     void readAllStaccato() throws Exception {
         // given
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault().withColor(Color.PINK).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withSpot(BigDecimal.ZERO, BigDecimal.ZERO)
                 .withTitle("title")
                 .withVisitedAt(LocalDateTime.of(2024, 5, 1, 0, 0))
                 .build();
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category)
                 .withSpot(new BigDecimal("123.456789"), new BigDecimal("123.456789"))
                 .withTitle("title2")
                 .withVisitedAt(LocalDateTime.of(2024, 5, 2, 0, 0))
@@ -119,11 +119,11 @@ class StaccatoControllerV2Test extends ControllerTest {
     void readStaccatoById() throws Exception {
         // given
         long staccatoId = 1L;
-        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
-        Category category = CategoryFixtures.defaultCategory()
+        when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.ofDefault().build());
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         StaccatoDetailResponseV2 response = new StaccatoDetailResponseV2(staccato);
         when(staccatoService.readStaccatoById(anyLong(), any(Member.class))).thenReturn(response);

--- a/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerV2Test.java
+++ b/backend/src/test/java/com/staccato/staccato/controller/StaccatoControllerV2Test.java
@@ -51,14 +51,12 @@ class StaccatoControllerV2Test extends ControllerTest {
         // given
         when(authService.extractFromToken(anyString())).thenReturn(MemberFixtures.defaultMember().build());
         Category category = CategoryFixtures.defaultCategory().withColor(Color.PINK).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withSpot(BigDecimal.ZERO, BigDecimal.ZERO)
                 .withTitle("title")
                 .withVisitedAt(LocalDateTime.of(2024, 5, 1, 0, 0))
                 .build();
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
                 .withSpot(new BigDecimal("123.456789"), new BigDecimal("123.456789"))
                 .withTitle("title2")
                 .withVisitedAt(LocalDateTime.of(2024, 5, 2, 0, 0))
@@ -125,8 +123,7 @@ class StaccatoControllerV2Test extends ControllerTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage.jpg")).build();
         StaccatoDetailResponseV2 response = new StaccatoDetailResponseV2(staccato);
         when(staccatoService.readStaccatoById(anyLong(), any(Member.class))).thenReturn(response);

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoImagesTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoImagesTest.java
@@ -78,12 +78,12 @@ class StaccatoImagesTest {
     @ParameterizedTest
     void update(List<String> existingImageNames, List<String> updatedImageNames) {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
+        Category category = CategoryFixtures.ofDefault().build();
         StaccatoImages existingImages = new StaccatoImages(existingImageNames);
         StaccatoImages updatedImages = new StaccatoImages(updatedImageNames);
 
         // when
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).build();
         existingImages.update(updatedImages, staccato);
         List<String> images = existingImages.getImages().stream().map(StaccatoImage::getImageUrl).toList();
 
@@ -110,13 +110,13 @@ class StaccatoImagesTest {
         @DisplayName("이미지가 변경되지 않으면 바뀌지 않는다.")
         void notChangeUpdatedAtWhenImagesAreSame() {
             // given
-            Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            Category category = CategoryFixtures.defaultCategory()
+            Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            Category category = CategoryFixtures.ofDefault()
                     .withHost(member)
                 .buildAndSave(categoryRepository);
             List<String> imageUrls = List.of("same1.jpg", "same2.jpg");
 
-            Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+            Staccato staccato = StaccatoFixtures.ofDefault(category)
                     .withStaccatoImages(imageUrls).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.clear();
@@ -137,13 +137,13 @@ class StaccatoImagesTest {
         @DisplayName("이미지가 변경되면 갱신된다.")
         void changeUpdatedAtWhenImagesAreDifferent() {
             // given
-            Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            Category category = CategoryFixtures.defaultCategory()
+            Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            Category category = CategoryFixtures.ofDefault()
                     .withHost(member)
                 .buildAndSave(categoryRepository);
             List<String> imageUrls = List.of("img1.jpg", "img2.jpg");
 
-            Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+            Staccato staccato = StaccatoFixtures.ofDefault(category)
                     .withStaccatoImages(imageUrls).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.clear();

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoImagesTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoImagesTest.java
@@ -83,8 +83,7 @@ class StaccatoImagesTest {
         StaccatoImages updatedImages = new StaccatoImages(updatedImageNames);
 
         // when
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
         existingImages.update(updatedImages, staccato);
         List<String> images = existingImages.getImages().stream().map(StaccatoImage::getImageUrl).toList();
 
@@ -117,8 +116,7 @@ class StaccatoImagesTest {
                 .buildAndSave(categoryRepository);
             List<String> imageUrls = List.of("same1.jpg", "same2.jpg");
 
-            Staccato staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category)
+            Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                     .withStaccatoImages(imageUrls).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.clear();
@@ -145,8 +143,7 @@ class StaccatoImagesTest {
                 .buildAndSave(categoryRepository);
             List<String> imageUrls = List.of("img1.jpg", "img2.jpg");
 
-            Staccato staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category)
+            Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                     .withStaccatoImages(imageUrls).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.clear();

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
@@ -57,8 +57,7 @@ class StaccatoTest {
     @Test
     void createStaccatoInUndefinedDuration() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
-                .withTerm(null, null).build();
+        Category category = CategoryFixtures.defaultCategory().build();
         LocalDateTime visitedAt = LocalDateTime.of(2024, 6, 1, 0, 0);
 
         // when & then
@@ -311,7 +310,6 @@ class StaccatoTest {
         Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(creator)
-                .withTerm(null, null)
                 .build();
 
         // when

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
@@ -35,7 +35,7 @@ class StaccatoTest {
     @Test
     void createStaccato() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
         LocalDateTime visitedAt = LocalDateTime.of(2024, 6, 1, 0, 0);
@@ -57,7 +57,7 @@ class StaccatoTest {
     @Test
     void createStaccatoInUndefinedDuration() {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
+        Category category = CategoryFixtures.ofDefault().build();
         LocalDateTime visitedAt = LocalDateTime.of(2024, 6, 1, 0, 0);
 
         // when & then
@@ -77,7 +77,7 @@ class StaccatoTest {
     @Test
     void failCreateStaccato() {
         // given
-        Category category = CategoryFixtures.defaultCategory()
+        Category category = CategoryFixtures.ofDefault()
                 .withTerm(LocalDate.of(2024, 1, 1),
                         LocalDate.of(2024, 12, 31)).build();
         LocalDateTime visitedAt = LocalDateTime.of(2023, 6, 1, 0, 0);
@@ -101,10 +101,10 @@ class StaccatoTest {
     @Test
     void thumbnail() {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
+        Category category = CategoryFixtures.ofDefault().build();
         String thumbnail = "https://example.com/staccatoImage1.jpg";
 
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of(thumbnail, "https://example.com/staccatoImage2.jpg")).build();
 
         // when
@@ -118,8 +118,8 @@ class StaccatoTest {
     @Test
     void noThumbnail() {
         // given
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of()).build();
 
         // when
@@ -146,14 +146,14 @@ class StaccatoTest {
         @Test
         void updateCategoryUpdatedDateWhenStaccatoCreated() {
             // given
-            Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            Category category = CategoryFixtures.defaultCategory()
+            Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            Category category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             LocalDateTime beforeCreate = category.getUpdatedAt();
 
             // when
-            StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+            StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.refresh(category);
             LocalDateTime afterCreate = category.getUpdatedAt();
@@ -166,11 +166,11 @@ class StaccatoTest {
         @Test
         void updateCategoryUpdatedDateWhenStaccatoUpdated() {
             // given
-            Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            Category category = CategoryFixtures.defaultCategory()
+            Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            Category category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+            Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
             LocalDateTime beforeUpdate = category.getUpdatedAt();
 
             // when
@@ -187,11 +187,11 @@ class StaccatoTest {
         @Test
         void updateCategoryUpdatedDateWhenStaccatoDeleted() {
             // given
-            Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            Category category = CategoryFixtures.defaultCategory()
+            Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            Category category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+            Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
             LocalDateTime beforeDelete = category.getUpdatedAt();
 
             // when
@@ -209,12 +209,12 @@ class StaccatoTest {
     @Test
     void getColor() {
         // given
-        Member member = MemberFixtures.defaultMember().build();
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().build();
+        Category category = CategoryFixtures.ofDefault()
                 .withColor(Color.PINK)
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).build();
 
         // when
         Color color = staccato.getColor();
@@ -227,19 +227,19 @@ class StaccatoTest {
     @Test
     void validateCategoryChangeable() {
         // given
-        Member host = MemberFixtures.defaultMember().withNickname("host").build();
-        Member guest = MemberFixtures.defaultMember().withNickname("guest").build();
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").build();
+        Member guest = MemberFixtures.ofDefault().withNickname("guest").build();
+        Category category = CategoryFixtures.ofDefault()
                 .withTitle("non-shared")
                 .withHost(host)
                 .build();
-        Category sharedCategory = CategoryFixtures.defaultCategory()
+        Category sharedCategory = CategoryFixtures.ofDefault()
                 .withTitle("shared")
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
-        Staccato sharedStaccato = StaccatoFixtures.defaultStaccato(sharedCategory).build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category).build();
+        Staccato sharedStaccato = StaccatoFixtures.ofDefault(sharedCategory).build();
 
         // when & then
         assertAll(
@@ -263,13 +263,13 @@ class StaccatoTest {
 
         @BeforeEach
         void setUp() {
-            host = MemberFixtures.defaultMember().withNickname("host").build();
-            guest = MemberFixtures.defaultMember().withNickname("guest").build();
-            category = CategoryFixtures.defaultCategory()
+            host = MemberFixtures.ofDefault().withNickname("host").build();
+            guest = MemberFixtures.ofDefault().withNickname("guest").build();
+            category = CategoryFixtures.ofDefault()
                     .withHost(host)
                     .withGuests(List.of(guest))
                     .build();
-            staccato = StaccatoFixtures.defaultStaccato(category).build();
+            staccato = StaccatoFixtures.ofDefault(category).build();
         }
 
         @DisplayName("카테고리의 HOST는 카테고리 안에 있는 스타카토의 소유자이다.")
@@ -287,7 +287,7 @@ class StaccatoTest {
         @DisplayName("카테고리의 함께하는 사람이 아니면 카테고리 안에 있는 스타카토의 소유자가 아니다.")
         @Test
         void failValidateOwnerIfMemberNotInCategory() {
-            Member other = MemberFixtures.defaultMember().withNickname("other").build();
+            Member other = MemberFixtures.ofDefault().withNickname("other").build();
             assertThatThrownBy(() -> staccato.validateOwner(other))
                     .isInstanceOf(ForbiddenException.class);
         }
@@ -297,8 +297,8 @@ class StaccatoTest {
     @Test
     void createdAndModifiedBySameWhenCreated() {
         // given
-        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
-        Category category = CategoryFixtures.defaultCategory()
+        Member creator = MemberFixtures.ofDefault().withNickname("creator").build();
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(creator)
                 .build();
 
@@ -326,15 +326,15 @@ class StaccatoTest {
     @Test
     void createdByDoesNotChangeOnUpdate() {
         // given
-        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
-        Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
-        Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
+        Member creator = MemberFixtures.ofDefault().withNickname("creator").build();
+        Member updater = MemberFixtures.ofDefault().withNickname("updater").build();
+        Category category = CategoryFixtures.ofDefault().withHost(creator).build();
 
-        Staccato original = StaccatoFixtures.defaultStaccato(category)
+        Staccato original = StaccatoFixtures.ofDefault(category)
                 .withCreator(creator)
                 .build();
 
-        Staccato updateData = StaccatoFixtures.defaultStaccato(category)
+        Staccato updateData = StaccatoFixtures.ofDefault(category)
                 .withCreator(updater)
                 .build();
 
@@ -349,15 +349,15 @@ class StaccatoTest {
     @Test
     void modifiedByChangesOnUpdate() {
         // given
-        Member creator = MemberFixtures.defaultMember().withNickname("creator").build();
-        Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
-        Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
+        Member creator = MemberFixtures.ofDefault().withNickname("creator").build();
+        Member updater = MemberFixtures.ofDefault().withNickname("updater").build();
+        Category category = CategoryFixtures.ofDefault().withHost(creator).build();
 
-        Staccato original = StaccatoFixtures.defaultStaccato(category)
+        Staccato original = StaccatoFixtures.ofDefault(category)
                 .withCreator(creator)
                 .build();
 
-        Staccato updateData = StaccatoFixtures.defaultStaccato(category)
+        Staccato updateData = StaccatoFixtures.ofDefault(category)
                 .withCreator(updater)
                 .build();
 

--- a/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
+++ b/backend/src/test/java/com/staccato/staccato/domain/StaccatoTest.java
@@ -104,8 +104,7 @@ class StaccatoTest {
         Category category = CategoryFixtures.defaultCategory().build();
         String thumbnail = "https://example.com/staccatoImage1.jpg";
 
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of(thumbnail, "https://example.com/staccatoImage2.jpg")).build();
 
         // when
@@ -120,8 +119,7 @@ class StaccatoTest {
     void noThumbnail() {
         // given
         Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of()).build();
 
         // when
@@ -155,8 +153,7 @@ class StaccatoTest {
             LocalDateTime beforeCreate = category.getUpdatedAt();
 
             // when
-            StaccatoFixtures.defaultStaccato()
-                    .withCategory(category).buildAndSave(staccatoRepository);
+            StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
             entityManager.flush();
             entityManager.refresh(category);
             LocalDateTime afterCreate = category.getUpdatedAt();
@@ -173,8 +170,7 @@ class StaccatoTest {
             Category category = CategoryFixtures.defaultCategory()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            Staccato staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category).buildAndSave(staccatoRepository);
+            Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
             LocalDateTime beforeUpdate = category.getUpdatedAt();
 
             // when
@@ -195,8 +191,7 @@ class StaccatoTest {
             Category category = CategoryFixtures.defaultCategory()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            Staccato staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category).buildAndSave(staccatoRepository);
+            Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
             LocalDateTime beforeDelete = category.getUpdatedAt();
 
             // when
@@ -219,8 +214,7 @@ class StaccatoTest {
                 .withColor(Color.PINK)
                 .withHost(member)
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
 
         // when
         Color color = staccato.getColor();
@@ -244,10 +238,8 @@ class StaccatoTest {
                 .withHost(host)
                 .withGuests(List.of(guest))
                 .build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).build();
-        Staccato sharedStaccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(sharedCategory).build();
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).build();
+        Staccato sharedStaccato = StaccatoFixtures.defaultStaccato(sharedCategory).build();
 
         // when & then
         assertAll(
@@ -277,9 +269,7 @@ class StaccatoTest {
                     .withHost(host)
                     .withGuests(List.of(guest))
                     .build();
-            staccato = StaccatoFixtures.defaultStaccato()
-                    .withCategory(category)
-                    .build();
+            staccato = StaccatoFixtures.defaultStaccato(category).build();
         }
 
         @DisplayName("카테고리의 HOST는 카테고리 안에 있는 스타카토의 소유자이다.")
@@ -340,13 +330,11 @@ class StaccatoTest {
         Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
         Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
 
-        Staccato original = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato original = StaccatoFixtures.defaultStaccato(category)
                 .withCreator(creator)
                 .build();
 
-        Staccato updateData = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato updateData = StaccatoFixtures.defaultStaccato(category)
                 .withCreator(updater)
                 .build();
 
@@ -365,13 +353,11 @@ class StaccatoTest {
         Member updater = MemberFixtures.defaultMember().withNickname("updater").build();
         Category category = CategoryFixtures.defaultCategory().withHost(creator).build();
 
-        Staccato original = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato original = StaccatoFixtures.defaultStaccato(category)
                 .withCreator(creator)
                 .build();
 
-        Staccato updateData = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato updateData = StaccatoFixtures.defaultStaccato(category)
                 .withCreator(updater)
                 .build();
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoImageRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoImageRepositoryTest.java
@@ -32,12 +32,10 @@ class StaccatoImageRepositoryTest extends RepositoryTest {
     void deleteAllByStaccatoIdInBulk() {
         // given
         Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("url1", "url2"))
                 .buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("url1", "url2"))
                 .buildAndSave(staccatoRepository);
 
@@ -60,8 +58,7 @@ class StaccatoImageRepositoryTest extends RepositoryTest {
     void deleteAllByIdInBulk() {
         // given
         Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("url1", "url2", "url3"))
                 .buildAndSave(staccatoRepository);
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoImageRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoImageRepositoryTest.java
@@ -31,11 +31,11 @@ class StaccatoImageRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByStaccatoIdInBulk() {
         // given
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        Staccato staccato1 = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("url1", "url2"))
                 .buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("url1", "url2"))
                 .buildAndSave(staccatoRepository);
 
@@ -57,8 +57,8 @@ class StaccatoImageRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByIdInBulk() {
         // given
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("url1", "url2", "url3"))
                 .buildAndSave(staccatoRepository);
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -66,13 +66,11 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     .withTitle("category2")
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            staccatoInCategory1 = StaccatoFixtures.defaultStaccato()
+            staccatoInCategory1 = StaccatoFixtures.defaultStaccato(category1ByMember)
                     .withSpot(MIN_LATITUDE, MAX_LONGITUDE)
-                    .withCategory(category1ByMember)
                     .buildAndSave(staccatoRepository);
-            staccatoInCategory2 = StaccatoFixtures.defaultStaccato()
+            staccatoInCategory2 = StaccatoFixtures.defaultStaccato(category2ByMember)
                     .withSpot(MAX_LATITUDE, MIN_LONGITUDE)
-                    .withCategory(category2ByMember)
                     .buildAndSave(staccatoRepository);
         }
 
@@ -88,8 +86,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 Category anotherCategory = CategoryFixtures.defaultCategory()
                         .withHost(anotherMember)
                         .buildAndSave(categoryRepository);
-                Staccato anotherStaccato = StaccatoFixtures.defaultStaccato()
-                        .withCategory(anotherCategory)
+                Staccato anotherStaccato = StaccatoFixtures.defaultStaccato(anotherCategory)
                         .buildAndSave(staccatoRepository);
 
                 // when
@@ -105,20 +102,16 @@ class StaccatoRepositoryTest extends RepositoryTest {
             void findAllStaccatoByMemberWithLocationRange() {
                 // given
                 BigDecimal threshold = new BigDecimal("0.01");
-                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MIN_LATITUDE.subtract(threshold), MAX_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MAX_LATITUDE.add(threshold), MIN_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MAX_LATITUDE, MIN_LONGITUDE.subtract(threshold))
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MIN_LATITUDE, MAX_LONGITUDE.add(threshold))
                         .buildAndSave(staccatoRepository);
 
@@ -153,20 +146,16 @@ class StaccatoRepositoryTest extends RepositoryTest {
             void findAllStaccatoByMemberWithCategoryAndInRange() {
                 // given
                 BigDecimal threshold = new BigDecimal("0.01");
-                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MIN_LATITUDE.subtract(threshold), MAX_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MAX_LATITUDE.add(threshold), MIN_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MAX_LATITUDE, MIN_LONGITUDE.subtract(threshold))
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato()
-                        .withCategory(category1ByMember)
+                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
                         .withSpot(MIN_LATITUDE, MAX_LONGITUDE.add(threshold))
                         .buildAndSave(staccatoRepository);
 
@@ -192,12 +181,9 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         staccatoRepository.deleteAllByCategoryIdInBulk(category.getId());
@@ -223,15 +209,15 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato()
+        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
+                .buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 2, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato3 = StaccatoFixtures.defaultStaccato()
+                .buildAndSave(staccatoRepository);
+        Staccato staccato3 = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 3, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
+                .buildAndSave(staccatoRepository);
 
         // when
         List<Staccato> staccatos = staccatoRepository.findAllByCategoryIdOrdered(category.getId());
@@ -253,12 +239,12 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato()
+        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
+                .buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                .withCategory(category).buildAndSave(staccatoRepository);
+                .buildAndSave(staccatoRepository);
 
         // when
         List<Staccato> staccatos = staccatoRepository.findAllByCategoryIdOrdered(category.getId());
@@ -280,8 +266,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
                 .withHost(host)
                 .buildAndSave(categoryRepository);
         for (int count = 1; count <= staccatoCount; count++) {
-            StaccatoFixtures.defaultStaccato()
-                    .withCategory(category)
+            StaccatoFixtures.defaultStaccato(category)
                     .buildAndSave(staccatoRepository);
         }
 
@@ -307,8 +292,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 3; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                staccatos.add(StaccatoFixtures.defaultStaccato(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -326,7 +310,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
         void readStaccatosByCategoryId() {
             // given
             Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-            Staccato otherStaccato = StaccatoFixtures.defaultStaccato().withCategory(otherCategory)
+            Staccato otherStaccato = StaccatoFixtures.defaultStaccato(otherCategory)
                     .buildAndSave(staccatoRepository);
             Staccato cursorStaccato = staccatos.get(0);
 
@@ -455,8 +439,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 3; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato()
-                        .withCategory(category)
+                staccatos.add(StaccatoFixtures.defaultStaccato(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -474,7 +457,7 @@ class StaccatoRepositoryTest extends RepositoryTest {
         void readStaccatosByCategoryId() {
             // given
             Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-            Staccato otherStaccato = StaccatoFixtures.defaultStaccato().withCategory(otherCategory)
+            Staccato otherStaccato = StaccatoFixtures.defaultStaccato(otherCategory)
                     .buildAndSave(staccatoRepository);
 
             // when
@@ -500,12 +483,12 @@ class StaccatoRepositoryTest extends RepositoryTest {
         @Test
         void readStaccatosOrderByCreatedAtDesc() {
             // given
-            Staccato first = StaccatoFixtures.defaultStaccato()
+            Staccato first = StaccatoFixtures.defaultStaccato(category)
                     .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                    .withCategory(category).buildAndSave(staccatoRepository);
-            Staccato second = StaccatoFixtures.defaultStaccato()
+                    .buildAndSave(staccatoRepository);
+            Staccato second = StaccatoFixtures.defaultStaccato(category)
                     .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
-                    .withCategory(category).buildAndSave(staccatoRepository);
+                    .buildAndSave(staccatoRepository);
 
             // when
             List<Staccato> result = staccatoRepository.findFirstPageByCategoryId(category.getId(), 2);

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -57,19 +57,19 @@ class StaccatoRepositoryTest extends RepositoryTest {
 
         @BeforeEach
         void init() {
-            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            category1ByMember = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            category1ByMember = CategoryFixtures.ofDefault()
                     .withTitle("category1")
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            category2ByMember = CategoryFixtures.defaultCategory()
+            category2ByMember = CategoryFixtures.ofDefault()
                     .withTitle("category2")
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            staccatoInCategory1 = StaccatoFixtures.defaultStaccato(category1ByMember)
+            staccatoInCategory1 = StaccatoFixtures.ofDefault(category1ByMember)
                     .withSpot(MIN_LATITUDE, MAX_LONGITUDE)
                     .buildAndSave(staccatoRepository);
-            staccatoInCategory2 = StaccatoFixtures.defaultStaccato(category2ByMember)
+            staccatoInCategory2 = StaccatoFixtures.ofDefault(category2ByMember)
                     .withSpot(MAX_LATITUDE, MIN_LONGITUDE)
                     .buildAndSave(staccatoRepository);
         }
@@ -81,12 +81,12 @@ class StaccatoRepositoryTest extends RepositoryTest {
             @Test
             void findAllStaccatoByMemberWithoutAnyCondition() {
                 // given
-                Member anotherMember = MemberFixtures.defaultMember().withNickname("otherMem")
+                Member anotherMember = MemberFixtures.ofDefault().withNickname("otherMem")
                         .buildAndSave(memberRepository);
-                Category anotherCategory = CategoryFixtures.defaultCategory()
+                Category anotherCategory = CategoryFixtures.ofDefault()
                         .withHost(anotherMember)
                         .buildAndSave(categoryRepository);
-                Staccato anotherStaccato = StaccatoFixtures.defaultStaccato(anotherCategory)
+                Staccato anotherStaccato = StaccatoFixtures.ofDefault(anotherCategory)
                         .buildAndSave(staccatoRepository);
 
                 // when
@@ -102,16 +102,16 @@ class StaccatoRepositoryTest extends RepositoryTest {
             void findAllStaccatoByMemberWithLocationRange() {
                 // given
                 BigDecimal threshold = new BigDecimal("0.01");
-                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato underMinLatitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MIN_LATITUDE.subtract(threshold), MAX_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato overMaxLatitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MAX_LATITUDE.add(threshold), MIN_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato underMinLongitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MAX_LATITUDE, MIN_LONGITUDE.subtract(threshold))
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato overMaxLongitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MIN_LATITUDE, MAX_LONGITUDE.add(threshold))
                         .buildAndSave(staccatoRepository);
 
@@ -146,16 +146,16 @@ class StaccatoRepositoryTest extends RepositoryTest {
             void findAllStaccatoByMemberWithCategoryAndInRange() {
                 // given
                 BigDecimal threshold = new BigDecimal("0.01");
-                Staccato underMinLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato underMinLatitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MIN_LATITUDE.subtract(threshold), MAX_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLatitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato overMaxLatitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MAX_LATITUDE.add(threshold), MIN_LONGITUDE)
                         .buildAndSave(staccatoRepository);
-                Staccato underMinLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato underMinLongitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MAX_LATITUDE, MIN_LONGITUDE.subtract(threshold))
                         .buildAndSave(staccatoRepository);
-                Staccato overMaxLongitude = StaccatoFixtures.defaultStaccato(category1ByMember)
+                Staccato overMaxLongitude = StaccatoFixtures.ofDefault(category1ByMember)
                         .withSpot(MIN_LATITUDE, MAX_LONGITUDE.add(threshold))
                         .buildAndSave(staccatoRepository);
 
@@ -175,15 +175,15 @@ class StaccatoRepositoryTest extends RepositoryTest {
     @Test
     void deleteAllByCategoryIdInBulk() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato staccato1 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         staccatoRepository.deleteAllByCategoryIdInBulk(category.getId());
@@ -203,19 +203,19 @@ class StaccatoRepositoryTest extends RepositoryTest {
     @Test
     void findAllByCategoryIdOrderByVisitedAt() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato1 = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 2, 0, 0))
                 .buildAndSave(staccatoRepository);
-        Staccato staccato3 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato3 = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 3, 0, 0))
                 .buildAndSave(staccatoRepository);
 
@@ -233,16 +233,16 @@ class StaccatoRepositoryTest extends RepositoryTest {
     @Test
     void findAllByCategoryIdOrderByCreatedAt() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-        CategoryMemberFixtures.defaultCategoryMember()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+        CategoryMemberFixtures.ofDefault()
                 .withMember(member)
                 .withCategory(category).buildAndSave(categoryMemberRepository);
 
-        Staccato staccato1 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato1 = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category)
                 .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                 .buildAndSave(staccatoRepository);
 
@@ -261,12 +261,12 @@ class StaccatoRepositoryTest extends RepositoryTest {
     @ValueSource(ints = {0, 2})
     void countAllByCategoryWhenZero(int staccatoCount) {
         //given
-        Member host = MemberFixtures.defaultMember().withNickname("host").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member host = MemberFixtures.ofDefault().withNickname("host").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(host)
                 .buildAndSave(categoryRepository);
         for (int count = 1; count <= staccatoCount; count++) {
-            StaccatoFixtures.defaultStaccato(category)
+            StaccatoFixtures.ofDefault(category)
                     .buildAndSave(staccatoRepository);
         }
 
@@ -286,13 +286,13 @@ class StaccatoRepositoryTest extends RepositoryTest {
 
         @BeforeEach
         void setUp() {
-            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            category = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 3; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato(category)
+                staccatos.add(StaccatoFixtures.ofDefault(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -309,8 +309,8 @@ class StaccatoRepositoryTest extends RepositoryTest {
         @Test
         void readStaccatosByCategoryId() {
             // given
-            Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-            Staccato otherStaccato = StaccatoFixtures.defaultStaccato(otherCategory)
+            Category otherCategory = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+            Staccato otherStaccato = StaccatoFixtures.ofDefault(otherCategory)
                     .buildAndSave(staccatoRepository);
             Staccato cursorStaccato = staccatos.get(0);
 
@@ -433,13 +433,13 @@ class StaccatoRepositoryTest extends RepositoryTest {
 
         @BeforeEach
         void setUp() {
-            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            category = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
             for (int count = 1; count <= 3; count++) {
-                staccatos.add(StaccatoFixtures.defaultStaccato(category)
+                staccatos.add(StaccatoFixtures.ofDefault(category)
                         .withCreator(member)
                         .withTitle("staccato " + count)
                         .withVisitedAt(LocalDateTime.of(2024, 1, count, 0, 0, 0))
@@ -456,8 +456,8 @@ class StaccatoRepositoryTest extends RepositoryTest {
         @Test
         void readStaccatosByCategoryId() {
             // given
-            Category otherCategory = CategoryFixtures.defaultCategory().buildAndSave(categoryRepository);
-            Staccato otherStaccato = StaccatoFixtures.defaultStaccato(otherCategory)
+            Category otherCategory = CategoryFixtures.ofDefault().buildAndSave(categoryRepository);
+            Staccato otherStaccato = StaccatoFixtures.ofDefault(otherCategory)
                     .buildAndSave(staccatoRepository);
 
             // when
@@ -483,10 +483,10 @@ class StaccatoRepositoryTest extends RepositoryTest {
         @Test
         void readStaccatosOrderByCreatedAtDesc() {
             // given
-            Staccato first = StaccatoFixtures.defaultStaccato(category)
+            Staccato first = StaccatoFixtures.ofDefault(category)
                     .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                     .buildAndSave(staccatoRepository);
-            Staccato second = StaccatoFixtures.defaultStaccato(category)
+            Staccato second = StaccatoFixtures.ofDefault(category)
                     .withVisitedAt(LocalDateTime.of(2024, 6, 1, 0, 0))
                     .buildAndSave(staccatoRepository);
 

--- a/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
+++ b/backend/src/test/java/com/staccato/staccato/repository/StaccatoRepositoryTest.java
@@ -303,7 +303,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
         void setUp() {
             member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
             category = CategoryFixtures.defaultCategory()
-                    .withTerm(null, null)
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();
@@ -452,7 +451,6 @@ class StaccatoRepositoryTest extends RepositoryTest {
         void setUp() {
             member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
             category = CategoryFixtures.defaultCategory()
-                    .withTerm(null, null)
                     .withHost(member)
                     .buildAndSave(categoryRepository);
             staccatos = new ArrayList<>();

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
@@ -62,11 +62,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void createStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId()).build();
 
         // when
@@ -80,11 +80,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void createStaccatoWithStaccatoImages() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId())
                 .withStaccatoImageUrls(List.of("https://example.com/staccatoImage.jpg")).build();
 
@@ -103,12 +103,12 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void cannotCreateStaccatoIfNotOwner() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId()).build();
 
         // when & then
@@ -121,8 +121,8 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void failCreateStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(0L).build();
 
         // when & then
@@ -135,19 +135,19 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void readAllStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().withCode("me").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().withCode("me").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withColor(Color.BLUE)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withTitle("title2")
                 .withColor(Color.PINK)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category2).buildAndSave(staccatoRepository);
-        Staccato staccato3 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.ofDefault(category2).buildAndSave(staccatoRepository);
+        Staccato staccato3 = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoLocationResponsesV2 responses = staccatoService.readAllStaccato(member, StaccatoLocationRangeRequest.empty());
@@ -168,11 +168,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void readStaccatoById() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoDetailResponseV2 actual = staccatoService.readStaccatoById(staccato.getId(), member);
@@ -185,12 +185,12 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void cannotReadStaccatoByIdIfNotOwner() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoService.readStaccatoById(staccato.getId(), otherMember))
@@ -202,7 +202,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void failReadStaccatoById() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoService.readStaccatoById(1L, member))
@@ -214,19 +214,19 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void updateStaccatoById() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category1 = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category1 = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category category2 = CategoryFixtures.defaultCategory()
+        Category category2 = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category1)
+        Staccato staccato = StaccatoFixtures.ofDefault(category1)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage1.jpg", "https://example.com/staccatoImage2.jpg"))
                 .buildAndSave(staccatoRepository);
 
         // when
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withStaccatoTitle("newStaccatoTitle")
                 .withCategoryId(category2.getId())
                 .withStaccatoImageUrls(List.of("https://example.com/staccatoImage2.jpg", "https://example.com/staccatoImage3.jpg"))
@@ -262,25 +262,25 @@ class StaccatoServiceTest extends ServiceSliceTest {
 
         @BeforeEach
         void setUp() {
-            member1 = MemberFixtures.defaultMember().withNickname("member1").buildAndSave(memberRepository);
-            member2 = MemberFixtures.defaultMember().withNickname("member2").buildAndSave(memberRepository);
-            privateCategory1 = CategoryFixtures.defaultCategory()
+            member1 = MemberFixtures.ofDefault().withNickname("member1").buildAndSave(memberRepository);
+            member2 = MemberFixtures.ofDefault().withNickname("member2").buildAndSave(memberRepository);
+            privateCategory1 = CategoryFixtures.ofDefault()
                     .withHost(member1)
                     .buildAndSave(categoryRepository);
-            privateCategory2 = CategoryFixtures.defaultCategory()
+            privateCategory2 = CategoryFixtures.ofDefault()
                     .withHost(member1)
                     .buildAndSave(categoryRepository);
-            sharedCategory1 = CategoryFixtures.defaultCategory()
-                    .withHost(member1)
-                    .withGuests(List.of(member2))
-                    .buildAndSave(categoryRepository);
-            sharedCategory2 = CategoryFixtures.defaultCategory()
+            sharedCategory1 = CategoryFixtures.ofDefault()
                     .withHost(member1)
                     .withGuests(List.of(member2))
                     .buildAndSave(categoryRepository);
-            staccatoInPrivate1 = StaccatoFixtures.defaultStaccato(privateCategory1)
+            sharedCategory2 = CategoryFixtures.ofDefault()
+                    .withHost(member1)
+                    .withGuests(List.of(member2))
+                    .buildAndSave(categoryRepository);
+            staccatoInPrivate1 = StaccatoFixtures.ofDefault(privateCategory1)
                     .buildAndSave(staccatoRepository);
-            staccatoInShared1 = StaccatoFixtures.defaultStaccato(sharedCategory1)
+            staccatoInShared1 = StaccatoFixtures.ofDefault(sharedCategory1)
                     .buildAndSave(staccatoRepository);
         }
 
@@ -290,7 +290,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
             Long staccatoId = staccatoInShared1.getId();
             Long sameCategoryId = sharedCategory1.getId();
 
-            StaccatoRequest request = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request = StaccatoRequestFixtures.ofDefault()
                     .withCategoryId(sameCategoryId)
                     .build();
 
@@ -302,7 +302,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         void updateAllows_privateToPrivate() {
             Long staccatoId = staccatoInPrivate1.getId();
 
-            StaccatoRequest request = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request = StaccatoRequestFixtures.ofDefault()
                     .withCategoryId(privateCategory2.getId())
                     .build();
 
@@ -314,7 +314,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         void updateThrows_privateToShared() {
             Long staccatoId = staccatoInPrivate1.getId();
 
-            StaccatoRequest request = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request = StaccatoRequestFixtures.ofDefault()
                     .withCategoryId(sharedCategory1.getId())
                     .build();
 
@@ -328,7 +328,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         void updateThrows_sharedToPrivate() {
             Long staccatoId = staccatoInShared1.getId();
 
-            StaccatoRequest request = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request = StaccatoRequestFixtures.ofDefault()
                     .withCategoryId(privateCategory1.getId())
                     .build();
 
@@ -342,7 +342,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         void updateThrows_sharedToShared() {
             Long staccatoId = staccatoInShared1.getId();
 
-            StaccatoRequest request = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request = StaccatoRequestFixtures.ofDefault()
                     .withCategoryId(sharedCategory2.getId())
                     .build();
 
@@ -356,13 +356,13 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void failToUpdateStaccatoOfOther() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId()).build();
 
         // when & then
@@ -375,15 +375,15 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void failToUpdateStaccatoToOtherCategory() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Category otherCategory = CategoryFixtures.defaultCategory()
+        Category otherCategory = CategoryFixtures.ofDefault()
                 .withHost(otherMember).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(otherCategory.getId()).build();
 
         // when & then
@@ -396,11 +396,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void failToUpdateNotExistStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
+        StaccatoRequest staccatoRequest = StaccatoRequestFixtures.ofDefault()
                 .withCategoryId(category.getId()).build();
 
         // when & then
@@ -413,14 +413,14 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void deleteStaccatoById() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage1.jpg", "https://example.com/staccatoImage2.jpg"))
                 .buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
+        Comment comment = CommentFixtures.ofDefault(staccato, member).buildAndSave(commentRepository);
 
         // when
         staccatoService.deleteStaccatoById(staccato.getId(), member);
@@ -438,12 +438,12 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void cannotDeleteStaccatoByIdIfNotOwner() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoService.deleteStaccatoById(staccato.getId(), otherMember))
@@ -455,11 +455,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
     @Test
     void updateStaccatoFeelingById() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
         FeelingRequest feelingRequest = new FeelingRequest("happy");
 
         // when
@@ -483,11 +483,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
 
         @BeforeEach
         void setUp() {
-            member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-            category = CategoryFixtures.defaultCategory()
+            member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+            category = CategoryFixtures.ofDefault()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            staccato = StaccatoFixtures.defaultStaccato(category)
+            staccato = StaccatoFixtures.ofDefault(category)
                     .withTitle("origin")
                     .withFeeling(Feeling.ANGRY)
                     .buildAndSave(staccatoRepository);
@@ -497,11 +497,11 @@ class StaccatoServiceTest extends ServiceSliceTest {
         @Test
         void sequentialUpdatesNoConflict() {
             // given
-            StaccatoRequest request1 = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request1 = StaccatoRequestFixtures.ofDefault()
                     .withStaccatoTitle("first")
                     .withCategoryId(category.getId())
                     .build();
-            StaccatoRequest request2 = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request2 = StaccatoRequestFixtures.ofDefault()
                     .withStaccatoTitle("second")
                     .withCategoryId(category.getId())
                     .build();
@@ -522,12 +522,12 @@ class StaccatoServiceTest extends ServiceSliceTest {
         @Test
         void failOnConcurrentUpdate() {
             // given
-            StaccatoRequest request1 = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request1 = StaccatoRequestFixtures.ofDefault()
                     .withStaccatoTitle("first")
                     .withCategoryId(category.getId())
                     .build();
 
-            StaccatoRequest request2 = StaccatoRequestFixtures.defaultStaccatoRequest()
+            StaccatoRequest request2 = StaccatoRequestFixtures.ofDefault()
                     .withStaccatoTitle("second")
                     .withCategoryId(category.getId())
                     .build();

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
@@ -145,12 +145,9 @@ class StaccatoServiceTest extends ServiceSliceTest {
                 .withColor(Color.PINK)
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
-        Staccato staccato2 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category2).buildAndSave(staccatoRepository);
-        Staccato staccato3 = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato2 = StaccatoFixtures.defaultStaccato(category2).buildAndSave(staccatoRepository);
+        Staccato staccato3 = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoLocationResponsesV2 responses = staccatoService.readAllStaccato(member, StaccatoLocationRangeRequest.empty());
@@ -175,8 +172,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoDetailResponseV2 actual = staccatoService.readStaccatoById(staccato.getId(), member);
@@ -194,8 +190,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoService.readStaccatoById(staccato.getId(), otherMember))
@@ -226,8 +221,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category2 = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category1)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category1)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage1.jpg", "https://example.com/staccatoImage2.jpg"))
                 .buildAndSave(staccatoRepository);
 
@@ -284,11 +278,9 @@ class StaccatoServiceTest extends ServiceSliceTest {
                     .withHost(member1)
                     .withGuests(List.of(member2))
                     .buildAndSave(categoryRepository);
-            staccatoInPrivate1 = StaccatoFixtures.defaultStaccato()
-                    .withCategory(privateCategory1)
+            staccatoInPrivate1 = StaccatoFixtures.defaultStaccato(privateCategory1)
                     .buildAndSave(staccatoRepository);
-            staccatoInShared1 = StaccatoFixtures.defaultStaccato()
-                    .withCategory(sharedCategory1)
+            staccatoInShared1 = StaccatoFixtures.defaultStaccato(sharedCategory1)
                     .buildAndSave(staccatoRepository);
         }
 
@@ -369,8 +361,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
                 .withCategoryId(category.getId()).build();
 
@@ -391,8 +382,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
                 .buildAndSave(categoryRepository);
         Category otherCategory = CategoryFixtures.defaultCategory()
                 .withHost(otherMember).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         StaccatoRequest staccatoRequest = StaccatoRequestFixtures.defaultStaccatoRequest()
                 .withCategoryId(otherCategory.getId()).build();
 
@@ -427,8 +417,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage1.jpg", "https://example.com/staccatoImage2.jpg"))
                 .buildAndSave(staccatoRepository);
         Comment comment = CommentFixtures.defaultComment()
@@ -456,8 +445,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoService.deleteStaccatoById(staccato.getId(), otherMember))
@@ -473,8 +461,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         FeelingRequest feelingRequest = new FeelingRequest("happy");
 
         // when
@@ -502,10 +489,9 @@ class StaccatoServiceTest extends ServiceSliceTest {
             category = CategoryFixtures.defaultCategory()
                     .withHost(member)
                     .buildAndSave(categoryRepository);
-            staccato = StaccatoFixtures.defaultStaccato()
+            staccato = StaccatoFixtures.defaultStaccato(category)
                     .withTitle("origin")
                     .withFeeling(Feeling.ANGRY)
-                    .withCategory(category)
                     .buildAndSave(staccatoRepository);
         }
 

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoServiceTest.java
@@ -420,9 +420,7 @@ class StaccatoServiceTest extends ServiceSliceTest {
         Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(List.of("https://example.com/staccatoImage1.jpg", "https://example.com/staccatoImage2.jpg"))
                 .buildAndSave(staccatoRepository);
-        Comment comment = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member).buildAndSave(commentRepository);
+        Comment comment = CommentFixtures.defaultComment(staccato, member).buildAndSave(commentRepository);
 
         // when
         staccatoService.deleteStaccatoById(staccato.getId(), member);

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
@@ -53,8 +53,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
@@ -84,8 +83,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoShareService.createStaccatoShareLink(staccato.getId(), otherMember))
@@ -101,8 +99,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
@@ -119,8 +116,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -138,8 +134,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -158,8 +153,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -176,8 +170,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Member member2 = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member1).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
         Comment comment1 = CommentFixtures.defaultComment()
                 .withStaccato(staccato)
                 .withMember(member1).buildAndSave(commentRepository);

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
@@ -171,12 +171,8 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
         Category category = CategoryFixtures.defaultCategory()
                 .withHost(member1).buildAndSave(categoryRepository);
         Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment1 = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member1).buildAndSave(commentRepository);
-        Comment comment2 = CommentFixtures.defaultComment()
-                .withStaccato(staccato)
-                .withMember(member2).buildAndSave(commentRepository);
+        Comment comment1 = CommentFixtures.defaultComment(staccato, member1).buildAndSave(commentRepository);
+        Comment comment2 = CommentFixtures.defaultComment(staccato, member2).buildAndSave(commentRepository);
 
         String token = shareTokenProvider.create(new ShareTokenPayload(staccato.getId(), member1.getId()));
 

--- a/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
+++ b/backend/src/test/java/com/staccato/staccato/service/StaccatoShareServiceTest.java
@@ -49,11 +49,11 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void createValidShareLink() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
@@ -66,7 +66,7 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void failToCreateShareLinkWhenNoStaccato() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoShareService.createStaccatoShareLink(1L, member))
@@ -78,12 +78,12 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void failToCreateShareLinkWhenInvalidMember() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member otherMember = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member otherMember = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when & then
         assertThatThrownBy(() -> staccatoShareService.createStaccatoShareLink(staccato.getId(), otherMember))
@@ -95,11 +95,11 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void shouldContainTokenInShareLink() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         // when
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
@@ -112,11 +112,11 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void shouldContainStaccatoIdInToken() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -130,11 +130,11 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void shouldContainExpirationInToken() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -149,11 +149,11 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void validateToken() {
         // given
-        Member member = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member)
                 .buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
 
         StaccatoShareLinkResponse response = staccatoShareService.createStaccatoShareLink(staccato.getId(), member);
 
@@ -166,13 +166,13 @@ public class StaccatoShareServiceTest extends ServiceSliceTest {
     @Test
     void readSharedStaccatoByToken() {
         // given
-        Member member1 = MemberFixtures.defaultMember().buildAndSave(memberRepository);
-        Member member2 = MemberFixtures.defaultMember().withNickname("otherMem").buildAndSave(memberRepository);
-        Category category = CategoryFixtures.defaultCategory()
+        Member member1 = MemberFixtures.ofDefault().buildAndSave(memberRepository);
+        Member member2 = MemberFixtures.ofDefault().withNickname("otherMem").buildAndSave(memberRepository);
+        Category category = CategoryFixtures.ofDefault()
                 .withHost(member1).buildAndSave(categoryRepository);
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category).buildAndSave(staccatoRepository);
-        Comment comment1 = CommentFixtures.defaultComment(staccato, member1).buildAndSave(commentRepository);
-        Comment comment2 = CommentFixtures.defaultComment(staccato, member2).buildAndSave(commentRepository);
+        Staccato staccato = StaccatoFixtures.ofDefault(category).buildAndSave(staccatoRepository);
+        Comment comment1 = CommentFixtures.ofDefault(staccato, member1).buildAndSave(commentRepository);
+        Comment comment2 = CommentFixtures.ofDefault(staccato, member2).buildAndSave(commentRepository);
 
         String token = shareTokenProvider.create(new ShareTokenPayload(staccato.getId(), member1.getId()));
 

--- a/backend/src/test/java/com/staccato/web/PageControllerTest.java
+++ b/backend/src/test/java/com/staccato/web/PageControllerTest.java
@@ -44,8 +44,7 @@ public class PageControllerTest extends ControllerTest {
         );
 
         Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(imageUrls).build();
         Member member = MemberFixtures.defaultMember().build();
         StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());
@@ -68,8 +67,7 @@ public class PageControllerTest extends ControllerTest {
         List<String> imageUrls = List.of();
 
         Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato()
-                .withCategory(category)
+        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
                 .withStaccatoImages(imageUrls).build();
         Member member = MemberFixtures.defaultMember().build();
         StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());

--- a/backend/src/test/java/com/staccato/web/PageControllerTest.java
+++ b/backend/src/test/java/com/staccato/web/PageControllerTest.java
@@ -43,10 +43,10 @@ public class PageControllerTest extends ControllerTest {
                 "https://image.staccato.kr/test-image3.png"
         );
 
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(imageUrls).build();
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());
 
         when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(response);
@@ -66,10 +66,10 @@ public class PageControllerTest extends ControllerTest {
         String token = "test-token";
         List<String> imageUrls = List.of();
 
-        Category category = CategoryFixtures.defaultCategory().build();
-        Staccato staccato = StaccatoFixtures.defaultStaccato(category)
+        Category category = CategoryFixtures.ofDefault().build();
+        Staccato staccato = StaccatoFixtures.ofDefault(category)
                 .withStaccatoImages(imageUrls).build();
-        Member member = MemberFixtures.defaultMember().build();
+        Member member = MemberFixtures.ofDefault().build();
         StaccatoSharedResponse response = new StaccatoSharedResponse(LocalDateTime.now(), staccato, member, List.of());
 
         when(staccatoShareService.readSharedStaccatoByToken(token)).thenReturn(response);


### PR DESCRIPTION
## ⭐️ Issue Number
- #984 

## 🚩 Summary

### 코드 품질 향상을 목적으로, 테스트 코드의 Fixture를 전반적으로 리팩터링

* Fixture 생성 메서드 이름을 `ofDefault()`로 통일
* `StaccatoFixtures.ofDefault(category)`와 같이 의존성을 명시적으로 주입하도록 변경하여, 테스트의 가독성과 안정성을 높임
* Category 기본 Fixture의 term 값을 null로 변경하여, 각 테스트가 필요로 하는 데이터를 명확히 설정하도록 유도

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do
