### PR TITLE
fix: AWS region yml과 사용부 기입 불일치

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -50,6 +50,7 @@ cloud:
   storage:
     mode: aws
   aws:
+    region: ENC(VU25sKaZUPFns2J8GhgAyrioMpwOaWyMa4fBWSzX8LH3zInZc2upgBttgy7EaJWV)
     access-key: ENC(esOew5zDP7xeUY4rqpHQIWRJvnyh4qC9HHMzFI9Bek4gu65ZxgQOaGT40tXaJ/kLBsPAXM4NIYF7g64+67gfHg==)
     secret-access-key: ENC(osZssrZ+Z1Mraw1D8Rd0tXOk0VfMj/8uaGeRrH7/pF+PMJQQga6EBCp14HbGE/zwsSKaZ4xyI5tBy6hwSCJFqKPzzgTN4/Y/AQX3bFp6k90=)
     s3:
@@ -57,8 +58,6 @@ cloud:
       endpoint: ENC(9yj+jkWlB807kp6umhJIA+osCj4ha/WQcuh8+TTipY3XJNpPs+LswGr4pPPQ5bLQobDzat8PSNZClqvALLpue3PCBxqpUq7Ot3zN02siH+PuFEAqV/izRYpku0bUgK65)
     cloudfront:
       endpoint: ENC(LMIPHd+0QQ480lNvi9VTyTjVs/+ok8dpUnZfcNTqrLrlmjAEFV61fh/JmgQmjTBCWW+vlKqWmp3tqnbjjqsxrTI+wl2IGB6O+K/ewjU6TMg=)
-    region:
-      static: ENC(VU25sKaZUPFns2J8GhgAyrioMpwOaWyMa4fBWSzX8LH3zInZc2upgBttgy7EaJWV)
     stack:
       auto: false
 image:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -80,6 +80,7 @@ cloud:
   storage:
     mode: aws
   aws:
+    region: ENC(vJkU8XavMdzVGfsG12iAMrFWN5pX49FIL8MZLHfFPQVO12TwBjuzji1D8Z1eh4bn)
     access-key: ENC(FkurMRWpLS2WpFdQLMkoY+LX+InfAKaB+MeTAlduvo8Iu8upBdCbHCxUOr/BWIMB6lVNiEAjudEr29Dp3V0Pgg==)
     secret-access-key: ENC(q9iscV69jad2wTy5i/FjvktTcC2yCKy+bQVFpx5RbE+B2xOO+yzyz8nwzZKsH9T44HdbroHdfecbt0TpCxDGHQonk7KYpx6wjdW8arMAPaI=)
     s3:
@@ -87,8 +88,6 @@ cloud:
       endpoint: ENC(9lRj8rogcOdHbIpkXcC5AUpV7MlB3AWbbTvLYzbygHl8GXEgZFG8SJSPjwRd+eK728+gHJZGHIvb+Byq9hsJcukiTXJveIOSUGpY/SVPjflSSrN9VlH8J++X+yMhni/q)
     cloudfront:
       endpoint: ENC(adIKldEPdhYmx3EdT/x3aIgLxfzWeB26JNTXCzcfZW2bBRjMw+hhjTEQW0O69OQ6+iWoeJaICI3glyQtLqLtm2bVYm7vF0bfALHaJH81lco=)
-    region:
-      static: ENC(vJkU8XavMdzVGfsG12iAMrFWN5pX49FIL8MZLHfFPQVO12TwBjuzji1D8Z1eh4bn)
     stack:
       auto: false
 image:


### PR DESCRIPTION
## 🚩 Summary

<img width="437" height="397" alt="image" src="https://github.com/user-attachments/assets/7514e7bf-5747-4d74-968b-e0da2271df6d" />

<img width="524" height="366" alt="image" src="https://github.com/user-attachments/assets/9c9aa0fc-1161-4e23-9dcf-51b6f2fa0930" />

* `static` 삭제 -> `cloud.aws.region`으로 접근하는 방식으로 수정

## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * AWS 클라우드 구성 설정 항목을 재구성했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->