### PR TITLE
fix: YearCalendar 팩토리 메서드 수정 #1016

### DIFF
--- a/android/Staccato_AN/domain/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
+++ b/android/Staccato_AN/domain/src/main/java/com/on/staccato/domain/model/YearCalendar.kt
@@ -86,9 +86,10 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
         fun of(
             periodStart: LocalDate? = null,
             periodEnd: LocalDate? = null,
+            today: LocalDate = LocalDate.now(),
         ): YearCalendar {
             if (periodStart != null && periodEnd != null) checkValid(periodStart, periodEnd)
-            val yearRange = createYearRange(periodStart, periodEnd)
+            val yearRange = createYearRange(periodStart, periodEnd, today)
             return YearCalendar(
                 yearRange.associateWith { year ->
                     of(year, periodStart, periodEnd)
@@ -109,11 +110,12 @@ data class YearCalendar private constructor(private val yearToMonthCalender: Map
         private fun createYearRange(
             periodStart: LocalDate?,
             periodEnd: LocalDate?,
+            today: LocalDate,
         ): List<Int> =
             if (periodStart != null && periodEnd != null) {
                 createYearsBetween(periodStart.year, periodEnd.year)
             } else {
-                createHundredOfYearsAroundCurrent(LocalDate.now())
+                createHundredOfYearsAroundCurrent(today)
             }
 
         private fun createYearsBetween(

--- a/android/Staccato_AN/domain/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
+++ b/android/Staccato_AN/domain/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
@@ -104,12 +104,11 @@ class YearCalendarTest {
     @Test
     fun `시작일과 종료일을 지정하지 않으면 현재 날짜를 기준으로 앞,뒤로 100년씩의 범위를 가진 YearCalendar가 생성된다`() {
         // given
-        val now = LocalDate.of(2025, 1, 1)
-        val expectedYearRange = (now.minusYears(100).year..now.plusYears(100).year).toList()
+        val today = LocalDate.now()
+        val expectedYearRange = (today.minusYears(100).year..today.plusYears(100).year).toList()
 
         // when
         val yearCalendar = YearCalendar.of()
-        println(yearCalendar.getAvailableYears())
 
         // then
         assertEquals(expectedYearRange, yearCalendar.getAvailableYears())

--- a/android/Staccato_AN/domain/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
+++ b/android/Staccato_AN/domain/src/test/java/com/on/staccato/domain/model/YearCalendarTest.kt
@@ -108,7 +108,7 @@ class YearCalendarTest {
         val expectedYearRange = (today.minusYears(100).year..today.plusYears(100).year).toList()
 
         // when
-        val yearCalendar = YearCalendar.of()
+        val yearCalendar = YearCalendar.of(today = today)
 
         // then
         assertEquals(expectedYearRange, yearCalendar.getAvailableYears())


### PR DESCRIPTION
## ⭐️ Issue Number
- #1016 

## 🚩 Summary
현재 날짜를 주입 받아 테스트가 가능한 구조로 변경
- of 메서드에 today 매개변수 추가
  - 기본 값 LocalDate.now() 전달
- createYearRange에 today 매개변수 추가

테스트 코드 수정
- given에서 현재 날짜를 LocalDate.now로 지정
- 기댓값을 출력하는 코드 제거


## 🛠️ Technical Concerns


## 🙂 To Reviewer


## 📋 To Do


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 연도 달력 기준일 처리를 더욱 유연하게 개선했습니다. 날짜 범위 생성 시 기준일을 명시적으로 지정할 수 있게 되었습니다.

* **테스트**
  * 연도 범위 계산 테스트 케이스를 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->