### PR TITLE
fix: 스케쥴러가 작동하지 않는 문제 #986

### DIFF
--- a/backend/src/main/java/com/staccato/StaccatoApplication.java
+++ b/backend/src/main/java/com/staccato/StaccatoApplication.java
@@ -2,8 +2,10 @@ package com.staccato;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class StaccatoApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## ⭐️ Issue Number
- #986 

## 🚩 Summary

- `StaccatoApplication`에 `@EnableScheduling` annotation을 추가해서 스프링이 `@Scheduled` 메서드를 스캔하고 등록하도록 수정했습니다.
- 로컬에서 annotation 유/무에 따른 스케쥴러 동작/미동작을 확인했습니다.

## 🛠️ Technical Concerns

## 🙂 To Reviewer

## 📋 To Do

- 로컬 실행 환경에서 S3Config 및 FcmConfig 설정 시 외부 서비스에 대한 의존성이 분리되지 않아 여러 설정 충돌 문제가 발생했습니다.
- 이를 개선하기 위해 환경별 Profile 구성을 명확히 분리하고, 필요 시 인터페이스를 통한 의존성 주입 구조를 도입하려고 합니다.
- 이를 통해 스케줄러 동작(`deleteOrphanS3Object`) 검증 테스트 케이스도 보완할 예정입니다.
